### PR TITLE
fix: labelled DataFrames for IRF / FEVD / HD result accessors (closes #72)

### DIFF
--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -371,7 +371,14 @@ class IdentifiedVAR(ImpulsoBaseModel):
         hd_da = xr.DataArray(
             hd,
             dims=["chain", "draw", "time", "response", "shock"],
-            coords={"response": self.var_names, "shock": self.shock_names},
+            coords={
+                "response": self.var_names,
+                "shock": self.shock_names,
+                # Tuple form forces the coord onto the declared `time` dim;
+                # otherwise a named DatetimeIndex (e.g. .name == "date")
+                # would be inferred as its own dim and collide.
+                "time": ("time", idx[t_start:t_end]),
+            },
             name="hd",
         )
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"hd": hd_da}))

--- a/src/impulso/plotting/_irf.py
+++ b/src/impulso/plotting/_irf.py
@@ -33,17 +33,17 @@ def plot_irf(
     fig.suptitle("Impulse Response Functions")
 
     horizons = range(result.horizon + 1)
+    shock_names = result.idata.posterior_predictive["irf"].coords["shock"].values.tolist()
     for i, resp in enumerate(var_names):
-        for j, shock in enumerate(var_names):
+        for j, shock in enumerate(shock_names[:n_vars]):
             ax = axes[i][j]
             ax.set_title(f"{shock} -> {resp}", fontsize=9)
             ax.axhline(0, color="grey", linewidth=0.5, linestyle="--")
-            col_idx = i * n_vars + j
-            ax.plot(horizons, med.values[:, col_idx])
+            ax.plot(horizons, med[(resp, shock)].values)
             ax.fill_between(
                 horizons,
-                hdi.lower.values[:, col_idx],
-                hdi.upper.values[:, col_idx],
+                hdi.lower[(resp, shock)].values,
+                hdi.upper[(resp, shock)].values,
                 alpha=0.3,
             )
 

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -5,10 +5,28 @@ from abc import abstractmethod
 import arviz as az
 import numpy as np
 import pandas as pd
+import xarray as xr
 from matplotlib.figure import Figure
 from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
+
+
+def _wide_frame(da: xr.DataArray, row_dim: str) -> pd.DataFrame:
+    """Reshape a (row_dim, response, shock) DataArray into a wide DataFrame.
+
+    The returned frame is indexed by the coord values of ``row_dim`` and has
+    a `MultiIndex(['response', 'shock'])` on columns built from those coords
+    in the order they appear on the DataArray.
+    """
+    da = da.transpose(row_dim, "response", "shock")
+    row_values = da.coords[row_dim].values
+    row_index = pd.DatetimeIndex(row_values, name="time") if row_dim == "time" else pd.Index(row_values, name=row_dim)
+    columns = pd.MultiIndex.from_product(
+        [da.coords["response"].values.tolist(), da.coords["shock"].values.tolist()],
+        names=["response", "shock"],
+    )
+    return pd.DataFrame(da.values.reshape(len(row_index), -1), index=row_index, columns=columns)
 
 
 class HDIResult(ImpulsoBaseModel):
@@ -133,21 +151,31 @@ class IRFResult(VARResultBase):
             )
 
     def median(self) -> pd.DataFrame:
-        """Posterior median IRF."""
+        """Posterior median IRF.
+
+        Returns:
+            DataFrame indexed by horizon (integer 0..H) with a
+            `MultiIndex(['response', 'shock'])` on columns.
+        """
         self._guard_no_time_dim()
         irf = self.idata.posterior_predictive["irf"]
-        return pd.DataFrame(irf.median(dim=("chain", "draw")).values.reshape(self.horizon + 1, -1))
+        return _wide_frame(irf.median(dim=("chain", "draw")), "horizon")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
-        """HDI for IRF."""
+        """HDI for IRF.
+
+        Returns:
+            HDIResult whose `lower` / `upper` DataFrames mirror the shape and
+            labels of `median()`.
+        """
         self._guard_no_time_dim()
         hdi_data = az.hdi(self.idata.posterior_predictive, hdi_prob=prob)["irf"]
