### PR TITLE
fix(spec): use safe default sampler with cores=1 in VAR.fit()

### DIFF
--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -46,6 +46,12 @@ class VAR(ImpulsoBaseModel):
             return _PRIOR_REGISTRY[self.prior]()
         return self.prior
 
+    @staticmethod
+    def _default_sampler() -> "Sampler":
+        """Return a safe default NUTSSampler with cores=1 to avoid multiprocessing crashes."""
+        from impulso.samplers import NUTSSampler
+        return NUTSSampler(cores=1, chains=4)
+
     def fit(
         self,
         data: VARData,
@@ -67,7 +73,7 @@ class VAR(ImpulsoBaseModel):
         from impulso.samplers import NUTSSampler
 
         if sampler is None:
-            sampler = NUTSSampler()
+            sampler = self._default_sampler()
 
         # Resolve lags
         if isinstance(self.lags, str):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,9 +1,12 @@
 """Tests for VAR specification."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from pydantic import ValidationError
 
 from impulso.priors import MinnesotaPrior
+from impulso.samplers import NUTSSampler
 from impulso.spec import VAR
 
 
@@ -43,3 +46,26 @@ class TestVARSpec:
     def test_rejects_zero_lags(self):
         with pytest.raises(ValidationError):
             VAR(lags=0, prior="minnesota")
+
+    def test_default_sampler_returns_nuts_with_safe_defaults(self):
+        """_default_sampler() must return NUTSSampler(cores=1, chains=4)."""
+        sampler = VAR._default_sampler()
+        assert isinstance(sampler, NUTSSampler)
+        assert sampler.cores == 1
+        assert sampler.chains == 4
+
+    def test_fit_with_no_sampler_uses_default(self, var_data_3v):
+        """fit(sampler=None) should call _default_sampler() and use its result."""
+        spec = VAR(lags=1, prior="minnesota")
+        default = VAR._default_sampler()
+
+        with patch.object(VAR, "_default_sampler", return_value=default):
+            with patch.object(NUTSSampler, "sample") as mock_sample:
+                mock_idata = MagicMock()
+                mock_sample.return_value = mock_idata
+                spec.fit(var_data_3v, sampler=None)
+
+                # _default_sampler must have been called
+                VAR._default_sampler.assert_called_once()
+                # sample must have been called on the default sampler
+                mock_sample.assert_called_once()

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -69,3 +69,17 @@ class TestVARSpec:
                 VAR._default_sampler.assert_called_once()
                 # sample must have been called on the default sampler
                 mock_sample.assert_called_once()
+
+    def test_default_sampler_is_callable_without_instance(self):
+        """_default_sampler() works as a static method (callable on class)."""
+        sampler = VAR._default_sampler()
+        assert hasattr(sampler, "sample")
+        assert callable(sampler.sample)
+
+    def test_default_sampler_returns_fresh_instance_each_call(self):
+        """Each call to _default_sampler() returns a new instance."""
+        s1 = VAR._default_sampler()
+        s2 = VAR._default_sampler()
+        assert s1 is not s2
+        assert s1.cores == s2.cores == 1
+        assert s1.chains == s2.chains == 4


### PR DESCRIPTION
## Summary

When no sampler is passed to `VAR.fit()`, the previous code created a bare
`NUTSSampler()` with `cores=None`, which auto-detects CPU cores and enables
multiprocessing. This can cause segfaults on macOS and other platforms (as
documented in CLAUDE.md).

## Changes

- Add `_default_sampler()` static method on `VAR` that returns
  `NUTSSampler(cores=1, chains=4)`
- Route the `sampler is None` branch through this method instead of calling
  `NUTSSampler()` directly

This matches the pattern already used by `StochasticVolatility.fit()` (see
the SV Layer 1 plan, Task 6).

Fixes #43