### PR TITLE
refactor: extract MA recursion + lift time-dim guard to base (closes #76)

### DIFF
--- a/src/impulso/_ma.py
+++ b/src/impulso/_ma.py
@@ -1,0 +1,60 @@
+"""MA coefficient recursion shared by IRF/FEVD computation and SignRestriction.
+
+The structural identity behind impulse-response and forecast-error-variance
+analysis is the moving-average representation of a VAR:
+
+    Phi_0 = I
+    Phi_h = sum_{j=1}^{min(h, p)} A_j @ Phi_{h-j},   h >= 1
+
+where ``A_1, ..., A_p`` are the lag coefficient matrices. `compute_ma_phi`
+is the single source of truth — both the posterior-batched IRF code in
+`identified.py` and the per-rotation sign-restriction check in
+`identification.py` delegate here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def compute_ma_phi(A: list[np.ndarray], horizon: int) -> np.ndarray:
+    """Compute MA coefficient matrices via the structural recursion.
+
+    Numpy's ``@`` operator broadcasts over leading dims, so the helper handles
+    both a single rotation and a posterior tensor of draws without branching:
+    pass each ``A_j`` with shape ``(n, n)`` for a single-draw computation, or
+    with shape ``(C, D, n, n)`` for a batched one.
+
+    Args:
+        A: Lag coefficient matrices ``A_1, ..., A_p`` in lag order. Each entry
+            has shape ``(..., n, n)`` where the leading dims are arbitrary but
+            shared across all entries. Must be non-empty.
+        horizon: Highest MA horizon to compute. The result spans
+            ``Phi_0`` through ``Phi_horizon`` inclusive.
+
+    Returns:
+        A stacked array with the horizon axis third-to-last. For a single
+        draw: shape ``(horizon + 1, n, n)``. For a batched posterior:
+        shape ``(C, D, horizon + 1, n, n)``.
+
+    Raises:
+        ValueError: If ``A`` is empty or ``horizon`` is negative.
+    """
+    if not A:
+        raise ValueError("A must contain at least one lag coefficient matrix")
+    if horizon < 0:
+        raise ValueError(f"horizon must be non-negative, got {horizon}")
+
+    n = A[0].shape[-1]
+    leading_shape = A[0].shape[:-2]
+    n_lags = len(A)
+
+    eye = np.broadcast_to(np.eye(n), (*leading_shape, n, n)).copy()
+    Phi: list[np.ndarray] = [eye]
+    for h in range(1, horizon + 1):
+        phi_h = np.zeros((*leading_shape, n, n))
+        for j in range(min(h, n_lags)):
+            phi_h = phi_h + A[j] @ Phi[h - j - 1]
+        Phi.append(phi_h)
+
+    return np.stack(Phi, axis=-3)

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -5,6 +5,7 @@ import xarray as xr
 from pydantic import Field, PrivateAttr
 
 from impulso._base import ImpulsoModel
+from impulso._ma import compute_ma_phi
 
 
 class Cholesky(ImpulsoModel):
@@ -206,19 +207,12 @@ class SignRestriction(ImpulsoModel):
         if not self._check_restrictions(candidate, var_names, shock_names):
             return False
 
-        # Extract lag coefficient matrices A_1..A_p
         A = [B_draw[:, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
+        Phi = compute_ma_phi(A, self.restriction_horizon)  # (H+1, n, n)
 
-        # MA recursion: Phi_0 = I, Phi_h = sum_{j=1}^{min(h,p)} A_j @ Phi_{h-j}
-        Phi_prev = [np.eye(n_vars)]
+        # Phi[0] (= I) handles the impact check above; iterate h=1..H here.
         for h in range(1, self.restriction_horizon + 1):
-            phi_h = np.zeros((n_vars, n_vars))
-            for j in range(min(h, n_lags)):
-                phi_h += A[j] @ Phi_prev[h - j - 1]
-            Phi_prev.append(phi_h)
-
-            # IRF at horizon h = Phi_h @ candidate
-            irf_h = phi_h @ candidate
+            irf_h = Phi[h] @ candidate
             if not self._check_restrictions(irf_h, var_names, shock_names):
                 return False
 

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -10,6 +10,7 @@ import xarray as xr
 from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
+from impulso._ma import compute_ma_phi
 from impulso.data import VARData
 from impulso.protocols import IdentificationScheme, VolatilityProcess
 from impulso.results import FEVDResult, HistoricalDecompositionResult, IRFResult
@@ -53,18 +54,8 @@ class IdentifiedVAR(ImpulsoBaseModel):
         Returns:
             Array of shape (C, D, horizon+1, n_vars, n_vars).
         """
-        # Extract A_j matrices: each (C, D, n, n)
         A = [B_draws[:, :, :, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
-
-        n_chains, n_draws = B_draws.shape[:2]
-        Phi = [np.broadcast_to(np.eye(n_vars), (n_chains, n_draws, n_vars, n_vars)).copy()]
-        for h in range(1, horizon + 1):
-            phi_h = np.zeros((n_chains, n_draws, n_vars, n_vars))
-            for j in range(min(h, n_lags)):
-                phi_h += np.einsum("cdij,cdjk->cdik", A[j], Phi[h - j - 1])
-            Phi.append(phi_h)
-
-        return np.stack(Phi, axis=2)
+        return compute_ma_phi(A, horizon)
 
     def _resolve_at(self, at: AtParam) -> int | None:
         """Resolve ``at=`` to an integer ``t`` suitable for ``cholesky_at(t)``.

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -1,6 +1,7 @@
 """Result objects for VAR post-estimation output."""
 
 from abc import abstractmethod
+from typing import ClassVar
 
 import arviz as az
 import numpy as np
@@ -46,11 +47,19 @@ class HDIResult(ImpulsoBaseModel):
 class VARResultBase(ImpulsoBaseModel):
     """Base class for VAR post-estimation results.
 
+    Subclasses that hold a single named DataArray in
+    ``idata.posterior_predictive`` (IRF, FEVD) declare its key via the
+    class-level ``_PRIMARY_KEY``; this drives the shared
+    ``_guard_no_time_dim`` check.
+
     Attributes:
         idata: ArviZ InferenceData holding the result draws.
     """
 
     idata: az.InferenceData = Field(repr=False)
+
+    # Empty default — subclasses with a `time`-aware median override it.
+    _PRIMARY_KEY: ClassVar[str] = ""
 
     @abstractmethod
     def median(self) -> pd.DataFrame:
@@ -75,6 +84,31 @@ class VARResultBase(ImpulsoBaseModel):
     def plot(self) -> Figure:
         """Plot the result. Subclasses must implement."""
         raise NotImplementedError
+
+    def _guard_no_time_dim(self) -> None:
+        """Refuse `median`/`hdi`/`to_dataframe` on a time-aware result.
+
+        The reshape-based aggregations assume a 5-D ``(C, D, H+1, n, n)``
+        DataArray. For ``at='all'`` the array is 6-D
+        ``(C, D, T, H+1, n, n)`` and ``.reshape(H+1, -1)`` would silently
+        scramble the time and variable dims into the column axis. Refuse
+        instead and point the user at the underlying DataArray.
+        """
+        key = self._PRIMARY_KEY
+        if not key:
+            raise NotImplementedError(
+                f"{type(self).__name__} did not declare _PRIMARY_KEY; the time-dim guard cannot be evaluated."
+            )
+        if "time" in self.idata.posterior_predictive[key].dims:
+            cls_name = type(self).__name__
+            raise NotImplementedError(
+                f"{cls_name}.median()/hdi()/to_dataframe() do not support "
+                f"time-varying {key.upper()}s (at='all'). Access the "
+                f"underlying DataArray directly via "
+                f"result.idata.posterior_predictive[{key!r}] and aggregate "
+                f"manually, or use at='last' / at=<int> / at=None for a "
+                f"single-time {key.upper()}."
+            )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"
@@ -129,26 +163,10 @@ class IRFResult(VARResultBase):
         var_names: Names of variables.
     """
 
+    _PRIMARY_KEY: ClassVar[str] = "irf"
+
     horizon: int
     var_names: list[str]
-
-    def _guard_no_time_dim(self) -> None:
-        """Raise if the IRF DataArray has a ``time`` dim (``at='all'`` case).
-
-        The reshape-based aggregations in ``median``/``hdi``/``to_dataframe``
-        assume a 5-D ``(C, D, H+1, n, n)`` array. For ``at='all'`` the array is
-        6-D ``(C, D, T, H+1, n, n)`` and ``.reshape(H+1, -1)`` would silently
-        scramble the time and variable dims into the column axis. Refuse
-        instead and point the user at the underlying DataArray.
-        """
-        if "time" in self.idata.posterior_predictive["irf"].dims:
-            raise NotImplementedError(
-                "IRFResult.median()/hdi()/to_dataframe() do not support "
-                "time-varying IRFs (at='all'). Access the underlying DataArray "
-                "directly via result.idata.posterior_predictive['irf'] and "
-                "aggregate manually, or use at='last' / at=<int> / at=None for "
-                "a single-time IRF."
-            )
 
     def median(self) -> pd.DataFrame:
         """Posterior median IRF.
@@ -194,26 +212,10 @@ class FEVDResult(VARResultBase):
         var_names: Names of variables.
     """
 
+    _PRIMARY_KEY: ClassVar[str] = "fevd"
+
     horizon: int
     var_names: list[str]
-
-    def _guard_no_time_dim(self) -> None:
-        """Raise if the FEVD DataArray has a ``time`` dim (``at='all'`` case).
-
-        The reshape-based aggregations in ``median``/``hdi``/``to_dataframe``
-        assume a 5-D ``(C, D, H+1, n, n)`` array. For ``at='all'`` the array is
-        6-D ``(C, D, T, H+1, n, n)`` and ``.reshape(H+1, -1)`` would silently
-        scramble the time and variable dims into the column axis. Refuse
-        instead and point the user at the underlying DataArray.
-        """
-        if "time" in self.idata.posterior_predictive["fevd"].dims:
-            raise NotImplementedError(
-                "FEVDResult.median()/hdi()/to_dataframe() do not support "
-                "time-varying FEVDs (at='all'). Access the underlying DataArray "
-                "directly via result.idata.posterior_predictive['fevd'] and "
-                "aggregate manually, or use at='last' / at=<int> / at=None for "
-                "a single-time FEVD."
-            )
 
     def median(self) -> pd.DataFrame:
         """Posterior median FEVD.

--- a/tests/test_ma.py
+++ b/tests/test_ma.py
@@ -1,0 +1,135 @@
+"""Tests for the MA coefficient recursion helper."""
+
+import numpy as np
+import pytest
+
+from impulso._ma import compute_ma_phi
+
+
+class TestComputeMaPhiSingleDraw:
+    """A_j arrays have shape (n, n) — the per-rotation case used by
+    `SignRestriction._check_restrictions_at_horizons`.
+    """
+
+    def test_horizon_zero_returns_identity(self):
+        """Phi_0 is the identity, regardless of A. Returned shape is (1, n, n)."""
+        n = 3
+        rng = np.random.default_rng(0)
+        A = [rng.standard_normal((n, n))]
+        Phi = compute_ma_phi(A, horizon=0)
+        assert Phi.shape == (1, n, n)
+        np.testing.assert_array_equal(Phi[0], np.eye(n))
+
+    def test_phi_one_equals_a_one(self):
+        """Phi_1 = sum_{j=1}^{min(1, p)} A_j @ Phi_0 = A_1 @ I = A_1."""
+        rng = np.random.default_rng(1)
+        n = 3
+        A_1 = rng.standard_normal((n, n))
+        Phi = compute_ma_phi([A_1, rng.standard_normal((n, n))], horizon=1)
+        assert Phi.shape == (2, n, n)
+        np.testing.assert_allclose(Phi[1], A_1)
+
+    def test_recursion_matches_manual_two_lags_three_horizons(self):
+        """Closed-form check: Phi_2 = A_1 @ Phi_1 + A_2 @ Phi_0 = A_1 @ A_1 + A_2."""
+        rng = np.random.default_rng(2)
+        n = 2
+        A_1 = rng.standard_normal((n, n))
+        A_2 = rng.standard_normal((n, n))
+        Phi = compute_ma_phi([A_1, A_2], horizon=3)
+        assert Phi.shape == (4, n, n)
+        np.testing.assert_allclose(Phi[0], np.eye(n))
+        np.testing.assert_allclose(Phi[1], A_1)
+        np.testing.assert_allclose(Phi[2], A_1 @ A_1 + A_2)
+        np.testing.assert_allclose(Phi[3], A_1 @ (A_1 @ A_1 + A_2) + A_2 @ A_1)
+
+    def test_horizon_less_than_n_lags_truncates_sum(self):
+        """At h=1 with p=3, only A_1 contributes (j=1..min(1, 3)=1)."""
+        rng = np.random.default_rng(3)
+        n = 2
+        A_1 = rng.standard_normal((n, n))
+        A_2 = rng.standard_normal((n, n))
+        A_3 = rng.standard_normal((n, n))
+        Phi = compute_ma_phi([A_1, A_2, A_3], horizon=1)
+        # A_2 and A_3 must NOT contribute to Phi_1; perturbing them is invisible.
+        Phi_perturbed = compute_ma_phi([A_1, A_2 * 100, A_3 * -50], horizon=1)
+        np.testing.assert_allclose(Phi[1], Phi_perturbed[1])
+        np.testing.assert_allclose(Phi[1], A_1)
+
+
+class TestComputeMaPhiBatched:
+    """A_j arrays have shape (C, D, n, n) — the posterior case used by
+    `IdentifiedVAR._ma_coefficients`.
+    """
+
+    def test_returns_expected_shape(self):
+        rng = np.random.default_rng(10)
+        n, n_chains, n_draws, n_lags, horizon = 3, 2, 5, 2, 4
+        A = [rng.standard_normal((n_chains, n_draws, n, n)) for _ in range(n_lags)]
+        Phi = compute_ma_phi(A, horizon=horizon)
+        assert Phi.shape == (n_chains, n_draws, horizon + 1, n, n)
+
+    def test_batched_matches_per_draw_loop(self):
+        """Each (c, d) slice of the batched result must equal the single-draw
+        recursion on the same coefficients — guarantees `@` broadcasting is
+        semantically equivalent to scalar matmul.
+        """
+        rng = np.random.default_rng(11)
+        n, n_chains, n_draws, n_lags, horizon = 3, 2, 4, 2, 3
+        A_batched = [rng.standard_normal((n_chains, n_draws, n, n)) for _ in range(n_lags)]
+        Phi_batched = compute_ma_phi(A_batched, horizon=horizon)
+
+        for c in range(n_chains):
+            for d in range(n_draws):
+                A_single = [A_j[c, d] for A_j in A_batched]
+                Phi_single = compute_ma_phi(A_single, horizon=horizon)
+                np.testing.assert_allclose(Phi_batched[c, d], Phi_single)
+
+    def test_horizon_zero_returns_identity_broadcast(self):
+        rng = np.random.default_rng(12)
+        n, n_chains, n_draws = 2, 2, 3
+        A = [rng.standard_normal((n_chains, n_draws, n, n))]
+        Phi = compute_ma_phi(A, horizon=0)
+        assert Phi.shape == (n_chains, n_draws, 1, n, n)
+        for c in range(n_chains):
+            for d in range(n_draws):
+                np.testing.assert_array_equal(Phi[c, d, 0], np.eye(n))
+
+
+class TestComputeMaPhiAgreesWithLegacyRecursion:
+    """Numerical agreement gate: the helper output must match the original
+    pre-refactor recursion in `identified.py` on a fixed seed.
+    """
+
+    @staticmethod
+    def _legacy_recursion(B_draws: np.ndarray, n_vars: int, n_lags: int, horizon: int) -> np.ndarray:
+        """Verbatim copy of the pre-refactor `_ma_coefficients` body."""
+        A = [B_draws[:, :, :, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
+        n_chains, n_draws = B_draws.shape[:2]
+        Phi = [np.broadcast_to(np.eye(n_vars), (n_chains, n_draws, n_vars, n_vars)).copy()]
+        for h in range(1, horizon + 1):
+            phi_h = np.zeros((n_chains, n_draws, n_vars, n_vars))
+            for j in range(min(h, n_lags)):
+                phi_h += np.einsum("cdij,cdjk->cdik", A[j], Phi[h - j - 1])
+            Phi.append(phi_h)
+        return np.stack(Phi, axis=2)
+
+    def test_helper_matches_legacy_on_fixed_seed(self):
+        rng = np.random.default_rng(42)
+        n_chains, n_draws, n_vars, n_lags, horizon = 2, 30, 3, 2, 8
+        B_draws = rng.standard_normal((n_chains, n_draws, n_vars, n_vars * n_lags)) * 0.3
+
+        legacy = self._legacy_recursion(B_draws, n_vars, n_lags, horizon)
+        A = [B_draws[:, :, :, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
+        helper = compute_ma_phi(A, horizon)
+
+        np.testing.assert_allclose(helper, legacy, atol=1e-12)
+
+
+class TestComputeMaPhiValidation:
+    def test_empty_A_raises(self):
+        with pytest.raises(ValueError, match="at least one lag"):
+            compute_ma_phi([], horizon=1)
+
+    def test_negative_horizon_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            compute_ma_phi([np.eye(2)], horizon=-1)


### PR DESCRIPTION
## Summary

- New `src/impulso/_ma.py` with `compute_ma_phi(A: list[np.ndarray], horizon: int)`. Numpy `@` broadcasts over leading dims, so the helper handles both the single-rotation `(n, n)` case used by `SignRestriction` and the posterior-batched `(C, D, n, n)` case used by `IdentifiedVAR` — without branching.
- `_ma_coefficients` (identified.py) and `_check_restrictions_at_horizons` (identification.py) each delegate to `compute_ma_phi` exactly once. The pre-refactor in-line recursions are deleted.
- `_guard_no_time_dim` lifts onto `VARResultBase`. Each subclass declares a class-level `_PRIMARY_KEY: ClassVar[str]` (`"irf"` / `"fevd"`); the base helper reads it. Removes ~30 lines of duplication.

Closes #76. Third of four stacked PRs from `plans/2026-05-18-audit-cleanup-plan.md`. Stacked on top of #75 (PR2).

## Test plan

- [x] `uv run python -m pytest tests/test_ma.py -v` — 10/10 pass (single-draw, batched, edge cases, byte-for-byte agreement with the pre-refactor recursion on a fixed seed, input validation).
- [x] `make test` — 281/281 pass (+10 vs PR2: the new `test_ma.py` suite). No behavioural change visible to tests outside `test_ma.py` — pure refactor.
- [x] `make check` — ruff + ty clean.
- [x] `grep -c compute_ma_phi src/impulso/identified.py src/impulso/identification.py` — 2 each (1 import + 1 call); satisfies "exactly once per file".

🤖 Generated with [Claude Code](https://claude.com/claude-code)