### PR TITLE
feat: VolatilityProcess seam + Constant adapter (P1, refs #61)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,10 @@ The time-index parameter on time-varying queries (`impulse_response(at=...)`, `f
 > **User:** "Just a univariate SV fit."
 > **Library:** `StochasticVolatility(dynamics="ar1").fit(SVData(y))`. Same class, standalone code path.
 
+## Conventions
+
+**Discriminator field on adapters**: every concrete adapter class (`Constant`, `RandomWalk`, `AR1`, …) declares its registry key with `name: Literal["x"] = "x"`, *not* `name: ClassVar[str] = "x"`. The Literal form is the modern Pydantic v2 idiom: it makes `name` a real instance attribute, fires `ValidationError` on construction-time mismatch (`Constant(name="other")`) and on post-construction mutation (under `frozen=True`), and participates in `model_dump`/`model_validate` round-trips. Class-level access (`Constant.name`) does *not* work with this pattern — registries that need the key value should hardcode the literal string.
+
 ## Flagged ambiguities
 
 - "SV" is both a noun (the model family — *stochastic volatility*) and an adjective ("an SV adapter"). The class `StochasticVolatility` is the canonical noun reference; the adjective form is fine in prose after the term has been spelled out.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "zensical>=0.0.28",
     "tabulate>=0.10.0",
     "papermill>=2.7.0",
+    "typing-extensions>=4.12",
 ]
 docs = [
     "statsmodels>=0.14.6",

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -7,6 +7,7 @@ from impulso.spec import VAR
 __all__ = [
     "VAR",
     "Cholesky",
+    "Constant",
     "FEVDResult",
     "FittedSV",
     "FittedVAR",
@@ -24,6 +25,7 @@ __all__ = [
     "SignRestriction",
     "StochasticVolatility",
     "VARData",
+    "VolatilityProcess",
     "VolatilityResult",
     "enable_runtime_checks",
     "select_lag_order",
@@ -51,6 +53,8 @@ def __getattr__(name: str):
         "SVDefaultPrior": "impulso.sv.priors",
         "VolatilityResult": "impulso.results",
         "SVForecastResult": "impulso.results",
+        "Constant": "impulso.volatility",
+        "VolatilityProcess": "impulso.protocols",
     }
     if name in _lazy_imports:
         import importlib

--- a/src/impulso/protocols.py
+++ b/src/impulso/protocols.py
@@ -7,6 +7,8 @@ import numpy as np
 if TYPE_CHECKING:
     import arviz as az
     import pymc as pm
+    import pytensor.tensor as pt
+    import xarray as xr
 
 
 @runtime_checkable
@@ -28,3 +30,53 @@ class IdentificationScheme(Protocol):
     """Contract for structural identification schemes."""
 
     def identify(self, idata: "az.InferenceData", var_names: list[str]) -> "az.InferenceData": ...
+
+
+@runtime_checkable
+class VolatilityProcess(Protocol):
+    """Contract for volatility processes.
+
+    A VolatilityProcess owns the construction of the structural-shock
+    covariance Σ_t — for constant adapters, Σ is shared across time;
+    for stochastic adapters, Σ_t evolves. The seam's primary output is
+    the lower-triangular Cholesky factor L_t such that Σ_t = L_t @ L_t.T.
+    See docs/adr/0001-volatility-process-seam-exposes-cholesky-factor.md.
+
+    Adapters own their downstream computation: time-`t` query and
+    forward simulation for forecasts.
+    """
+
+    name: str
+
+    def build_pymc_latent(self, n_vars: int, T: int) -> "pt.TensorVariable":
+        """Register volatility latent variables in the active PyMC model.
+
+        Returns the lower-triangular Cholesky factor as a PyTensor variable.
+        For constant volatility, shape is (n_vars, n_vars). For stochastic
+        volatility, shape is (T, n_vars, n_vars).
+        """
+        ...
+
+    def cholesky_at(self, posterior: "xr.Dataset", t: int | None) -> np.ndarray:
+        """Posterior draws of the Cholesky factor at time `t`.
+
+        Returns shape (chains, draws, n_vars, n_vars). For constant
+        volatility, `t` is ignored. For stochastic volatility, indexes
+        into the time dimension; `t=None` defaults to the most recent
+        period.
+        """
+        ...
+
+    def forecast_cholesky_path(
+        self,
+        posterior: "xr.Dataset",
+        steps: int,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        """Posterior-predictive Cholesky factors for steps ahead.
+
+        Returns shape (chains, draws, steps, n_vars, n_vars). For constant
+        volatility, broadcasts the constant L across `steps`. For stochastic
+        volatility, simulates forward from posterior dynamics.
+        """
+        ...

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -30,6 +30,7 @@ class VAR(ImpulsoBaseModel):
         lags: Fixed lag order (int >= 1) or selection criterion string.
         max_lags: Upper bound for automatic selection. Only valid with string lags.
         prior: Prior shorthand string or Prior protocol instance.
+        volatility: Volatility shorthand string or VolatilityProcess protocol instance.
     """
 
     lags: int | Literal["aic", "bic", "hq"] = Field(...)

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -8,13 +8,18 @@ from pydantic import Field, model_validator
 from impulso._base import ImpulsoBaseModel
 from impulso.data import VARData
 from impulso.priors import MinnesotaPrior
-from impulso.protocols import Prior, Sampler
+from impulso.protocols import Prior, Sampler, VolatilityProcess
+from impulso.volatility import Constant
 
 if TYPE_CHECKING:
     from impulso.fitted import FittedVAR
 
 _PRIOR_REGISTRY: dict[str, type] = {
     "minnesota": MinnesotaPrior,
+}
+
+_VOLATILITY_REGISTRY: dict[str, type] = {
+    "constant": Constant,
 }
 
 
@@ -30,6 +35,7 @@ class VAR(ImpulsoBaseModel):
     lags: int | Literal["aic", "bic", "hq"] = Field(...)
     max_lags: int | None = None
     prior: Literal["minnesota"] | Prior = "minnesota"
+    volatility: Literal["constant"] | VolatilityProcess = "constant"
 
     @model_validator(mode="after")
     def _validate_spec(self) -> Self:
@@ -45,6 +51,13 @@ class VAR(ImpulsoBaseModel):
         if isinstance(self.prior, str):
             return _PRIOR_REGISTRY[self.prior]()
         return self.prior
+
+    @property
+    def resolved_volatility(self) -> VolatilityProcess:
+        """Resolve string volatility shorthand to a VolatilityProcess instance."""
+        if isinstance(self.volatility, str):
+            return _VOLATILITY_REGISTRY[self.volatility]()
+        return self.volatility
 
     def fit(
         self,

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -127,25 +127,14 @@ class VAR(ImpulsoBaseModel):
             else:
                 mu = intercept + pm.math.dot(X_lag, B.T)
 
-            # Residual covariance (Cholesky parameterization)
-            import pytensor.tensor as pt
-
-            sd = pm.HalfCauchy("sigma_sd", beta=2.5, shape=n_vars)
-            n_tril = n_vars * (n_vars - 1) // 2
-            L = pt.zeros((n_vars, n_vars))
-            L = pt.set_subtensor(L[np.diag_indices(n_vars)], sd)
-            if n_tril > 0:
-                tril_vals = pm.Normal("tril_offdiag", mu=0, sigma=0.5, shape=n_tril)
-                idx = 0
-                for i in range(1, n_vars):
-                    for j in range(i):
-                        L = pt.set_subtensor(L[i, j], tril_vals[idx] * sd[i])
-                        idx += 1
-            chol = L
-            pm.Deterministic("Sigma", pm.math.dot(chol, chol.T))
+            # Volatility process: registers latent vars, returns L (Cholesky factor of Σ_t).
+            # For constant volatility, L is (n_vars, n_vars) and time-invariant.
+            volatility = self.resolved_volatility
+            L = volatility.build_pymc_latent(n_vars=n_vars, T=Y.shape[0])
+            pm.Deterministic("Sigma", pm.math.dot(L, L.T))
 
             # Likelihood
-            pm.MvNormal("obs", mu=mu, chol=chol, observed=Y)
+            pm.MvNormal("obs", mu=mu, chol=L, observed=Y)
 
         # Sample
         idata = sampler.sample(model)

--- a/src/impulso/sv/dynamics.py
+++ b/src/impulso/sv/dynamics.py
@@ -1,6 +1,6 @@
 """Log-volatility dynamics for univariate stochastic volatility models."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import xarray as xr
@@ -43,7 +43,7 @@ class SVDynamics(Protocol):
 class RandomWalk(ImpulsoModel):
     """Random-walk log-volatility dynamics (Primiceri 2005)."""
 
-    name: ClassVar[str] = "random_walk"
+    name: Literal["random_walk"] = "random_walk"
 
     def build_latent_path(self, prior_params: dict, T: int, sigma_eta: Any) -> Any:
         import pymc as pm
@@ -73,7 +73,7 @@ class RandomWalk(ImpulsoModel):
 class AR1(ImpulsoModel):
     """AR(1) log-volatility dynamics (Kim-Shephard-Chib 1998)."""
 
-    name: ClassVar[str] = "ar1"
+    name: Literal["ar1"] = "ar1"
 
     def build_latent_path(self, prior_params: dict, T: int, sigma_eta: Any) -> Any:
         import pymc as pm
@@ -116,6 +116,6 @@ class AR1(ImpulsoModel):
 
 
 SV_DYNAMICS_REGISTRY: dict[str, type[SVDynamics]] = {
-    RandomWalk.name: RandomWalk,
-    AR1.name: AR1,
+    "random_walk": RandomWalk,
+    "ar1": AR1,
 }

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -47,7 +47,37 @@ class Constant(ImpulsoModel):
     tril_offdiag_sigma: float = Field(0.5, gt=0)
 
     def build_pymc_latent(self, n_vars: int, T: int) -> "pt.TensorVariable":
-        raise NotImplementedError  # Task 3
+        """Register the constant-volatility latent vars in the active PyMC model.
+
+        Lifts the manual-Cholesky parameterisation from the previous
+        location in ``spec.py:_build_pymc_model``. PyMC variable names
+        (``sigma_sd``, ``tril_offdiag``) match the prior contents byte-for-byte
+        so existing posterior-consuming code keeps working unchanged.
+
+        Args:
+            n_vars: Number of endogenous variables.
+            T: Number of observations after lag trimming. Ignored for
+                constant volatility — kept in the signature for parity
+                with stochastic adapters.
+
+        Returns:
+            Lower-triangular Cholesky factor L of shape (n_vars, n_vars).
+        """
+        import pymc as pm
+        import pytensor.tensor as pt
+
+        sd = pm.HalfCauchy("sigma_sd", beta=self.sigma_sd_beta, shape=n_vars)
+        n_tril = n_vars * (n_vars - 1) // 2
+        L = pt.zeros((n_vars, n_vars))
+        L = pt.set_subtensor(L[np.diag_indices(n_vars)], sd)
+        if n_tril > 0:
+            tril_vals = pm.Normal("tril_offdiag", mu=0, sigma=self.tril_offdiag_sigma, shape=n_tril)
+            idx = 0
+            for i in range(1, n_vars):
+                for j in range(i):
+                    L = pt.set_subtensor(L[i, j], tril_vals[idx] * sd[i])
+                    idx += 1
+        return L
 
     def cholesky_at(self, posterior: "xr.Dataset", t: int | None) -> np.ndarray:
         raise NotImplementedError  # Task 7

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -31,9 +31,10 @@ class Constant(ImpulsoModel):
     the off-diagonal block is empty.
 
     The PyMC variable names produced inside ``build_pymc_latent``
-    (``sigma_sd``, ``tril_offdiag``, ``Sigma``) match today's posterior
-    contents exactly so existing identification and downstream code
-    keep working unchanged.
+    (``sigma_sd``, ``tril_offdiag``) match today's posterior contents
+    exactly so existing identification and downstream code keep working
+    unchanged. The ``Sigma = L @ L.T`` deterministic is registered by
+    the caller in ``spec.py``, not by the adapter.
 
     Attributes:
         name: Discriminator key for the registry (always ``"constant"``).

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -102,4 +102,20 @@ class Constant(ImpulsoModel):
         steps: int,
         rng: np.random.Generator,
     ) -> np.ndarray:
-        raise NotImplementedError  # Task 8
+        """Broadcast the constant Cholesky factor across forecast steps.
+
+        For constant volatility there is nothing to simulate — the forecast
+        covariance equals the in-sample covariance. ``rng`` is accepted for
+        signature parity with stochastic adapters and is ignored.
+
+        Args:
+            posterior: An xarray Dataset with ``Sigma`` of shape
+                (chains, draws, n_vars, n_vars).
+            steps: Forecast horizon.
+            rng: Unused.
+
+        Returns:
+            Cholesky factor path of shape (chains, draws, steps, n_vars, n_vars).
+        """
+        L = self.cholesky_at(posterior, t=None)  # (C, D, n, n)
+        return np.broadcast_to(L[:, :, np.newaxis, :, :], (*L.shape[:2], steps, *L.shape[-2:])).copy()

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -81,7 +81,20 @@ class Constant(ImpulsoModel):
         return L
 
     def cholesky_at(self, posterior: "xr.Dataset", t: int | None) -> np.ndarray:
-        raise NotImplementedError  # Task 7
+        """Return the lower-triangular Cholesky factor of Σ for every draw.
+
+        For constant volatility, ``t`` is ignored — Σ is time-invariant.
+
+        Args:
+            posterior: An xarray Dataset (typically ``idata.posterior``)
+                containing ``Sigma`` of shape (chains, draws, n_vars, n_vars).
+            t: Time index. Ignored.
+
+        Returns:
+            Cholesky factors of shape (chains, draws, n_vars, n_vars).
+        """
+        sigma = posterior["Sigma"].values
+        return np.linalg.cholesky(sigma)
 
     def forecast_cholesky_path(
         self,

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -1,0 +1,60 @@
+"""Volatility processes for the VAR pipeline.
+
+Defines concrete adapters of the VolatilityProcess Protocol declared in
+protocols.py. The constant adapter (Constant) holds today's homoscedastic
+manual-Cholesky parameterisation; stochastic adapters live elsewhere
+(StochasticVolatility in impulso.sv) and arrive in later phases.
+
+See docs/adr/0001-volatility-process-seam-exposes-cholesky-factor.md.
+"""
+
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+from pydantic import Field
+
+from impulso._base import ImpulsoModel
+
+if TYPE_CHECKING:
+    import pytensor.tensor as pt
+    import xarray as xr
+
+
+class Constant(ImpulsoModel):
+    """Homoscedastic volatility — single Σ shared across all time points.
+
+    Lifts today's manual-Cholesky parameterisation from
+    ``spec.py:_build_pymc_model`` into the volatility-process seam:
+    HalfCauchy(beta=sigma_sd_beta) on the diagonal scales,
+    Normal(mu=0, sigma=tril_offdiag_sigma) on the lower-triangular
+    off-diagonals (scaled by the row's diagonal). For ``n_vars == 1``
+    the off-diagonal block is empty.
+
+    The PyMC variable names produced inside ``build_pymc_latent``
+    (``sigma_sd``, ``tril_offdiag``, ``Sigma``) match today's posterior
+    contents exactly so existing identification and downstream code
+    keep working unchanged.
+
+    Attributes:
+        sigma_sd_beta: HalfCauchy scale on diagonal SDs.
+        tril_offdiag_sigma: Normal SD on off-diagonal correlation factors.
+    """
+
+    name: Literal["constant"] = "constant"
+
+    sigma_sd_beta: float = Field(2.5, gt=0)
+    tril_offdiag_sigma: float = Field(0.5, gt=0)
+
+    def build_pymc_latent(self, n_vars: int, T: int) -> "pt.TensorVariable":
+        raise NotImplementedError  # Task 3
+
+    def cholesky_at(self, posterior: "xr.Dataset", t: int | None) -> np.ndarray:
+        raise NotImplementedError  # Task 7
+
+    def forecast_cholesky_path(
+        self,
+        posterior: "xr.Dataset",
+        steps: int,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        raise NotImplementedError  # Task 8

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -36,6 +36,7 @@ class Constant(ImpulsoModel):
     keep working unchanged.
 
     Attributes:
+        name: Discriminator key for the registry (always ``"constant"``).
         sigma_sd_beta: HalfCauchy scale on diagonal SDs.
         tril_offdiag_sigma: Normal SD on off-diagonal correlation factors.
     """

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -2,7 +2,9 @@
 
 from typing import runtime_checkable
 
-from impulso.protocols import IdentificationScheme, Prior, Sampler
+from typing_extensions import get_protocol_members
+
+from impulso.protocols import IdentificationScheme, Prior, Sampler, VolatilityProcess
 
 
 class TestProtocols:
@@ -14,3 +16,13 @@ class TestProtocols:
 
     def test_identification_is_runtime_checkable(self):
         assert hasattr(IdentificationScheme, "__protocol_attrs__") or runtime_checkable
+
+
+class TestVolatilityProcess:
+    def test_volatility_process_is_runtime_checkable(self):
+        assert hasattr(VolatilityProcess, "__protocol_attrs__") or runtime_checkable
+
+    def test_volatility_process_methods_declared(self):
+        # Protocol must declare the three seam operations.
+        attrs = set(get_protocol_members(VolatilityProcess))
+        assert {"build_pymc_latent", "cholesky_at", "forecast_cholesky_path"} <= attrs

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,3 +21,23 @@ class TestPublicAPI:
         from impulso import enable_runtime_checks
 
         assert callable(enable_runtime_checks)
+
+
+class TestVolatilityPublicAPI:
+    def test_constant_importable_from_impulso(self):
+        from impulso import Constant
+        from impulso.volatility import Constant as DirectConstant
+
+        assert Constant is DirectConstant
+
+    def test_volatility_process_importable_from_impulso(self):
+        from impulso import VolatilityProcess
+        from impulso.protocols import VolatilityProcess as DirectVolatilityProcess
+
+        assert VolatilityProcess is DirectVolatilityProcess
+
+    def test_volatility_names_in_all(self):
+        import impulso
+
+        assert "Constant" in impulso.__all__
+        assert "VolatilityProcess" in impulso.__all__

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -64,3 +64,39 @@ class TestVolatilityParameter:
     def test_unknown_string_raises(self):
         with pytest.raises(ValidationError):
             VAR(lags=2, volatility="nonexistent")
+
+
+class TestPyMCModelBuild:
+    """Verify the PyMC model graph composition after the seam refactor."""
+
+    def test_model_has_expected_unobserved_rvs(self, var_data_2v):
+        """The same set of RVs must exist in the PyMC graph as before the seam."""
+        # We don't run MCMC here; we just build the model and inspect.
+        # Rebuild logic mirrors VAR.fit but stops before sampler.sample().
+        import pymc as pm
+
+        from impulso._lag_selection import select_lag_order  # noqa: F401 — import-side-effect parity
+
+        spec = VAR(lags=1)
+        prior_params = spec.resolved_prior.build_priors(n_vars=2, n_lags=1)
+        volatility = spec.resolved_volatility
+
+        y = var_data_2v.endog
+        Y = y[1:]
+        X_lag = y[:-1]
+
+        with pm.Model() as model:
+            pm.Normal("intercept", mu=0, sigma=1, shape=2)
+            pm.Normal("B", mu=prior_params["B_mu"], sigma=prior_params["B_sigma"], shape=(2, 2))
+            L = volatility.build_pymc_latent(n_vars=2, T=Y.shape[0])
+            pm.Deterministic("Sigma", pm.math.dot(L, L.T))
+            mu = pm.math.dot(X_lag, model.named_vars["B"].T)
+            pm.MvNormal("obs", mu=mu, chol=L, observed=Y)
+
+        rv_names = {v.name for v in model.unobserved_RVs}
+        det_names = {v.name for v in model.deterministics}
+        assert "intercept" in rv_names
+        assert "B" in rv_names
+        assert "sigma_sd" in rv_names
+        assert "tril_offdiag" in rv_names
+        assert "Sigma" in det_names

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from impulso.priors import MinnesotaPrior
 from impulso.spec import VAR
+from impulso.volatility import Constant
 
 
 class TestVARSpec:
@@ -43,3 +44,23 @@ class TestVARSpec:
     def test_rejects_zero_lags(self):
         with pytest.raises(ValidationError):
             VAR(lags=0, prior="minnesota")
+
+
+class TestVolatilityParameter:
+    def test_default_volatility_is_constant_string(self):
+        spec = VAR(lags=2)
+        assert spec.volatility == "constant"
+
+    def test_volatility_string_resolves_to_constant(self):
+        spec = VAR(lags=2)
+        assert isinstance(spec.resolved_volatility, Constant)
+
+    def test_volatility_object_pass_through(self):
+        adapter = Constant(sigma_sd_beta=3.0)
+        spec = VAR(lags=2, volatility=adapter)
+        assert spec.resolved_volatility is adapter
+        assert spec.resolved_volatility.sigma_sd_beta == 3.0
+
+    def test_unknown_string_raises(self):
+        with pytest.raises(ValidationError):
+            VAR(lags=2, volatility="nonexistent")

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -100,3 +100,33 @@ class TestPyMCModelBuild:
         assert "sigma_sd" in rv_names
         assert "tril_offdiag" in rv_names
         assert "Sigma" in det_names
+
+    def test_var_fit_routes_through_volatility_seam(self, var_data_2v):
+        """VAR.fit (intercepted before sampling) must register the canonical RV set.
+
+        The companion test above mirrors the model graph by hand, so it would
+        keep passing even if VAR.fit silently skipped the volatility delegation.
+        This one captures the model from the production codepath via a sampler
+        that aborts before MCMC, then asserts the graph shape.
+        """
+        import pymc as pm
+
+        captured: dict[str, pm.Model] = {}
+
+        class CapturingSampler:
+            name = "capture"
+
+            def sample(self, model: pm.Model):
+                captured["model"] = model
+                raise RuntimeError("stop before sampling")
+
+        spec = VAR(lags=1)
+        with pytest.raises(RuntimeError, match="stop before sampling"):
+            spec.fit(var_data_2v, sampler=CapturingSampler())
+
+        model = captured["model"]
+        rv_names = {v.name for v in model.unobserved_RVs}
+        det_names = {v.name for v in model.deterministics}
+        assert {"intercept", "B", "sigma_sd", "tril_offdiag"} <= rv_names
+        assert "Sigma" in det_names
+        assert {v.name for v in model.observed_RVs} == {"obs"}

--- a/tests/test_sv_spec.py
+++ b/tests/test_sv_spec.py
@@ -123,3 +123,36 @@ def test_sv_spec_fit_ar1_smoke():
     assert fitted.dynamics.name == "ar1"
     assert "phi" in fitted.idata.posterior
     assert "alpha" in fitted.idata.posterior
+
+
+class TestSVDynamicsDiscriminator:
+    """Locks in the Literal[...] discriminator semantics for the SV dynamics
+    adapters (RandomWalk, AR1) — see CONTEXT.md "Conventions" and the
+    project-wide convention adopted in the volatility-process P1 work.
+    """
+
+    def test_random_walk_rejects_wrong_name_at_construction(self):
+        from impulso.sv.dynamics import RandomWalk
+
+        with pytest.raises(ValidationError):
+            RandomWalk(name="ar1")
+
+    def test_ar1_rejects_wrong_name_at_construction(self):
+        from impulso.sv.dynamics import AR1
+
+        with pytest.raises(ValidationError):
+            AR1(name="random_walk")
+
+    def test_random_walk_name_is_frozen(self):
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        with pytest.raises(ValidationError):
+            rw.name = "ar1"  # ty: ignore[invalid-assignment]
+
+    def test_ar1_name_is_frozen(self):
+        from impulso.sv.dynamics import AR1
+
+        ar = AR1()
+        with pytest.raises(ValidationError):
+            ar.name = "random_walk"  # ty: ignore[invalid-assignment]

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from impulso.protocols import VolatilityProcess
+from impulso.samplers import NUTSSampler
+from impulso.spec import VAR
 from impulso.volatility import Constant
 
 
@@ -97,14 +99,17 @@ class TestPosteriorEquivalence:
     Intent is regression detection on the seam refactor, not statistical
     correctness — the latter is covered by existing test_fitted.py /
     test_identified.py tests, which we also run to confirm.
+
+    The byte-for-byte equivalence assertion below pins ``nuts_sampler="pymc"``
+    explicitly so the determinism contract doesn't depend on whether nutpie
+    happens to be installed in the runner's environment. Coverage today is
+    only ``lags=1, n_vars=2, no exog``; extending the gate across
+    ``(lags, n_vars, exog)`` combinations is tracked as future work.
     """
 
     @pytest.mark.slow
     def test_default_volatility_posterior_shape_unchanged(self, var_data_2v):
-        from impulso.samplers import NUTSSampler
-        from impulso.spec import VAR
-
-        sampler = NUTSSampler(cores=1, chains=2, draws=200, tune=200, random_seed=42)
+        sampler = NUTSSampler(cores=1, chains=2, draws=200, tune=200, random_seed=42, nuts_sampler="pymc")
         fitted = VAR(lags=1).fit(var_data_2v, sampler=sampler)
 
         posterior_vars = set(fitted.idata.posterior.data_vars)
@@ -112,11 +117,14 @@ class TestPosteriorEquivalence:
         expected = {"intercept", "B", "sigma_sd", "tril_offdiag", "Sigma"}
         assert expected <= posterior_vars, f"Missing posterior variables: {expected - posterior_vars}"
 
-        # Shape contracts.
-        assert fitted.idata.posterior["intercept"].shape == (2, 200, 2)
-        assert fitted.idata.posterior["B"].shape == (2, 200, 2, 2)
-        assert fitted.idata.posterior["Sigma"].shape == (2, 200, 2, 2)
-        # Sigma is symmetric positive-definite per draw.
+        # Shape contracts: (chains, draws, n_vars[, n_vars]).
+        n_chains, n_draws = sampler.chains, sampler.draws
+        n_vars = var_data_2v.endog.shape[1]
+        assert fitted.idata.posterior["intercept"].shape == (n_chains, n_draws, n_vars)
+        assert fitted.idata.posterior["B"].shape == (n_chains, n_draws, n_vars, n_vars)
+        assert fitted.idata.posterior["Sigma"].shape == (n_chains, n_draws, n_vars, n_vars)
+        # Sigma is symmetric per draw (positive-definiteness is enforced upstream
+        # by HalfCauchy(sigma_sd) > 0 and the MvNormal likelihood).
         sigma = fitted.idata.posterior["Sigma"].values
         assert np.allclose(sigma, np.swapaxes(sigma, -1, -2)), "Sigma not symmetric"
 
@@ -124,11 +132,9 @@ class TestPosteriorEquivalence:
     def test_explicit_constant_matches_string_default(self, var_data_2v):
         """VAR(lags=1, volatility="constant") and VAR(lags=1, volatility=Constant())
         and VAR(lags=1) all produce identical posteriors given the same seed."""
-        from impulso.samplers import NUTSSampler
-        from impulso.spec import VAR
 
         def _fit(spec_kwargs):
-            sampler = NUTSSampler(cores=1, chains=2, draws=100, tune=100, random_seed=42)
+            sampler = NUTSSampler(cores=1, chains=2, draws=100, tune=100, random_seed=42, nuts_sampler="pymc")
             return VAR(lags=1, **spec_kwargs).fit(var_data_2v, sampler=sampler)
 
         fit_default = _fit({})

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -1,5 +1,6 @@
 """Tests for the volatility-process seam and adapters."""
 
+import numpy as np
 import pytest
 
 from impulso.protocols import VolatilityProcess
@@ -20,3 +21,48 @@ class TestConstantAdapter:
         adapter = Constant()
         with pytest.raises(ValidationError):
             adapter.name = "other"
+
+
+class TestConstantBuildPymcLatent:
+    def test_returns_lower_triangular_for_n_vars_3(self):
+        import pymc as pm
+
+        adapter = Constant()
+        with pm.Model():
+            L_tensor = adapter.build_pymc_latent(n_vars=3, T=100)
+            L_value = L_tensor.eval()  # uses prior values; deterministic shape
+
+        assert L_value.shape == (3, 3)
+        # Strictly lower-triangular plus positive diagonal: upper triangle is zero.
+        upper = np.triu(L_value, k=1)
+        assert np.allclose(upper, 0.0)
+
+    def test_handles_n_vars_1(self):
+        import pymc as pm
+
+        adapter = Constant()
+        with pm.Model():
+            L_tensor = adapter.build_pymc_latent(n_vars=1, T=50)
+            assert L_tensor.eval().shape == (1, 1)
+
+    def test_registers_expected_pymc_vars(self):
+        import pymc as pm
+
+        adapter = Constant()
+        with pm.Model() as model:
+            adapter.build_pymc_latent(n_vars=3, T=100)
+
+        var_names = {v.name for v in model.unobserved_RVs}
+        assert "sigma_sd" in var_names
+        assert "tril_offdiag" in var_names
+
+    def test_n_vars_1_skips_tril_offdiag(self):
+        import pymc as pm
+
+        adapter = Constant()
+        with pm.Model() as model:
+            adapter.build_pymc_latent(n_vars=1, T=50)
+
+        var_names = {v.name for v in model.unobserved_RVs}
+        assert "sigma_sd" in var_names
+        assert "tril_offdiag" not in var_names

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -1,0 +1,22 @@
+"""Tests for the volatility-process seam and adapters."""
+
+import pytest
+
+from impulso.protocols import VolatilityProcess
+from impulso.volatility import Constant
+
+
+class TestConstantAdapter:
+    def test_constant_satisfies_protocol(self):
+        adapter = Constant()
+        assert isinstance(adapter, VolatilityProcess)
+
+    def test_constant_name(self):
+        assert Constant().name == "constant"
+
+    def test_constant_is_frozen(self):
+        from pydantic import ValidationError
+
+        adapter = Constant()
+        with pytest.raises(ValidationError):
+            adapter.name = "other"

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -22,7 +22,9 @@ class TestConstantAdapter:
 
         adapter = Constant()
         with pytest.raises(ValidationError):
-            adapter.name = "other"
+            # Deliberately violate the `Literal["constant"]` static type to
+            # assert that the frozen Pydantic model raises at runtime.
+            adapter.name = "other"  # ty: ignore[invalid-assignment]
 
 
 class TestConstantBuildPymcLatent:

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -87,3 +87,62 @@ class TestConstantBuildPymcLatent:
         assert L_value[0, 1] == 0.0  # upper-triangular cell stays zero
         assert L_value[1, 0] != 0.0  # off-diagonal placed in the lower-triangular cell
         np.testing.assert_array_equal(np.diag(L_value), sd_value)
+
+
+class TestPosteriorEquivalence:
+    """Sanity check: VAR(lags=1) with default volatility="constant" reproduces
+    the *shape* and *variable names* of today's posterior.
+
+    Marked slow because it runs MCMC (cores=1, draws=200, tune=200).
+    Intent is regression detection on the seam refactor, not statistical
+    correctness — the latter is covered by existing test_fitted.py /
+    test_identified.py tests, which we also run to confirm.
+    """
+
+    @pytest.mark.slow
+    def test_default_volatility_posterior_shape_unchanged(self, var_data_2v):
+        from impulso.samplers import NUTSSampler
+        from impulso.spec import VAR
+
+        sampler = NUTSSampler(cores=1, chains=2, draws=200, tune=200, random_seed=42)
+        fitted = VAR(lags=1).fit(var_data_2v, sampler=sampler)
+
+        posterior_vars = set(fitted.idata.posterior.data_vars)
+        # Exact set of variables today's pipeline produces:
+        expected = {"intercept", "B", "sigma_sd", "tril_offdiag", "Sigma"}
+        assert expected <= posterior_vars, f"Missing posterior variables: {expected - posterior_vars}"
+
+        # Shape contracts.
+        assert fitted.idata.posterior["intercept"].shape == (2, 200, 2)
+        assert fitted.idata.posterior["B"].shape == (2, 200, 2, 2)
+        assert fitted.idata.posterior["Sigma"].shape == (2, 200, 2, 2)
+        # Sigma is symmetric positive-definite per draw.
+        sigma = fitted.idata.posterior["Sigma"].values
+        assert np.allclose(sigma, np.swapaxes(sigma, -1, -2)), "Sigma not symmetric"
+
+    @pytest.mark.slow
+    def test_explicit_constant_matches_string_default(self, var_data_2v):
+        """VAR(lags=1, volatility="constant") and VAR(lags=1, volatility=Constant())
+        and VAR(lags=1) all produce identical posteriors given the same seed."""
+        from impulso.samplers import NUTSSampler
+        from impulso.spec import VAR
+
+        def _fit(spec_kwargs):
+            sampler = NUTSSampler(cores=1, chains=2, draws=100, tune=100, random_seed=42)
+            return VAR(lags=1, **spec_kwargs).fit(var_data_2v, sampler=sampler)
+
+        fit_default = _fit({})
+        fit_string = _fit({"volatility": "constant"})
+        fit_object = _fit({"volatility": Constant()})
+
+        for name in ["intercept", "B", "Sigma"]:
+            np.testing.assert_array_equal(
+                fit_default.idata.posterior[name].values,
+                fit_string.idata.posterior[name].values,
+                err_msg=f"default vs string disagree on {name}",
+            )
+            np.testing.assert_array_equal(
+                fit_default.idata.posterior[name].values,
+                fit_object.idata.posterior[name].values,
+                err_msg=f"default vs Constant() instance disagree on {name}",
+            )

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -152,3 +152,30 @@ class TestPosteriorEquivalence:
                 fit_object.idata.posterior[name].values,
                 err_msg=f"default vs Constant() instance disagree on {name}",
             )
+
+
+class TestConstantCholeskyAt:
+    def test_returns_cholesky_of_sigma(self, synthetic_idata_2v):
+        adapter = Constant()
+        L = adapter.cholesky_at(synthetic_idata_2v.posterior, t=None)
+
+        sigma = synthetic_idata_2v.posterior["Sigma"].values
+        # L @ L.T should reproduce Sigma.
+        reconstructed = np.einsum("cdij,cdkj->cdik", L, L)
+        np.testing.assert_allclose(reconstructed, sigma, rtol=1e-6)
+
+    def test_t_argument_ignored_for_constant(self, synthetic_idata_2v):
+        """For constant volatility, any value of t returns the same L."""
+        adapter = Constant()
+        L_none = adapter.cholesky_at(synthetic_idata_2v.posterior, t=None)
+        L_zero = adapter.cholesky_at(synthetic_idata_2v.posterior, t=0)
+        L_arbitrary = adapter.cholesky_at(synthetic_idata_2v.posterior, t=42)
+        np.testing.assert_array_equal(L_none, L_zero)
+        np.testing.assert_array_equal(L_none, L_arbitrary)
+
+    def test_returns_lower_triangular(self, synthetic_idata_2v):
+        adapter = Constant()
+        L = adapter.cholesky_at(synthetic_idata_2v.posterior, t=None)
+        # Strictly upper-triangular block must be zero.
+        upper = np.triu(L, k=1)
+        assert np.allclose(upper, 0.0)

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -179,3 +179,27 @@ class TestConstantCholeskyAt:
         # Strictly upper-triangular block must be zero.
         upper = np.triu(L, k=1)
         assert np.allclose(upper, 0.0)
+
+
+class TestConstantForecastCholeskyPath:
+    def test_returns_broadcast_shape(self, synthetic_idata_2v):
+        adapter = Constant()
+        rng = np.random.default_rng(0)
+        path = adapter.forecast_cholesky_path(synthetic_idata_2v.posterior, steps=5, rng=rng)
+        # (chains, draws, steps, n_vars, n_vars)
+        assert path.shape == (2, 50, 5, 2, 2)
+
+    def test_constant_across_steps(self, synthetic_idata_2v):
+        """For constant volatility, every forecast step has the same L."""
+        adapter = Constant()
+        rng = np.random.default_rng(0)
+        path = adapter.forecast_cholesky_path(synthetic_idata_2v.posterior, steps=10, rng=rng)
+        # path[..., 0, :, :] must equal path[..., k, :, :] for all k.
+        np.testing.assert_array_equal(path[..., 0, :, :], path[..., 9, :, :])
+
+    def test_rng_unused_for_constant(self, synthetic_idata_2v):
+        """Constant is deterministic given the posterior — rng is accepted but unused."""
+        adapter = Constant()
+        path_a = adapter.forecast_cholesky_path(synthetic_idata_2v.posterior, steps=3, rng=np.random.default_rng(0))
+        path_b = adapter.forecast_cholesky_path(synthetic_idata_2v.posterior, steps=3, rng=np.random.default_rng(99999))
+        np.testing.assert_array_equal(path_a, path_b)

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -66,3 +66,24 @@ class TestConstantBuildPymcLatent:
         var_names = {v.name for v in model.unobserved_RVs}
         assert "sigma_sd" in var_names
         assert "tril_offdiag" not in var_names
+
+    def test_n_vars_2_indexing_and_diagonal(self):
+        """Smallest non-trivial off-diagonal case.
+
+        Verifies the single off-diagonal sits at ``L[1, 0]`` (lower-triangular
+        cell, not upper) and the diagonal carries the ``sigma_sd`` draws
+        (not zeros). A regression that swapped the ``(i, j)`` indexing or
+        dropped the ``set_subtensor`` for the diagonal would slip past the
+        existing ``n_vars=3`` upper-triangular check.
+        """
+        import pymc as pm
+
+        adapter = Constant()
+        with pm.Model() as model:
+            L_tensor = adapter.build_pymc_latent(n_vars=2, T=50)
+            L_value, sd_value = pm.draw([L_tensor, model["sigma_sd"]], random_seed=42)
+
+        assert L_value.shape == (2, 2)
+        assert L_value[0, 1] == 0.0  # upper-triangular cell stays zero
+        assert L_value[1, 0] != 0.0  # off-diagonal placed in the lower-triangular cell
+        np.testing.assert_array_equal(np.diag(L_value), sd_value)

--- a/uv.lock
+++ b/uv.lock
@@ -1289,6 +1289,7 @@ dev = [
     { name = "tabulate" },
     { name = "tox-uv" },
     { name = "ty" },
+    { name = "typing-extensions" },
     { name = "zensical" },
 ]
 docs = [
@@ -1323,6 +1324,7 @@ dev = [
     { name = "tabulate", specifier = ">=0.10.0" },
     { name = "tox-uv", specifier = ">=1.29.0" },
     { name = "ty", specifier = ">=0.0.14" },
+    { name = "typing-extensions", specifier = ">=4.12" },
     { name = "zensical", specifier = ">=0.0.28" },
 ]
 docs = [{ name = "statsmodels", specifier = ">=0.14.6" }]


### PR DESCRIPTION
## Summary

- Introduces a public `VolatilityProcess` Protocol (`build_pymc_latent`, `cholesky_at`, `forecast_cholesky_path`) and a `Constant` adapter that lifts today's manual-Cholesky parameterisation out of `VAR.fit` into the seam.
- Wires `VAR(volatility=...)` (default `"constant"`) and refactors `_build_pymc_model` to delegate Σ construction through `self.resolved_volatility.build_pymc_latent(...)`. PyMC variable names (`sigma_sd`, `tril_offdiag`, `Sigma`) preserved verbatim — `np.testing.assert_array_equal` of `intercept` / `B` / `Sigma` holds across `VAR(lags=1)`, `VAR(lags=1, volatility="constant")`, and `VAR(lags=1, volatility=Constant())` under the same seed.
- Exposes `VolatilityProcess` and `Constant` at the package top level (lazy-imported); aligns the `sv/dynamics.{RandomWalk, AR1}` discriminator fields onto the same `Literal["x"] = "x"` pattern adopted for `Constant.name`, with the convention documented in `CONTEXT.md`.

P1 of issue #61. Pipeline integration of `cholesky_at` is P2; stochastic-volatility adapter and `forecast_cholesky_path` wiring is P3.

## Test plan

- [ ] `uv run python -m pytest -m "not slow" -q` — expect **177 passed, 18 deselected**
- [ ] `uv run python -m pytest tests/test_volatility.py::TestPosteriorEquivalence -v` — slow MCMC byte-for-byte gate (pinned `nuts_sampler="pymc"`); ~14s
- [ ] `uv run python -m pytest tests/test_fitted.py tests/test_identified.py tests/test_identification.py -v` — 38 downstream tests confirm `Cholesky`, `SignRestriction`, `FittedVAR.forecast`, `IdentifiedVAR.{impulse_response, fevd, historical_decomposition}` still read `posterior["Sigma"]` correctly
- [ ] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [ ] `uv run ty check` — clean
- [ ] `uv lock --locked` — clean
- [ ] `python -c "from impulso import VolatilityProcess, Constant; from impulso.sv import StochasticVolatility"` — public-API + standalone SV path both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)