### PR TITLE
Fix Cholesky structural_shock_matrix dim/coord ordering

### DIFF
--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -46,8 +46,8 @@ class Cholesky(BaseModel):
 
         P_da = xr.DataArray(
             P,
-            dims=["chain", "draw", "shock", "response"],
-            coords={"shock": self.ordering, "response": self.ordering},
+            dims=["chain", "draw", "response", "shock"],
+            coords={"response": self.ordering, "shock": self.ordering},
         )
 
         new_posterior = idata.posterior.assign(structural_shock_matrix=P_da)

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -49,6 +49,11 @@ class TestCholesky:
 
         assert "structural_shock_matrix" in result.posterior
 
+        p_da = result.posterior["structural_shock_matrix"]
+        assert p_da.dims == ("chain", "draw", "response", "shock")
+        assert list(p_da.coords["response"].values) == ["y1", "y2"]
+        assert list(p_da.coords["shock"].values) == ["y1", "y2"]
+
 
 class TestSignRestriction:
     def test_construction(self):


### PR DESCRIPTION
## Summary\nFixes the Cholesky identification output to use the same dim/coord ordering as the sign-restriction path (esponse, shock).\n\n### Changes\n- In Cholesky.identify, changed structural_shock_matrix dims from:\n  - (chain, draw, shock, response)\n  to:\n  - (chain, draw, response, shock)\n- Updated coord mapping accordingly.\n- Added a regression assertion in 	ests/test_identification.py to lock the expected dim + coord order.\n\n## Why\nIssue #26 reports that Cholesky xarray labels are transposed relative to SignRestriction, which can cause downstream confusion/misalignment.\n\n## Validation\nAdded targeted test assertions for dims and coords.\n\nNote: I couldn’t execute pytest in this environment because no Python runtime is installed on host (py -3.11 reports no suitable runtime).