-        lower = pd.DataFrame(hdi_data.sel(hdi="lower").values.reshape(self.horizon + 1, -1))
-        upper = pd.DataFrame(hdi_data.sel(hdi="higher").values.reshape(self.horizon + 1, -1))
+        lower = _wide_frame(hdi_data.sel(hdi="lower"), "horizon")
+        upper = _wide_frame(hdi_data.sel(hdi="higher"), "horizon")
         return HDIResult(lower=lower, upper=upper, prob=prob)
 
     def to_dataframe(self) -> pd.DataFrame:
-        """Convert IRF to DataFrame."""
+        """Convert IRF to DataFrame (passthrough to `median()`)."""
         return self.median()
 
     def plot(self) -> Figure:
@@ -188,21 +216,31 @@ class FEVDResult(VARResultBase):
             )
 
     def median(self) -> pd.DataFrame:
-        """Posterior median FEVD."""
+        """Posterior median FEVD.
+
+        Returns:
+            DataFrame indexed by horizon (integer 0..H) with a
+            `MultiIndex(['response', 'shock'])` on columns.
+        """
         self._guard_no_time_dim()
         fevd = self.idata.posterior_predictive["fevd"]
-        return pd.DataFrame(fevd.median(dim=("chain", "draw")).values.reshape(self.horizon + 1, -1))
+        return _wide_frame(fevd.median(dim=("chain", "draw")), "horizon")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
-        """HDI for FEVD."""
+        """HDI for FEVD.
+
+        Returns:
+            HDIResult whose `lower` / `upper` DataFrames mirror the shape and
+            labels of `median()`.
+        """
         self._guard_no_time_dim()
         hdi_data = az.hdi(self.idata.posterior_predictive, hdi_prob=prob)["fevd"]
-        lower = pd.DataFrame(hdi_data.sel(hdi="lower").values.reshape(self.horizon + 1, -1))
-        upper = pd.DataFrame(hdi_data.sel(hdi="higher").values.reshape(self.horizon + 1, -1))
+        lower = _wide_frame(hdi_data.sel(hdi="lower"), "horizon")
+        upper = _wide_frame(hdi_data.sel(hdi="higher"), "horizon")
         return HDIResult(lower=lower, upper=upper, prob=prob)
 
     def to_dataframe(self) -> pd.DataFrame:
-        """Convert FEVD to DataFrame."""
+        """Convert FEVD to DataFrame (passthrough to `median()`)."""
         return self.median()
 
     def plot(self) -> Figure:
@@ -223,19 +261,31 @@ class HistoricalDecompositionResult(VARResultBase):
     var_names: list[str]
 
     def median(self) -> pd.DataFrame:
-        """Posterior median historical decomposition."""
+        """Posterior median historical decomposition.
+
+        Returns:
+            DataFrame indexed by a `DatetimeIndex` over the in-sample period
+            (after lag-trimming and any `start` / `end` filter applied at
+            decomposition time), with a `MultiIndex(['response', 'shock'])`
+            on columns.
+        """
         hd = self.idata.posterior_predictive["hd"]
-        return pd.DataFrame(hd.median(dim=("chain", "draw")).values.reshape(-1, len(self.var_names)))
+        return _wide_frame(hd.median(dim=("chain", "draw")), "time")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
-        """HDI for historical decomposition."""
+        """HDI for historical decomposition.
+
+        Returns:
+            HDIResult whose `lower` / `upper` DataFrames mirror the shape and
+            labels of `median()`.
+        """
         hdi_data = az.hdi(self.idata.posterior_predictive, hdi_prob=prob)["hd"]
