### PR TITLE
Expose public API in dir(impulso) via __dir__

### DIFF
--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -12,6 +12,11 @@ __all__ = [
 ]
 
 
+def __dir__() -> list[str]:
+    """Expose all public API names in interactive discovery tools."""
+    return sorted(__all__)
+
+
 def enable_runtime_checks() -> None:
     """Enable beartype runtime type checking on public API.
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,3 +21,10 @@ class TestPublicAPI:
         from impulso import enable_runtime_checks
 
         assert callable(enable_runtime_checks)
+
+    def test_dir_includes_public_api(self):
+        import impulso
+
+        names = dir(impulso)
+        for expected in impulso.__all__:
+            assert expected in names


### PR DESCRIPTION
## Summary\nAdds a module-level __dir__ in src/impulso/__init__.py so interactive discovery tools and IDE completion include all public API names from __all__.\n\nAlso adds a focused test in 	ests/test_public_api.py to ensure each __all__ symbol appears in dir(impulso).\n\n## Why\nFixes #25 (__getattr__ does not update __dir__).\n\n## Validation\nI added/updated tests for this behavior.\n\nNote: I could not run pytest locally in this environment because no Python runtime is installed on host (py -3.11 reported no suitable runtime).