### PR TITLE
chore: docstring + naming + repr cleanup, bump 0.0.6 (closes #78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,9 @@ Shared fixtures available in all test files:
 - `assert` is allowed in tests (`S101` ignored for `tests/*`)
 - `E501` (line length), `E731` (lambda assignment), and `TRY003` (long exception messages) are globally ignored
 - Docstrings follow Google style (Args/Returns sections)
+- Docstring inline code uses **single backticks** (Markdown-native, what
+  mkdocstrings expects): write `` `Foo.bar` ``, not `` ``Foo.bar`` ``.
+  Cross-references are plain text — no RST `:meth:` / `:class:` directives.
 
 ## PyMC / Sampling Gotchas
 

--- a/docs/tutorials/stochastic-volatility.md
+++ b/docs/tutorials/stochastic-volatility.md
@@ -761,7 +761,7 @@ print(h.dims, h.shape)
 
 ## Time-varying impulse responses with `at=`
 
-When the volatility is time-varying, the structural impact matrix is too. The `at=` parameter on `impulse_response`, `forecast_error_variance_decomposition`, and `historical_decomposition` selects which date’s Cholesky factor (and hence which structural impact matrix) the computation uses:
+When the volatility is time-varying, the structural impact matrix is too. The `at=` parameter on `impulse_response`, `fevd`, and `historical_decomposition` selects which date’s Cholesky factor (and hence which structural impact matrix) the computation uses:
 
 - `at="last"` — most recent in-sample period (the default when the volatility is stochastic)
 - `at=t` — a specific integer index into the lag-trimmed sample
@@ -808,7 +808,7 @@ print(irf_all_arr.dims)
     (2, 500, 732, 13, 3, 3)
     ('chain', 'draw', 'time', 'horizon', 'response', 'shock')
 
-The same `at=` argument is accepted by `forecast_error_variance_decomposition` and `historical_decomposition` with the same semantics.
+The same `at=` argument is accepted by `fevd` and `historical_decomposition` with the same semantics.
 
 ## References
 

--- a/docs/tutorials/stochastic-volatility.qmd
+++ b/docs/tutorials/stochastic-volatility.qmd
@@ -286,7 +286,7 @@ print(h.dims, h.shape)
 
 ## Time-varying impulse responses with `at=`
 
-When the volatility is time-varying, the structural impact matrix is too. The `at=` parameter on `impulse_response`, `forecast_error_variance_decomposition`, and `historical_decomposition` selects which date's Cholesky factor (and hence which structural impact matrix) the computation uses:
+When the volatility is time-varying, the structural impact matrix is too. The `at=` parameter on `impulse_response`, `fevd`, and `historical_decomposition` selects which date's Cholesky factor (and hence which structural impact matrix) the computation uses:
 
 - `at="last"` — most recent in-sample period (the default when the volatility is stochastic)
 - `at=t` — a specific integer index into the lag-trimmed sample
@@ -326,7 +326,7 @@ print(irf_all_arr.shape)
 print(irf_all_arr.dims)
 ```
 
-The same `at=` argument is accepted by `forecast_error_variance_decomposition` and `historical_decomposition` with the same semantics.
+The same `at=` argument is accepted by `fevd` and `historical_decomposition` with the same semantics.
 
 ## References
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "impulso"
-version = "0.0.5"
+version = "0.0.6"
 description = "Bayesian Vector Autoregression (VAR) in Python."
 authors = [{ name = "Thomas Pinder", email = "tompinder@live.co.uk" }]
 readme = "README.md"

--- a/src/impulso/_ma.py
+++ b/src/impulso/_ma.py
@@ -6,7 +6,7 @@ analysis is the moving-average representation of a VAR:
     Phi_0 = I
     Phi_h = sum_{j=1}^{min(h, p)} A_j @ Phi_{h-j},   h >= 1
 
-where ``A_1, ..., A_p`` are the lag coefficient matrices. `compute_ma_phi`
+where `A_1, ..., A_p` are the lag coefficient matrices. `compute_ma_phi`
 is the single source of truth — both the posterior-batched IRF code in
 `identified.py` and the per-rotation sign-restriction check in
 `identification.py` delegate here.
@@ -20,25 +20,25 @@ import numpy as np
 def compute_ma_phi(A: list[np.ndarray], horizon: int) -> np.ndarray:
     """Compute MA coefficient matrices via the structural recursion.
 
-    Numpy's ``@`` operator broadcasts over leading dims, so the helper handles
+    Numpy's `@` operator broadcasts over leading dims, so the helper handles
     both a single rotation and a posterior tensor of draws without branching:
-    pass each ``A_j`` with shape ``(n, n)`` for a single-draw computation, or
-    with shape ``(C, D, n, n)`` for a batched one.
+    pass each `A_j` with shape `(n, n)` for a single-draw computation, or
+    with shape `(C, D, n, n)` for a batched one.
 
     Args:
-        A: Lag coefficient matrices ``A_1, ..., A_p`` in lag order. Each entry
-            has shape ``(..., n, n)`` where the leading dims are arbitrary but
+        A: Lag coefficient matrices `A_1, ..., A_p` in lag order. Each entry
+            has shape `(..., n, n)` where the leading dims are arbitrary but
             shared across all entries. Must be non-empty.
         horizon: Highest MA horizon to compute. The result spans
-            ``Phi_0`` through ``Phi_horizon`` inclusive.
+            `Phi_0` through `Phi_horizon` inclusive.
 
     Returns:
         A stacked array with the horizon axis third-to-last. For a single
-        draw: shape ``(horizon + 1, n, n)``. For a batched posterior:
-        shape ``(C, D, horizon + 1, n, n)``.
+        draw: shape `(horizon + 1, n, n)`. For a batched posterior:
+        shape `(C, D, horizon + 1, n, n)`.
 
     Raises:
-        ValueError: If ``A`` is empty or ``horizon`` is negative.
+        ValueError: If `A` is empty or `horizon` is negative.
     """
     if not A:
         raise ValueError("A must contain at least one lag coefficient matrix")

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import arviz as az
 import numpy as np
-from pydantic import Field, computed_field
+from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
 from impulso.data import VARData
@@ -34,7 +34,6 @@ class FittedVAR(ImpulsoBaseModel):
     var_names: list[str]
     volatility: VolatilityProcess
 
-    @computed_field
     @property
     def has_exog(self) -> bool:
         """Whether the model includes exogenous variables."""
@@ -57,21 +56,21 @@ class FittedVAR(ImpulsoBaseModel):
         shape depends on whether Σ is time-invariant or time-varying:
 
         * Constant volatility — Σ is shared across time, so the result
-          has shape ``(chains, draws, n_vars, n_vars)``.
+          has shape `(chains, draws, n_vars, n_vars)`.
         * Stochastic volatility — Σ_t evolves, so the result has shape
-          ``(chains, draws, T, n_vars, n_vars)`` where ``T`` is the
+          `(chains, draws, T, n_vars, n_vars)` where `T` is the
           in-sample length after lag trimming. Callers needing a single
-          slice should call ``volatility.cholesky_at(posterior, t)`` and
+          slice should call `volatility.cholesky_at(posterior, t)` and
           square the factor themselves.
 
         Note:
-            **Breaking change vs. v0.0.4 and earlier**: ``sigma`` is now
-            a method, not a property. Call sites that used ``fitted.sigma``
-            must be updated to ``fitted.sigma()``.
+            **Breaking change vs. v0.0.4 and earlier**: `sigma` is now
+            a method, not a property. Call sites that used `fitted.sigma`
+            must be updated to `fitted.sigma()`.
 
         Returns:
             Posterior draws of Σ (or Σ_t for SV) computed from the
-            volatility adapter's Cholesky factor as ``L @ L.T``.
+            volatility adapter's Cholesky factor as `L @ L.T`.
         """
         if self.volatility.is_time_varying:
             T = self.data.endog.shape[0] - self.n_lags
@@ -148,8 +147,8 @@ class FittedVAR(ImpulsoBaseModel):
         Queries the fitted volatility process for the Cholesky factor of Σ
         and passes it to the scheme. For constant volatility, the factor is
         the same across all time points; for stochastic volatility (P3),
-        ``cholesky_at(t=None)`` returns the most-recent slice and
-        downstream IRF/FEVD/HD methods can re-query at other ``at`` values.
+        `cholesky_at(t=None)` returns the most-recent slice and
+        downstream IRF/FEVD/HD methods can re-query at other `at` values.
 
         Args:
             scheme: An IdentificationScheme protocol instance (e.g. Cholesky,

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -29,8 +29,8 @@ class Cholesky(ImpulsoModel):
     ) -> np.ndarray:
         """Apply Cholesky identification.
 
-        For default variable ordering, ``identify`` is a no-op and returns
-        ``L`` unchanged. When ``self.ordering`` differs from ``var_names``,
+        For default variable ordering, `identify` is a no-op and returns
+        `L` unchanged. When `self.ordering` differs from `var_names`,
         the underlying covariance is permuted and re-decomposed so the
         Cholesky factor reflects the requested causal ordering.
 
@@ -96,16 +96,16 @@ class SignRestriction(ImpulsoModel):
         Args:
             L: Lower-triangular Cholesky factor, shape (chains, draws, n_vars, n_vars).
             var_names: Variable names in the data's natural order.
-            posterior: Required when ``self.restriction_horizon > 0`` because
-                the multi-horizon check needs the VAR coefficients ``B`` from
+            posterior: Required when `self.restriction_horizon > 0` because
+                the multi-horizon check needs the VAR coefficients `B` from
                 the posterior. Ignored for impact-only restrictions
-                (``restriction_horizon == 0``).
+                (`restriction_horizon == 0`).
 
         Returns:
             Structural shock matrix, shape (chains, draws, n_vars, n_vars).
-            Per-draw fallback to the supplied ``L`` for draws where no
+            Per-draw fallback to the supplied `L` for draws where no
             rotation satisfies the restrictions. Acceptance rate available
-            via the ``sign_restriction_acceptance_rate`` attribute on the
+            via the `sign_restriction_acceptance_rate` attribute on the
             wrapping IdentifiedVAR's posterior (set by the pipeline).
         """
         from scipy.stats import special_ortho_group

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -28,11 +28,11 @@ class IdentifiedVAR(ImpulsoBaseModel):
         data: Original VARData.
         var_names: Endogenous variable names.
         volatility: Volatility process carried through from the fitted VAR.
-            Required for ``at=`` queries on impulse_response / fevd /
+            Required for `at=` queries on impulse_response / fevd /
             historical_decomposition (P3), which re-call
-            ``volatility.cholesky_at(at)`` for the requested time slice.
+            `volatility.cholesky_at(at)` for the requested time slice.
         scheme: Identification scheme used to produce the structural shock
-            matrix. Required for ``at=`` queries so the scheme can be
+            matrix. Required for `at=` queries so the scheme can be
             re-applied to a different Cholesky factor on demand.
     """
 
@@ -58,23 +58,23 @@ class IdentifiedVAR(ImpulsoBaseModel):
         return compute_ma_phi(A, horizon)
 
     def _resolve_at(self, at: AtParam) -> int | None:
-        """Resolve ``at=`` to an integer ``t`` suitable for ``cholesky_at(t)``.
+        """Resolve `at=` to an integer `t` suitable for `cholesky_at(t)`.
 
-        Returns ``None`` when ``at`` is ``None`` or ``"last"``. ``cholesky_at``
-        adapters interpret ``t=None`` as "most recent" (SV) or "ignored"
-        (Constant), so passing ``None`` through is the right default in both
+        Returns `None` when `at` is `None` or `"last"`. `cholesky_at`
+        adapters interpret `t=None` as "most recent" (SV) or "ignored"
+        (Constant), so passing `None` through is the right default in both
         cases. Integer values are returned unchanged.
 
         Args:
-            at: Either ``None``, ``"last"``, or an integer time index.
-                ``"all"`` is not handled here — callers must dispatch to the
+            at: Either `None`, `"last"`, or an integer time index.
+                `"all"` is not handled here — callers must dispatch to the
                 per-t path before calling this helper.
 
         Returns:
-            An integer time index, or ``None`` for the most-recent default.
+            An integer time index, or `None` for the most-recent default.
 
         Raises:
-            ValueError: If ``at`` is not one of the supported forms.
+            ValueError: If `at` is not one of the supported forms.
         """
         if at == "last" or at is None:
             return None
@@ -86,19 +86,19 @@ class IdentifiedVAR(ImpulsoBaseModel):
         )
 
     def _identify_per_t(self, L_path: np.ndarray) -> np.ndarray:
-        """Apply ``self.scheme.identify`` per time slice.
+        """Apply `self.scheme.identify` per time slice.
 
         Iterates the per-t loop in Python — fine for Cholesky (vectorised
-        internally over draws), but expensive for ``SignRestriction`` at
-        large ``T`` because rotations are re-sampled per time slice. A
+        internally over draws), but expensive for `SignRestriction` at
+        large `T` because rotations are re-sampled per time slice. A
         future optimisation could specialise the loop for time-invariant
         schemes, but P3 does not need it.
 
         Args:
-            L_path: ``(C, D, T, n, n)`` Cholesky factor path.
+            L_path: `(C, D, T, n, n)` Cholesky factor path.
 
         Returns:
-            ``(C, D, T, n, n)`` structural shock matrix path.
+            `(C, D, T, n, n)` structural shock matrix path.
         """
         T = L_path.shape[2]
         P_path = np.zeros_like(L_path)
@@ -115,21 +115,21 @@ class IdentifiedVAR(ImpulsoBaseModel):
             horizon: Number of periods.
             at: Time index for the structural shock matrix:
 
-                - ``None`` (default): for SV, equivalent to ``"last"``;
+                - `None` (default): for SV, equivalent to `"last"`;
                   for Constant, ignored entirely.
-                - ``int``: query the shock matrix at this specific ``t``.
-                - ``"last"``: most recent time slice.
-                - ``"all"``: return IRFs for shocks at every ``t`` (adds a
-                  ``time`` dim to the result).
+                - `int`: query the shock matrix at this specific `t`.
+                - `"last"`: most recent time slice.
+                - `"all"`: return IRFs for shocks at every `t` (adds a
+                  `time` dim to the result).
 
         Returns:
             IRFResult with IRF posterior draws.
 
         Raises:
-            ValueError: When ``at='all'`` is requested for a non-time-varying
-                volatility process (``Constant``). Under constant Σ the per-t
+            ValueError: When `at='all'` is requested for a non-time-varying
+                volatility process (`Constant`). Under constant Σ the per-t
                 IRF is identical for every t, so the time axis carries no
-                information — use ``at=None`` (default) or ``at='last'``.
+                information — use `at=None` (default) or `at='last'`.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
         n_vars = B_draws.shape[2]
@@ -190,28 +190,28 @@ class IdentifiedVAR(ImpulsoBaseModel):
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"irf": irf_da}))
         return IRFResult(idata=idata, horizon=horizon, var_names=self.var_names)
 
-    def forecast_error_variance_decomposition(self, horizon: int = 20, at: AtParam = None) -> FEVDResult:
+    def fevd(self, horizon: int = 20, at: AtParam = None) -> FEVDResult:
         """Compute forecast error variance decomposition.
 
         Args:
             horizon: Number of periods.
             at: Time index for the structural shock matrix:
 
-                - ``None`` (default): for SV, equivalent to ``"last"``;
+                - `None` (default): for SV, equivalent to `"last"`;
                   for Constant, ignored entirely.
-                - ``int``: query the shock matrix at this specific ``t``.
-                - ``"last"``: most recent time slice.
-                - ``"all"``: return FEVDs for shocks at every ``t`` (adds a
-                  ``time`` dim to the result).
+                - `int`: query the shock matrix at this specific `t`.
+                - `"last"`: most recent time slice.
+                - `"all"`: return FEVDs for shocks at every `t` (adds a
+                  `time` dim to the result).
 
         Returns:
             FEVDResult with FEVD posterior draws.
 
         Raises:
-            ValueError: When ``at='all'`` is requested for a non-time-varying
-                volatility process (``Constant``). Under constant Σ the per-t
+            ValueError: When `at='all'` is requested for a non-time-varying
+                volatility process (`Constant`). Under constant Σ the per-t
                 FEVD is identical for every t, so the time axis carries no
-                information — use ``at=None`` (default) or ``at='last'``.
+                information — use `at=None` (default) or `at='last'`.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
         n_vars = B_draws.shape[2]
@@ -280,18 +280,6 @@ class IdentifiedVAR(ImpulsoBaseModel):
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"fevd": fevd_da}))
         return FEVDResult(idata=idata, horizon=horizon, var_names=self.var_names)
 
-    def fevd(self, horizon: int = 20, at: AtParam = None) -> FEVDResult:
-        """Alias for forecast_error_variance_decomposition.
-
-        Args:
-            horizon: Number of periods.
-            at: See :meth:`forecast_error_variance_decomposition`.
-
-        Returns:
-            FEVDResult.
-        """
-        return self.forecast_error_variance_decomposition(horizon=horizon, at=at)
-
     def historical_decomposition(
         self,
         start: pd.Timestamp | None = None,
@@ -302,7 +290,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
         """Compute historical decomposition of observed series.
 
         Historical decomposition is intrinsically time-indexed: it attributes
-        each in-sample observation to past structural shocks. The ``at=``
+        each in-sample observation to past structural shocks. The `at=`
         parameter controls which Cholesky factor identifies those shocks.
 
         Args:
@@ -311,16 +299,16 @@ class IdentifiedVAR(ImpulsoBaseModel):
             cumulative: If True, return cumulative shock contributions.
             at: Time index for the structural shock matrix:
 
-                - ``None`` (default) or ``"all"``: use ``cholesky_path`` —
-                  identify the shock at each ``t`` with its own ``L_t``.
+                - `None` (default) or `"all"`: use `cholesky_path` —
+                  identify the shock at each `t` with its own `L_t`.
                   For stochastic volatility this is the correct structural
-                  decomposition; for constant volatility ``L_t`` is the same
-                  for all ``t`` and the result matches the legacy behaviour.
-                - ``int`` or ``"last"``: identify every shock with a single
-                  ``L`` queried at the supplied time index. Under stochastic
+                  decomposition; for constant volatility `L_t` is the same
+                  for all `t` and the result matches the legacy behaviour.
+                - `int` or `"last"`: identify every shock with a single
+                  `L` queried at the supplied time index. Under stochastic
                   volatility this is a non-standard hypothetical ("what if
-                  regime ``t`` had prevailed throughout?") and emits a
-                  ``UserWarning``. For constant volatility the result is
+                  regime `t` had prevailed throughout?") and emits a
+                  `UserWarning`. For constant volatility the result is
                   identical to the default.
 
         Returns:

--- a/src/impulso/protocols.py
+++ b/src/impulso/protocols.py
@@ -40,16 +40,16 @@ class IdentificationScheme(Protocol):
         Args:
             L: Lower-triangular Cholesky factor of the structural-shock
                 covariance, shape (chains, draws, n_vars, n_vars). Produced
-                by ``volatility.cholesky_at(...)``.
+                by `volatility.cholesky_at(...)`.
             var_names: Endogenous variable names, in the order they appear
                 in the underlying data.
             posterior: Full posterior xarray Dataset. Optional; provided by
                 the pipeline so schemes that need additional draws (e.g.,
                 SignRestriction with restriction_horizon > 0 needs B for the
                 MA recursion) can reach for them. Schemes that only need L
-                may ignore this argument. Schemes that need ``posterior``
-                for context but receive ``None`` should raise a clear
-                ``ValueError``.
+                may ignore this argument. Schemes that need `posterior`
+                for context but receive `None` should raise a clear
+                `ValueError`.
 
         Returns:
             Structural shock matrix array of shape (chains, draws, n_vars, n_vars).
@@ -59,9 +59,9 @@ class IdentificationScheme(Protocol):
         ...
 
     def shock_coords(self, n_vars: int) -> list[str]:
-        """Return the labels for the ``shock`` coordinate of the structural matrix.
+        """Return the labels for the `shock` coordinate of the structural matrix.
 
-        The pipeline calls this after ``identify`` to label the columns of
+        The pipeline calls this after `identify` to label the columns of
         the structural shock matrix when wrapping into an xarray DataArray.
 
         Args:
@@ -69,7 +69,7 @@ class IdentificationScheme(Protocol):
                 structural shock matrix).
 
         Returns:
-            A list of length ``n_vars`` naming each shock column.
+            A list of length `n_vars` naming each shock column.
         """
         ...
 
@@ -90,10 +90,10 @@ class VolatilityProcess(Protocol):
 
     name: str
     is_time_varying: bool
-    """Whether Σ_t evolves over time. ``False`` for homoscedastic adapters
-    (``Constant``); ``True`` for stochastic-volatility adapters. Drives
+    """Whether Σ_t evolves over time. `False` for homoscedastic adapters
+    (`Constant`); `True` for stochastic-volatility adapters. Drives
     branching in `FittedVAR.sigma` and `IdentifiedVAR.historical_decomposition`
-    so neither has to string-sniff the adapter ``name``."""
+    so neither has to string-sniff the adapter `name`."""
 
     def build_pymc_latent(
         self,
@@ -110,7 +110,7 @@ class VolatilityProcess(Protocol):
         Args:
             n_vars: Number of endogenous variables.
             T: Number of in-sample observations (after lag trimming).
-            data: Optional per-variable series of shape ``(T, n_vars)``,
+            data: Optional per-variable series of shape `(T, n_vars)`,
                 typically OLS residuals from the VAR pipeline. Stochastic
                 adapters use this to seed per-variable priors; constant
                 adapters ignore it.
@@ -146,7 +146,7 @@ class VolatilityProcess(Protocol):
 
         Returns shape (chains, draws, T, n_vars, n_vars). For constant
         volatility, broadcasts the time-invariant L across the requested
-        ``T``. For stochastic volatility, indexes into the latent log-vol
+        `T`. For stochastic volatility, indexes into the latent log-vol
         posterior to construct L_t for each t.
         """
         ...

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -16,7 +16,7 @@ from impulso._base import ImpulsoBaseModel
 def _wide_frame(da: xr.DataArray, row_dim: str) -> pd.DataFrame:
     """Reshape a (row_dim, response, shock) DataArray into a wide DataFrame.
 
-    The returned frame is indexed by the coord values of ``row_dim`` and has
+    The returned frame is indexed by the coord values of `row_dim` and has
     a `MultiIndex(['response', 'shock'])` on columns built from those coords
     in the order they appear on the DataArray.
     """
@@ -48,9 +48,9 @@ class VARResultBase(ImpulsoBaseModel):
     """Base class for VAR post-estimation results.
 
     Subclasses that hold a single named DataArray in
-    ``idata.posterior_predictive`` (IRF, FEVD) declare its key via the
-    class-level ``_PRIMARY_KEY``; this drives the shared
-    ``_guard_no_time_dim`` check.
+    `idata.posterior_predictive` (IRF, FEVD) declare its key via the
+    class-level `_PRIMARY_KEY`; this drives the shared
+    `_guard_no_time_dim` check.
 
     Attributes:
         idata: ArviZ InferenceData holding the result draws.
@@ -88,9 +88,9 @@ class VARResultBase(ImpulsoBaseModel):
     def _guard_no_time_dim(self) -> None:
         """Refuse `median`/`hdi`/`to_dataframe` on a time-aware result.
 
-        The reshape-based aggregations assume a 5-D ``(C, D, H+1, n, n)``
-        DataArray. For ``at='all'`` the array is 6-D
-        ``(C, D, T, H+1, n, n)`` and ``.reshape(H+1, -1)`` would silently
+        The reshape-based aggregations assume a 5-D `(C, D, H+1, n, n)`
+        DataArray. For `at='all'` the array is 6-D
+        `(C, D, T, H+1, n, n)` and `.reshape(H+1, -1)` would silently
         scramble the time and variable dims into the column axis. Refuse
         instead and point the user at the underlying DataArray.
         """
@@ -109,9 +109,6 @@ class VARResultBase(ImpulsoBaseModel):
                 f"manually, or use at='last' / at=<int> / at=None for a "
                 f"single-time {key.upper()}."
             )
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
 
 
 class ForecastResult(VARResultBase):

--- a/src/impulso/sv/data.py
+++ b/src/impulso/sv/data.py
@@ -1,6 +1,6 @@
 """SVData — validated, immutable data container for univariate SV models."""
 
-from typing import Self
+from typing import ClassVar, Self
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,9 @@ class SVData(ImpulsoBaseModel):
     name: str
     index: pd.DatetimeIndex = Field(repr=False)
 
-    _MIN_OBS: int = 24  # two years of monthly data; SV estimation is uninformative below this
+    # Class-level constant — two years of monthly data. ClassVar keeps this
+    # out of Pydantic's model_fields so it never appears in model_dump or repr.
+    _MIN_OBS: ClassVar[int] = 24
 
     @model_validator(mode="after")
     def _validate(self) -> Self:

--- a/src/impulso/sv/dynamics.py
+++ b/src/impulso/sv/dynamics.py
@@ -1,6 +1,6 @@
 """Log-volatility dynamics for univariate stochastic volatility models."""
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import xarray as xr
@@ -22,9 +22,9 @@ class SVDynamics(Protocol):
     name: str
     has_explicit_level: bool
     """Whether the dynamics owns the log-vol level via an explicit intercept
-    (e.g. AR(1)'s ``alpha``). Multivariate adapters use this to avoid a
-    redundant outer ``mu_i`` shift when the dynamics already carries the
-    level. ``True`` for AR(1), ``False`` for random-walk."""
+    (e.g. AR(1)'s `alpha`). Multivariate adapters use this to avoid a
+    redundant outer `mu_i` shift when the dynamics already carries the
+    level. `True` for AR(1), `False` for random-walk."""
 
     def build_latent_path(
         self,
@@ -35,8 +35,8 @@ class SVDynamics(Protocol):
     ) -> "pt.TensorVariable":
         """Register and return the latent log-volatility path inside the active PyMC model.
 
-        ``name_prefix`` is prepended to every registered PyMC variable name
-        (e.g., ``name_prefix="v0_"`` produces ``v0_h0``, ``v0_z``, ``v0_h``).
+        `name_prefix` is prepended to every registered PyMC variable name
+        (e.g., `name_prefix="v0_"` produces `v0_h0`, `v0_z`, `v0_h`).
         Used by multivariate SV adapters to avoid name collisions across
         per-variable log-vol paths. Default empty prefix preserves the
         univariate naming.
@@ -59,7 +59,13 @@ class RandomWalk(ImpulsoModel):
     name: Literal["random_walk"] = "random_walk"
     has_explicit_level: bool = False
 
-    def build_latent_path(self, prior_params: dict, T: int, sigma_eta: Any, name_prefix: str = "") -> Any:
+    def build_latent_path(
+        self,
+        prior_params: dict,
+        T: int,
+        sigma_eta: "pt.TensorVariable",
+        name_prefix: str = "",
+    ) -> "pt.TensorVariable":
         import pymc as pm
         import pytensor.tensor as pt
 
@@ -90,7 +96,13 @@ class AR1(ImpulsoModel):
     name: Literal["ar1"] = "ar1"
     has_explicit_level: bool = True
 
-    def build_latent_path(self, prior_params: dict, T: int, sigma_eta: Any, name_prefix: str = "") -> Any:
+    def build_latent_path(
+        self,
+        prior_params: dict,
+        T: int,
+        sigma_eta: "pt.TensorVariable",
+        name_prefix: str = "",
+    ) -> "pt.TensorVariable":
         import pymc as pm
         import pytensor.tensor as pt
 

--- a/src/impulso/sv/fitted.py
+++ b/src/impulso/sv/fitted.py
@@ -57,9 +57,9 @@ class FittedSV(ImpulsoBaseModel):
         Args:
             steps: Number of forecast steps.
             random_seed: Controls the RNG used to draw forecast innovations.
-                Accepts an int seed, a ``numpy.random.Generator``, or ``None``
+                Accepts an int seed, a `numpy.random.Generator`, or `None`
                 (default) for fresh non-deterministic draws. Pass an int or
-                ``Generator`` for reproducible forecasts.
+                `Generator` for reproducible forecasts.
 
         Returns:
             SVForecastResult wrapping posterior predictive draws.

--- a/src/impulso/sv/spec.py
+++ b/src/impulso/sv/spec.py
@@ -26,11 +26,11 @@ class StochasticVolatility(ImpulsoBaseModel):
 
     Attributes:
         name: Discriminator key for the volatility-process registry
-            (always ``"sv"``).
-        is_time_varying: Always ``True`` — Σ_t evolves over t.
-        dynamics: Log-volatility dynamics. String shorthand (``"random_walk"``
-            or ``"ar1"``) or an explicit ``SVDynamics`` instance (e.g.
-            ``RandomWalk()``, ``AR1()``).
+            (always `"sv"`).
+        is_time_varying: Always `True` — Σ_t evolves over t.
+        dynamics: Log-volatility dynamics. String shorthand (`"random_walk"`
+            or `"ar1"`) or an explicit `SVDynamics` instance (e.g.
+            `RandomWalk()`, `AR1()`).
         prior: Prior shorthand string or SVPrior instance.
     """
 
@@ -113,31 +113,31 @@ class StochasticVolatility(ImpulsoBaseModel):
     ) -> "pt.TensorVariable":
         """Register the Clark-style multivariate SV latents.
 
-        For each ``i`` in ``0..n_vars-1``: per-variable priors are seeded
-        from ``data[:, i]`` (typically VAR OLS residuals), then a log-vol
-        path ``h_i,t`` is registered via the configured dynamics. The
+        For each `i` in `0..n_vars-1`: per-variable priors are seeded
+        from `data[:, i]` (typically VAR OLS residuals), then a log-vol
+        path `h_i,t` is registered via the configured dynamics. The
         per-variable log-vol *level* comes from the dynamics' own intercept
-        when available (AR(1)'s ``alpha``), else from an outer ``mu_i``
+        when available (AR(1)'s `alpha`), else from an outer `mu_i`
         (random-walk has no intrinsic level). The shared mixing factor
-        ``R_chol`` (a unit-diagonal lower-triangular ``n_vars x n_vars``
+        `R_chol` (a unit-diagonal lower-triangular `n_vars x n_vars`
         matrix) is registered once via the manual LKJ workaround. Note:
         pinning the diagonal of a Cholesky factor to 1 does **not** make
-        ``R_chol @ R_chol.T`` a correlation matrix; the Gram-matrix
-        diagonal is ``1 + sum_j off[i,j]^2``. The diagonal pin is an
-        *identifiability* device: all volatility scaling lives in ``h``,
-        so ``R_chol`` is identified only up to its off-diagonal mixing
+        `R_chol @ R_chol.T` a correlation matrix; the Gram-matrix
+        diagonal is `1 + sum_j off[i,j]^2`. The diagonal pin is an
+        *identifiability* device: all volatility scaling lives in `h`,
+        so `R_chol` is identified only up to its off-diagonal mixing
         entries. See CLAUDE.md for the broader LKJCholeskyCov workaround.
 
         Args:
             n_vars: Number of structural shocks / endogenous variables.
             T: Number of in-sample observations.
-            data: Per-variable series of shape ``(T, n_vars)`` used to
+            data: Per-variable series of shape `(T, n_vars)` used to
                 seed per-variable priors. Required — the VAR pipeline
                 passes OLS residuals; direct callers should do the same.
 
         Returns:
-            ``L_t`` of shape ``(T, n_vars, n_vars)`` where
-            ``L_t[t] = diag(exp(h_t / 2)) @ R_chol``.
+            `L_t` of shape `(T, n_vars, n_vars)` where
+            `L_t[t] = diag(exp(h_t / 2)) @ R_chol`.
         """
         import pymc as pm
         import pytensor.tensor as pt
@@ -208,10 +208,10 @@ class StochasticVolatility(ImpulsoBaseModel):
         """Return L_t = diag(exp(h_t / 2)) @ R_chol for the requested t.
 
         Args:
-            posterior: An xarray Dataset containing ``h`` of shape
-                (chains, draws, T, n_vars) and ``R_chol`` of shape
+            posterior: An xarray Dataset containing `h` of shape
+                (chains, draws, T, n_vars) and `R_chol` of shape
                 (chains, draws, n_vars, n_vars).
-            t: Time index. ``None`` defaults to the most recent (T-1).
+            t: Time index. `None` defaults to the most recent (T-1).
 
         Returns:
             Cholesky factor at time t, shape (chains, draws, n_vars, n_vars).
@@ -231,8 +231,8 @@ class StochasticVolatility(ImpulsoBaseModel):
         """Return the full L_t path for t in 0..T-1.
 
         Args:
-            posterior: An xarray Dataset containing ``h`` (chains, draws, T, n_vars)
-                and ``R_chol`` (chains, draws, n_vars, n_vars).
+            posterior: An xarray Dataset containing `h` (chains, draws, T, n_vars)
+                and `R_chol` (chains, draws, n_vars, n_vars).
             T: Expected length of the time axis. Must match h.shape[2].
 
         Returns:
@@ -253,28 +253,28 @@ class StochasticVolatility(ImpulsoBaseModel):
         steps: int,
         rng: np.random.Generator,
     ) -> np.ndarray:
-        """Forecast the per-t Cholesky factor for ``steps`` ahead.
+        """Forecast the per-t Cholesky factor for `steps` ahead.
 
         Each variable's log-vol is extrapolated independently using the
-        configured dynamics; the correlation Cholesky ``R_chol`` is held
+        configured dynamics; the correlation Cholesky `R_chol` is held
         constant (Clark-style assumption).
 
-        ``SVDynamics.forecast_log_vol`` reads bare posterior keys (``h``,
-        ``sigma_eta``, and for AR(1) also ``phi``/``alpha``), whereas the
+        `SVDynamics.forecast_log_vol` reads bare posterior keys (`h`,
+        `sigma_eta`, and for AR(1) also `phi`/`alpha`), whereas the
         multivariate-fit posterior stores per-variable hyperparameters
-        under prefixed names (``v{i}_sigma_eta``, ...). For each variable
-        ``i`` we build a small slice ``Dataset`` with renamed keys and
-        delegate the extrapolation to ``dynamics.forecast_log_vol``.
+        under prefixed names (`v{i}_sigma_eta`, ...). For each variable
+        `i` we build a small slice `Dataset` with renamed keys and
+        delegate the extrapolation to `dynamics.forecast_log_vol`.
 
         Args:
-            posterior: Dataset with per-variable log-vol paths (``h``)
-                and ``R_chol``.
+            posterior: Dataset with per-variable log-vol paths (`h`)
+                and `R_chol`.
             steps: Forecast horizon.
             rng: Random number generator for the extrapolation
                 innovations.
 
         Returns:
-            ``(chains, draws, steps, n_vars, n_vars)``.
+            `(chains, draws, steps, n_vars, n_vars)`.
         """
         import xarray as xr
 

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -24,21 +24,21 @@ class Constant(ImpulsoModel):
     """Homoscedastic volatility — single Σ shared across all time points.
 
     Lifts today's manual-Cholesky parameterisation from
-    ``spec.py:_build_pymc_model`` into the volatility-process seam:
+    `spec.py:_build_pymc_model` into the volatility-process seam:
     HalfCauchy(beta=sigma_sd_beta) on the diagonal scales,
     Normal(mu=0, sigma=tril_offdiag_sigma) on the lower-triangular
-    off-diagonals (scaled by the row's diagonal). For ``n_vars == 1``
+    off-diagonals (scaled by the row's diagonal). For `n_vars == 1`
     the off-diagonal block is empty.
 
-    The PyMC variable names produced inside ``build_pymc_latent``
-    (``sigma_sd``, ``tril_offdiag``) match today's posterior contents
+    The PyMC variable names produced inside `build_pymc_latent`
+    (`sigma_sd`, `tril_offdiag`) match today's posterior contents
     exactly so existing identification and downstream code keep working
-    unchanged. The ``Sigma = L @ L.T`` deterministic is registered by
-    the caller in ``spec.py``, not by the adapter.
+    unchanged. The `Sigma = L @ L.T` deterministic is registered by
+    the caller in `spec.py`, not by the adapter.
 
     Attributes:
-        name: Discriminator key for the registry (always ``"constant"``).
-        is_time_varying: Always ``False`` — Σ is shared across t.
+        name: Discriminator key for the registry (always `"constant"`).
+        is_time_varying: Always `False` — Σ is shared across t.
         sigma_sd_beta: HalfCauchy scale on diagonal SDs.
         tril_offdiag_sigma: Normal SD on off-diagonal correlation factors.
     """
@@ -58,8 +58,8 @@ class Constant(ImpulsoModel):
         """Register the constant-volatility latent vars in the active PyMC model.
 
         Lifts the manual-Cholesky parameterisation from the previous
-        location in ``spec.py:_build_pymc_model``. PyMC variable names
-        (``sigma_sd``, ``tril_offdiag``) match the prior contents byte-for-byte
+        location in `spec.py:_build_pymc_model`. PyMC variable names
+        (`sigma_sd`, `tril_offdiag`) match the prior contents byte-for-byte
         so existing posterior-consuming code keeps working unchanged.
 
         Args:
@@ -94,13 +94,13 @@ class Constant(ImpulsoModel):
     def cholesky_at(self, posterior: "xr.Dataset", t: int | None) -> np.ndarray:
         """Return the lower-triangular Cholesky factor of Σ for every draw.
 
-        Reads ``posterior["L"]`` directly — the factor is registered as a
-        deterministic in ``build_pymc_latent`` so this method does not
-        re-decompose Σ. For constant volatility, ``t`` is ignored.
+        Reads `posterior["L"]` directly — the factor is registered as a
+        deterministic in `build_pymc_latent` so this method does not
+        re-decompose Σ. For constant volatility, `t` is ignored.
 
         Args:
-            posterior: An xarray Dataset (typically ``idata.posterior``)
-                containing ``L`` of shape (chains, draws, n_vars, n_vars).
+            posterior: An xarray Dataset (typically `idata.posterior`)
+                containing `L` of shape (chains, draws, n_vars, n_vars).
             t: Time index. Ignored.
 
         Returns:
@@ -117,12 +117,13 @@ class Constant(ImpulsoModel):
         """Broadcast the constant Cholesky factor across forecast steps.
 
         For constant volatility there is nothing to simulate — the forecast
-        covariance equals the in-sample covariance. ``rng`` is accepted for
+        covariance equals the in-sample covariance. `rng` is accepted for
         signature parity with stochastic adapters and is ignored.
 
         Args:
-            posterior: An xarray Dataset with ``Sigma`` of shape
-                (chains, draws, n_vars, n_vars).
+            posterior: An xarray Dataset containing `L` of shape
+                (chains, draws, n_vars, n_vars). Read via
+                `Constant.cholesky_at`, which is the canonical accessor.
             steps: Forecast horizon.
             rng: Unused.
 
@@ -139,7 +140,9 @@ class Constant(ImpulsoModel):
         broadcast convenience for the IdentifiedVAR query layer.
 
         Args:
-            posterior: An xarray Dataset with ``Sigma``.
+            posterior: An xarray Dataset containing `L` of shape
+                (chains, draws, n_vars, n_vars). Read via
+                `Constant.cholesky_at`, which is the canonical accessor.
             T: In-sample length (after lag trimming).
 
         Returns:

--- a/uv.lock
+++ b/uv.lock
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "impulso"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
## Summary

Wraps up the audit cleanup stack — small individual fixes that share a single style/cleanup theme.

- **#5** `volatility.py`: `Constant.cholesky_path` / `forecast_cholesky_path` docstrings now reference `L` (the actual posterior key) instead of stale `Sigma`; cross-ref `Constant.cholesky_at`.
- **#8** `sv/data.py`: `_MIN_OBS: ClassVar[int] = 24` — explicit class-attribute intent.
- **#12** `fitted.py`: `FittedVAR.has_exog` drops `@computed_field`; plain `@property` now, so it's no longer in `model_dump()`.
- **#13** `sv/dynamics.py`: `RandomWalk` / `AR1` `build_latent_path` use `"pt.TensorVariable"` forward refs instead of `Any`.
- **#14** `results.py`: delete `VARResultBase.__repr__` override — Pydantic's default repr is already compact thanks to `Field(repr=False)` on `idata`.
- **#15** `src/impulso/**/*.py`: docstring sweep — double backticks (RST) → single backticks (Markdown / mkdocstrings); no `:meth:` / `:class:` cross-refs anywhere.
- **#16** `identified.py`: delete `forecast_error_variance_decomposition`; `fevd` is the canonical name. Tutorial `.qmd` + `.md` updated.
- `CLAUDE.md`: codify the docstring convention.
- `pyproject.toml` + `uv.lock`: bump `0.0.5 → 0.0.6`.

Closes #78. Final layer of the 4-PR audit stack, stacked on top of #77 (PR3).

## Breaking changes (pre-v0.1)

- `IdentifiedVAR.forecast_error_variance_decomposition` removed. Migrate to `IdentifiedVAR.fevd` (same signature). Long name was always an alias.

## Test plan

- [x] `make test` — 281/281 pass.
- [x] `make check` — ruff + ty clean; `uv lock --locked` matches `pyproject.toml`.
- [x] `make docs-render-ci` — clean, exit 0.
- [x] `grep -r forecast_error_variance_decomposition src/ tests/ docs/` — no matches (gate 3).
- [x] `grep -rn ':meth:\|:class:' src/` — no matches (gate 4).
- [x] `grep -rn '\`\`' src/` — no matches (gate 5).
- [x] `SVData._MIN_OBS` not in `model_fields` (gate 6).
- [x] `FittedVAR(...).model_dump()` does not include `has_exog` (gate 7).
- [x] `repr(ForecastResult(...))` shows `steps=4, var_names=['a', 'b']`, no `idata` (gate 8).
- [x] `pyproject.toml` shows `version = "0.0.6"` (gate 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)