-        lower = pd.DataFrame(hdi_data.sel(hdi="lower").values.reshape(-1, len(self.var_names)))
-        upper = pd.DataFrame(hdi_data.sel(hdi="higher").values.reshape(-1, len(self.var_names)))
+        lower = _wide_frame(hdi_data.sel(hdi="lower"), "time")
+        upper = _wide_frame(hdi_data.sel(hdi="higher"), "time")
         return HDIResult(lower=lower, upper=upper, prob=prob)
 
     def to_dataframe(self) -> pd.DataFrame:
-        """Convert historical decomposition to DataFrame."""
+        """Convert historical decomposition to DataFrame (passthrough to `median()`)."""
         return self.median()
 
     def plot(self) -> Figure:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -98,17 +98,204 @@ class TestForecastResultMethods:
         assert df.shape == (4, 2)
 
 
+def _make_irf_result(responses=("gdp", "inf"), shocks=("e_gdp", "e_inf"), horizon=10):
+    rng = np.random.default_rng(42)
+    n_resp = len(responses)
+    n_shock = len(shocks)
+    data = rng.standard_normal((2, 50, horizon + 1, n_resp, n_shock))
+    da = xr.DataArray(
+        data,
+        dims=["chain", "draw", "horizon", "response", "shock"],
+        coords={
+            "response": list(responses),
+            "shock": list(shocks),
+            "horizon": np.arange(horizon + 1),
+        },
+        name="irf",
+    )
+    idata = az.InferenceData(posterior_predictive=xr.Dataset({"irf": da}))
+    return IRFResult.model_construct(idata=idata, horizon=horizon, var_names=list(responses))
+
+
+def _make_fevd_result(responses=("gdp", "inf"), shocks=("e_gdp", "e_inf"), horizon=10):
+    rng = np.random.default_rng(43)
+    n_resp = len(responses)
+    n_shock = len(shocks)
+    data = rng.uniform(size=(2, 50, horizon + 1, n_resp, n_shock))
+    data = data / data.sum(axis=-1, keepdims=True)  # rows sum to 1, like an FEVD
+    da = xr.DataArray(
+        data,
+        dims=["chain", "draw", "horizon", "response", "shock"],
+        coords={
+            "response": list(responses),
+            "shock": list(shocks),
+            "horizon": np.arange(horizon + 1),
+        },
+        name="fevd",
+    )
+    idata = az.InferenceData(posterior_predictive=xr.Dataset({"fevd": da}))
+    return FEVDResult.model_construct(idata=idata, horizon=horizon, var_names=list(responses))
+
+
+def _make_hd_result(responses=("gdp", "inf"), shocks=("e_gdp", "e_inf"), n_periods=24):
+    rng = np.random.default_rng(44)
+    n_resp = len(responses)
+    n_shock = len(shocks)
+    data = rng.standard_normal((2, 50, n_periods, n_resp, n_shock))
+    time_index = pd.date_range("2000-01-01", periods=n_periods, freq="QS")
+    da = xr.DataArray(
+        data,
+        dims=["chain", "draw", "time", "response", "shock"],
+        coords={
+            "response": list(responses),
+            "shock": list(shocks),
+            "time": ("time", time_index),
+        },
+        name="hd",
+    )
+    idata = az.InferenceData(posterior_predictive=xr.Dataset({"hd": da}))
+    return HistoricalDecompositionResult.model_construct(idata=idata, var_names=list(responses))
+
+
 class TestIRFResultMethods:
-    def test_median_shape(self):
-        rng = np.random.default_rng(42)
-        data = rng.standard_normal((2, 50, 11, 2, 2))
-        da = xr.DataArray(
-            data,
-            dims=["chain", "draw", "horizon", "response", "shock"],
-            coords={"response": ["y1", "y2"], "shock": ["y1", "y2"], "horizon": np.arange(11)},
-            name="irf",
-        )
-        idata = az.InferenceData(posterior_predictive=xr.Dataset({"irf": da}))
-        result = IRFResult.model_construct(idata=idata, horizon=10, var_names=["y1", "y2"])
+    def test_median_shape_and_labels(self):
+        """IRF.median() returns wide DataFrame indexed by horizon with
+        MultiIndex(['response','shock']) on columns.
+        """
+        result = _make_irf_result(horizon=10)
         med = result.median()
-        assert med.shape == (11, 4)  # (horizon+1) x (n_vars * n_vars)
+        assert isinstance(med, pd.DataFrame)
+        assert med.shape == (11, 4)
+        assert isinstance(med.columns, pd.MultiIndex)
+        assert med.columns.names == ["response", "shock"]
+        assert set(med.columns.tolist()) == {
+            ("gdp", "e_gdp"),
+            ("gdp", "e_inf"),
+            ("inf", "e_gdp"),
+            ("inf", "e_inf"),
+        }
+        # Row index is the integer horizon 0..H
+        assert list(med.index) == list(range(11))
+
+    def test_median_values_round_trip_labels(self):
+        """Values selected by label must match values pulled from the raw
+        DataArray, proving the column labelling isn't swapped or permuted.
+        """
+        result = _make_irf_result(horizon=10)
+        med = result.median()
+        raw = result.idata.posterior_predictive["irf"].median(dim=("chain", "draw"))
+        for resp in ("gdp", "inf"):
+            for shock in ("e_gdp", "e_inf"):
+                np.testing.assert_allclose(
+                    med[(resp, shock)].values,
+                    raw.sel(response=resp, shock=shock).values,
+                )
+
+    def test_hdi_shape_and_labels(self):
+        """HDIResult.lower / .upper must mirror median()'s shape and labels."""
+        result = _make_irf_result(horizon=10)
+        hdi = result.hdi(prob=0.89)
+        for frame in (hdi.lower, hdi.upper):
+            assert isinstance(frame, pd.DataFrame)
+            assert frame.shape == (11, 4)
+            assert isinstance(frame.columns, pd.MultiIndex)
+            assert frame.columns.names == ["response", "shock"]
+            assert set(frame.columns.tolist()) == {
+                ("gdp", "e_gdp"),
+                ("gdp", "e_inf"),
+                ("inf", "e_gdp"),
+                ("inf", "e_inf"),
+            }
+            assert list(frame.index) == list(range(11))
+        assert (hdi.upper.values >= hdi.lower.values).all()
+
+
+class TestFEVDResultMethods:
+    def test_median_shape_and_labels(self):
+        """FEVD.median() returns wide DataFrame indexed by horizon with
+        MultiIndex(['response','shock']) on columns.
+        """
+        result = _make_fevd_result(horizon=10)
+        med = result.median()
+        assert isinstance(med, pd.DataFrame)
+        assert med.shape == (11, 4)
+        assert isinstance(med.columns, pd.MultiIndex)
+        assert med.columns.names == ["response", "shock"]
+        assert set(med.columns.tolist()) == {
+            ("gdp", "e_gdp"),
+            ("gdp", "e_inf"),
+            ("inf", "e_gdp"),
+            ("inf", "e_inf"),
+        }
+        assert list(med.index) == list(range(11))
+
+    def test_median_values_round_trip_labels(self):
+        result = _make_fevd_result(horizon=10)
+        med = result.median()
+        raw = result.idata.posterior_predictive["fevd"].median(dim=("chain", "draw"))
+        for resp in ("gdp", "inf"):
+            for shock in ("e_gdp", "e_inf"):
+                np.testing.assert_allclose(
+                    med[(resp, shock)].values,
+                    raw.sel(response=resp, shock=shock).values,
+                )
+
+    def test_hdi_shape_and_labels(self):
+        result = _make_fevd_result(horizon=10)
+        hdi = result.hdi(prob=0.89)
+        for frame in (hdi.lower, hdi.upper):
+            assert isinstance(frame, pd.DataFrame)
+            assert frame.shape == (11, 4)
+            assert isinstance(frame.columns, pd.MultiIndex)
+            assert frame.columns.names == ["response", "shock"]
+            assert list(frame.index) == list(range(11))
+        assert (hdi.upper.values >= hdi.lower.values).all()
+
+
+class TestHistoricalDecompositionResultMethods:
+    def test_median_indexed_by_time_with_multiindex_columns(self):
+        """HD.median() returns wide DataFrame indexed by a DatetimeIndex
+        (the per-t in-sample dates) with MultiIndex(['response','shock'])
+        on columns. The shape is (T, n_resp * n_shock).
+        """
+        result = _make_hd_result(n_periods=24)
+        med = result.median()
+        assert isinstance(med, pd.DataFrame)
+        assert med.shape == (24, 4)
+        assert isinstance(med.index, pd.DatetimeIndex)
+        expected_index = pd.date_range("2000-01-01", periods=24, freq="QS")
+        assert med.index.name == "time"
+        np.testing.assert_array_equal(med.index.values, expected_index.values)
+        assert isinstance(med.columns, pd.MultiIndex)
+        assert med.columns.names == ["response", "shock"]
+        assert set(med.columns.tolist()) == {
+            ("gdp", "e_gdp"),
+            ("gdp", "e_inf"),
+            ("inf", "e_gdp"),
+            ("inf", "e_inf"),
+        }
+
+    def test_median_values_round_trip_labels(self):
+        result = _make_hd_result(n_periods=24)
+        med = result.median()
+        raw = result.idata.posterior_predictive["hd"].median(dim=("chain", "draw"))
+        for resp in ("gdp", "inf"):
+            for shock in ("e_gdp", "e_inf"):
+                np.testing.assert_allclose(
+                    med[(resp, shock)].values,
+                    raw.sel(response=resp, shock=shock).values,
+                )
+
+    def test_hdi_shape_and_labels(self):
+        result = _make_hd_result(n_periods=24)
+        hdi = result.hdi(prob=0.89)
+        expected_index = pd.date_range("2000-01-01", periods=24, freq="QS")
+        for frame in (hdi.lower, hdi.upper):
+            assert isinstance(frame, pd.DataFrame)
+            assert frame.shape == (24, 4)
+            assert isinstance(frame.index, pd.DatetimeIndex)
+            assert frame.index.name == "time"
+            np.testing.assert_array_equal(frame.index.values, expected_index.values)
+            assert isinstance(frame.columns, pd.MultiIndex)
+            assert frame.columns.names == ["response", "shock"]
+        assert (hdi.upper.values >= hdi.lower.values).all()


### PR DESCRIPTION
## Summary

- IRF/FEVD `.median()` / `.hdi()` return wide DataFrames with `MultiIndex(['response','shock'])` on columns, integer horizon index.
- HD `.median()` / `.hdi()` now indexed by `DatetimeIndex` (recovered via a new `time` coord on the underlying DataArray), with the same MultiIndex columns — the `(T, response, shock)` axes are no longer collapsed.
- `_irf.py` switches from `col_idx = i*n_vars + j` integer arithmetic to label-based `med[(resp, shock)]` selection.

Resolves audit findings #1 (collapsed named axes) and #10 (HD time axis lost) — see `reports/audit-2026-05-18.md`. First of four stacked PRs from `plans/2026-05-18-audit-cleanup-plan.md`.

Closes #72.

## Test plan

- [x] `uv run python -m pytest tests/test_results.py -v` — 21/21 pass; 9 new tests cover the new contract for IRF/FEVD/HD (round-trip values via label selection, `MultiIndex(['response','shock'])` columns, HD `DatetimeIndex` rows, `HDIResult` mirrors `.median()` shape and labels).
- [x] `make test` — 268/268 pass (incl. slow MCMC).
- [x] `make check` — ruff + ty clean.
- [x] `make docs-render-ci` — all 5 tutorials render, exit 0.
- [x] `test_identified.py` / `test_plotting.py` unchanged: shape `(11, 4)` survives; values unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)