### PR TITLE
feat: type-safe is_time_varying flag + at='all' guards (closes #74)

### DIFF
--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -73,7 +73,7 @@ class FittedVAR(ImpulsoBaseModel):
             Posterior draws of Σ (or Σ_t for SV) computed from the
             volatility adapter's Cholesky factor as ``L @ L.T``.
         """
-        if getattr(self.volatility, "name", None) == "sv":
+        if self.volatility.is_time_varying:
             T = self.data.endog.shape[0] - self.n_lags
             L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
             # Σ_t = L_t @ L_t.T, broadcast over (chains, draws, T).

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -133,12 +133,27 @@ class IdentifiedVAR(ImpulsoBaseModel):
 
         Returns:
             IRFResult with IRF posterior draws.
+
+        Raises:
+            ValueError: When ``at='all'`` is requested for a non-time-varying
+                volatility process (``Constant``). Under constant Σ the per-t
+                IRF is identical for every t, so the time axis carries no
+                information — use ``at=None`` (default) or ``at='last'``.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
         n_vars = B_draws.shape[2]
         Phi_arr = self._ma_coefficients(B_draws, n_vars, self.n_lags, horizon)
 
         if at == "all":
+            if not self.volatility.is_time_varying:
+                raise ValueError(
+                    "impulse_response(at='all') is only meaningful for "
+                    "time-varying volatility (Σ_t evolves over t). The "
+                    f"current volatility process ({type(self.volatility).__name__}) "
+                    "is time-invariant, so the per-t IRF would be identical at "
+                    "every t. Use at=None (default) or at='last' for a "
+                    "single-time IRF instead."
+                )
             # Per-t IRFs. T = effective in-sample length after lag trimming.
             T = self.data.endog.shape[0] - self.n_lags
             L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
@@ -200,12 +215,27 @@ class IdentifiedVAR(ImpulsoBaseModel):
 
         Returns:
             FEVDResult with FEVD posterior draws.
+
+        Raises:
+            ValueError: When ``at='all'`` is requested for a non-time-varying
+                volatility process (``Constant``). Under constant Σ the per-t
+                FEVD is identical for every t, so the time axis carries no
+                information — use ``at=None`` (default) or ``at='last'``.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
         n_vars = B_draws.shape[2]
         Phi_arr = self._ma_coefficients(B_draws, n_vars, self.n_lags, horizon)
 
         if at == "all":
+            if not self.volatility.is_time_varying:
+                raise ValueError(
+                    "fevd(at='all') is only meaningful for time-varying "
+                    "volatility (Σ_t evolves over t). The current volatility "
+                    f"process ({type(self.volatility).__name__}) is "
+                    "time-invariant, so the per-t FEVD would be identical at "
+                    "every t. Use at=None (default) or at='last' for a "
+                    "single-time FEVD instead."
+                )
             # Per-t FEVDs. T = effective in-sample length after lag trimming.
             T = self.data.endog.shape[0] - self.n_lags
             L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
@@ -323,15 +353,14 @@ class IdentifiedVAR(ImpulsoBaseModel):
         y_obs = y[n_lags:]  # (T-p, n)
         resid = y_obs[np.newaxis, np.newaxis, :, :] - y_hat
 
-        # Build a per-t structural shock matrix path P_path: (C, D, T_eff, n, n).
-        if at is None or at == "all":
-            # Per-t identification — correct for SV; broadcasts to constant L
-            # for Constant volatility, matching the legacy single-P behaviour.
-            L_path = self.volatility.cholesky_path(self.idata.posterior, T=T_eff)
-            P_path = self._identify_per_t(L_path)
-        else:
-            # Single-L hypothetical applied across all t.
-            if getattr(self.volatility, "name", None) == "sv":
+        # Two regimes for the structural-shock matrix:
+        #   1. Time-invariant Σ (Constant adapter), or SV with an explicit
+        #      single-L hypothetical (at=int / 'last'): identify once,
+        #      invert once, broadcast across t.
+        #   2. Time-varying Σ with default at=None/'all': per-t identify and
+        #      invert (the standard SV structural decomposition).
+        if not self.volatility.is_time_varying or at not in (None, "all"):
+            if self.volatility.is_time_varying:
                 warnings.warn(
                     f"historical_decomposition(at={at!r}) under stochastic "
                     "volatility applies a single L across every in-sample "
@@ -342,18 +371,22 @@ class IdentifiedVAR(ImpulsoBaseModel):
                     UserWarning,
                     stacklevel=2,
                 )
-            t = self._resolve_at(at)
+            # For Constant the time index is irrelevant; for SV+explicit-at it
+            # is the resolved single time slice. Either way: one identify, one
+            # invert, then broadcast over t via einsum / np.newaxis.
+            t = self._resolve_at(at) if self.volatility.is_time_varying else None
             L = self.volatility.cholesky_at(self.idata.posterior, t=t)
-            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)
-            # Broadcast P across the time axis.
-            P_path = np.broadcast_to(P[:, :, np.newaxis, :, :], (*P.shape[:2], T_eff, *P.shape[2:])).copy()
-
-        # Structural residuals: P_t^{-1} @ resid_t  -> (C, D, T-p, n)
-        P_inv_path = np.linalg.inv(P_path)  # (C, D, T_eff, n, n)
-        structural_resid = np.einsum("cdtij,cdtj->cdti", P_inv_path, resid)
-
-        # hd[..., t, resp, shock] = P_t[resp, shock] * structural_resid[t, shock]
-        hd = P_path * structural_resid[:, :, :, np.newaxis, :]
+            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)  # (C, D, n, n)
+            P_inv = np.linalg.inv(P)  # (C, D, n, n)
+            structural_resid = np.einsum("cdij,cdtj->cdti", P_inv, resid)  # (C, D, T_eff, n)
+            hd = P[:, :, np.newaxis, :, :] * structural_resid[:, :, :, np.newaxis, :]
+        else:
+            # SV per-t structural decomposition.
+            L_path = self.volatility.cholesky_path(self.idata.posterior, T=T_eff)
+            P_path = self._identify_per_t(L_path)  # (C, D, T_eff, n, n)
+            P_inv_path = np.linalg.inv(P_path)
+            structural_resid = np.einsum("cdtij,cdtj->cdti", P_inv_path, resid)
+            hd = P_path * structural_resid[:, :, :, np.newaxis, :]
 
         if cumulative:
             hd = np.cumsum(hd, axis=2)

--- a/src/impulso/protocols.py
+++ b/src/impulso/protocols.py
@@ -89,6 +89,11 @@ class VolatilityProcess(Protocol):
     """
 
     name: str
+    is_time_varying: bool
+    """Whether Σ_t evolves over time. ``False`` for homoscedastic adapters
+    (``Constant``); ``True`` for stochastic-volatility adapters. Drives
+    branching in `FittedVAR.sigma` and `IdentifiedVAR.historical_decomposition`
+    so neither has to string-sniff the adapter ``name``."""
 
     def build_pymc_latent(
         self,

--- a/src/impulso/sv/dynamics.py
+++ b/src/impulso/sv/dynamics.py
@@ -1,6 +1,6 @@
 """Log-volatility dynamics for univariate stochastic volatility models."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import xarray as xr
@@ -57,7 +57,7 @@ class RandomWalk(ImpulsoModel):
     """Random-walk log-volatility dynamics (Primiceri 2005)."""
 
     name: Literal["random_walk"] = "random_walk"
-    has_explicit_level: ClassVar[bool] = False
+    has_explicit_level: bool = False
 
     def build_latent_path(self, prior_params: dict, T: int, sigma_eta: Any, name_prefix: str = "") -> Any:
         import pymc as pm
@@ -88,7 +88,7 @@ class AR1(ImpulsoModel):
     """AR(1) log-volatility dynamics (Kim-Shephard-Chib 1998)."""
 
     name: Literal["ar1"] = "ar1"
-    has_explicit_level: ClassVar[bool] = True
+    has_explicit_level: bool = True
 
     def build_latent_path(self, prior_params: dict, T: int, sigma_eta: Any, name_prefix: str = "") -> Any:
         import pymc as pm

--- a/src/impulso/sv/spec.py
+++ b/src/impulso/sv/spec.py
@@ -27,6 +27,7 @@ class StochasticVolatility(ImpulsoBaseModel):
     Attributes:
         name: Discriminator key for the volatility-process registry
             (always ``"sv"``).
+        is_time_varying: Always ``True`` — Σ_t evolves over t.
         dynamics: Log-volatility dynamics. String shorthand (``"random_walk"``
             or ``"ar1"``) or an explicit ``SVDynamics`` instance (e.g.
             ``RandomWalk()``, ``AR1()``).
@@ -34,6 +35,7 @@ class StochasticVolatility(ImpulsoBaseModel):
     """
 
     name: Literal["sv"] = "sv"
+    is_time_varying: bool = True
     dynamics: Literal["random_walk", "ar1"] | SVDynamics = "random_walk"
     prior: Literal["default"] | SVPrior = "default"
 

--- a/src/impulso/volatility.py
+++ b/src/impulso/volatility.py
@@ -38,11 +38,13 @@ class Constant(ImpulsoModel):
 
     Attributes:
         name: Discriminator key for the registry (always ``"constant"``).
+        is_time_varying: Always ``False`` — Σ is shared across t.
         sigma_sd_beta: HalfCauchy scale on diagonal SDs.
         tril_offdiag_sigma: Normal SD on off-diagonal correlation factors.
     """
 
     name: Literal["constant"] = "constant"
+    is_time_varying: bool = False
 
     sigma_sd_beta: float = Field(2.5, gt=0)
     tril_offdiag_sigma: float = Field(0.5, gt=0)

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -268,46 +268,16 @@ class TestImpulseResponseAt:
             irf_at_none.idata.posterior_predictive["irf"].values,
         )
 
-    def test_at_all_returns_time_axis(self, synthetic_idata_2v, var_data_2v):
-        """at='all' adds a time dim of correct length to the result."""
+    def test_at_all_raises_for_constant_volatility(self, synthetic_idata_2v, var_data_2v):
+        """``at='all'`` is meaningless under constant Σ — the per-t IRF would
+        be identical at every t. Refuse with a ``ValueError`` pointing the
+        caller at ``at=None`` / ``at='last'``.
+        """
         fitted = _fitted_from_synthetic(synthetic_idata_2v, var_data_2v)
         identified = fitted.set_identification_strategy(Cholesky(ordering=fitted.var_names))
 
-        horizon = 5
-        irf_all = identified.impulse_response(horizon=horizon, at="all")
-        irf = irf_all.idata.posterior_predictive["irf"]
-        assert "time" in irf.dims
-        T_eff = var_data_2v.endog.shape[0] - 1  # lags=1
-        n_chains = fitted.idata.posterior.sizes["chain"]
-        n_draws = fitted.idata.posterior.sizes["draw"]
-        n_vars = len(fitted.var_names)
-        assert irf.sizes["time"] == T_eff
-        assert irf.shape == (n_chains, n_draws, T_eff, horizon + 1, n_vars, n_vars)
-        # For Constant, every time slice must be identical.
-        np.testing.assert_array_equal(irf.values[:, :, 0, :, :, :], irf.values[:, :, -1, :, :, :])
-
-    def test_at_all_with_named_index_does_not_collide(self, synthetic_idata_2v):
-        """Regression: VARData built from a DataFrame whose index has a name
-        (e.g. 'date') used to crash at='all' because xarray inferred the
-        coord's dim from the DatetimeIndex name, conflicting with the
-        declared 'time' dim."""
-        import pandas as pd
-
-        from impulso.data import VARData
-
-        T, n = 30, 2
-        rng = np.random.default_rng(0)
-        y = rng.standard_normal((T, n)) * 0.1
-        named_index = pd.date_range("2000-01-01", periods=T, freq="QS", name="date")
-        var_data_named = VARData(endog=y, endog_names=["y1", "y2"], index=named_index)
-
-        fitted = _fitted_from_synthetic(synthetic_idata_2v, var_data_named)
-        identified = fitted.set_identification_strategy(Cholesky(ordering=fitted.var_names))
-
-        irf_all = identified.impulse_response(horizon=3, at="all")
-        irf = irf_all.idata.posterior_predictive["irf"]
-        assert "time" in irf.dims
-        assert "date" not in irf.dims
+        with pytest.raises(ValueError, match=r"at=None.*at='last'"):
+            identified.impulse_response(horizon=5, at="all")
 
 
 class TestFEVDAt:
@@ -322,58 +292,34 @@ class TestFEVDAt:
             fevd_at_int.idata.posterior_predictive["fevd"].values,
         )
 
-    def test_at_all_returns_time_axis(self, synthetic_idata_2v, var_data_2v):
-        """at='all' adds a time dim of correct length to the result."""
+    def test_at_all_raises_for_constant_volatility(self, synthetic_idata_2v, var_data_2v):
+        """``at='all'`` is meaningless under constant Σ — same reasoning as IRF."""
         fitted = _fitted_from_synthetic(synthetic_idata_2v, var_data_2v)
         identified = fitted.set_identification_strategy(Cholesky(ordering=fitted.var_names))
 
-        horizon = 5
-        fevd_all = identified.fevd(horizon=horizon, at="all")
-        fevd = fevd_all.idata.posterior_predictive["fevd"]
-        assert "time" in fevd.dims
-        T_eff = var_data_2v.endog.shape[0] - 1  # lags=1
-        n_chains = fitted.idata.posterior.sizes["chain"]
-        n_draws = fitted.idata.posterior.sizes["draw"]
-        n_vars = len(fitted.var_names)
-        assert fevd.sizes["time"] == T_eff
-        assert fevd.shape == (n_chains, n_draws, T_eff, horizon + 1, n_vars, n_vars)
-        # For Constant, every time slice must be identical.
-        np.testing.assert_array_equal(fevd.values[:, :, 0, :, :, :], fevd.values[:, :, -1, :, :, :])
+        with pytest.raises(ValueError, match=r"at=None.*at='last'"):
+            identified.fevd(horizon=5, at="all")
 
-    def test_at_all_with_named_index_does_not_collide(self, synthetic_idata_2v):
-        """Regression: same as the IRF test above — named DatetimeIndex used to
-        crash at='all' for FEVD as well."""
-        import pandas as pd
-
-        from impulso.data import VARData
-
-        T, n = 30, 2
+    def test_median_raises_for_time_dim_fevd(self):
+        """``FEVDResult.median()/hdi()/to_dataframe()`` must refuse FEVDs that
+        carry a ``time`` dim (only reachable via time-varying volatility now
+        that constant + ``at='all'`` raises at the call site)."""
         rng = np.random.default_rng(0)
-        y = rng.standard_normal((T, n)) * 0.1
-        named_index = pd.date_range("2000-01-01", periods=T, freq="QS", name="date")
-        var_data_named = VARData(endog=y, endog_names=["y1", "y2"], index=named_index)
-
-        fitted = _fitted_from_synthetic(synthetic_idata_2v, var_data_named)
-        identified = fitted.set_identification_strategy(Cholesky(ordering=fitted.var_names))
-
-        fevd_all = identified.fevd(horizon=3, at="all")
-        fevd = fevd_all.idata.posterior_predictive["fevd"]
-        assert "time" in fevd.dims
-        assert "date" not in fevd.dims
-
-    def test_median_raises_for_at_all(self, synthetic_identified_idata_2v, var_data_2v):
-        """median()/hdi()/to_dataframe() must refuse FEVDs with a time dim."""
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
+        T_eff, horizon = 5, 4
+        data = rng.uniform(size=(2, 10, T_eff, horizon + 1, 2, 2))
+        fevd_da = xr.DataArray(
+            data,
+            dims=["chain", "draw", "time", "horizon", "response", "shock"],
+            coords={
+                "response": ["y1", "y2"],
+                "shock": ["y1", "y2"],
+                "horizon": np.arange(horizon + 1),
+            },
+            name="fevd",
         )
-        fevd_all = identified.fevd(horizon=5, at="all")
+        idata = az.InferenceData(posterior_predictive=xr.Dataset({"fevd": fevd_da}))
+        fevd_all = FEVDResult.model_construct(idata=idata, horizon=horizon, var_names=["y1", "y2"])
+
         with pytest.raises(NotImplementedError, match="time-varying FEVDs"):
             fevd_all.median()
         with pytest.raises(NotImplementedError, match="time-varying FEVDs"):
@@ -501,6 +447,7 @@ class TestHistoricalDecompositionAt:
 
         class _FakeSV:
             name = "sv"
+            is_time_varying = True
 
             def build_pymc_latent(self, n_vars, T):  # pragma: no cover
                 raise NotImplementedError
@@ -549,6 +496,7 @@ class TestHistoricalDecompositionAt:
 
         class _FakeSV:
             name = "sv"
+            is_time_varying = True
 
             def build_pymc_latent(self, n_vars, T):  # pragma: no cover
                 raise NotImplementedError

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -187,6 +187,7 @@ class TestVarPassesResidualsToVolatility:
             and returns a trivial constant L so the model still builds."""
 
             name = "capturing"
+            is_time_varying = False
 
             def build_pymc_latent(self, n_vars, T, data=None):
                 captured["n_vars"] = n_vars

--- a/tests/test_sv_spec.py
+++ b/tests/test_sv_spec.py
@@ -171,6 +171,14 @@ class TestHasExplicitLevel:
 
         assert AR1().has_explicit_level is True
 
+    def test_has_explicit_level_settable_per_instance(self):
+        # Plain instance field (not ClassVar), so future MSV-style adapters can
+        # override per-instance at construction time.
+        from impulso.sv.dynamics import AR1, RandomWalk
+
+        assert RandomWalk(has_explicit_level=True).has_explicit_level is True
+        assert AR1(has_explicit_level=False).has_explicit_level is False
+
 
 class TestStochasticVolatilityIsVolatilityProcess:
     def test_satisfies_protocol(self):
@@ -186,6 +194,16 @@ class TestStochasticVolatilityIsVolatilityProcess:
         from impulso.sv.spec import StochasticVolatility
 
         assert StochasticVolatility().name == "sv"
+
+    def test_is_time_varying_true(self):
+        from impulso.sv.spec import StochasticVolatility
+
+        assert StochasticVolatility().is_time_varying is True
+
+    def test_is_time_varying_settable_per_instance(self):
+        from impulso.sv.spec import StochasticVolatility
+
+        assert StochasticVolatility(is_time_varying=False).is_time_varying is False
 
     def test_name_is_frozen(self):
         from pydantic import ValidationError

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -17,6 +17,14 @@ class TestConstantAdapter:
     def test_constant_name(self):
         assert Constant().name == "constant"
 
+    def test_constant_is_time_varying_false(self):
+        assert Constant().is_time_varying is False
+
+    def test_is_time_varying_settable_per_instance(self):
+        # Plain instance field (not ClassVar), so a subclass or wrapper can
+        # override at construction time.
+        assert Constant(is_time_varying=True).is_time_varying is True
+
     def test_constant_is_frozen(self):
         from pydantic import ValidationError
 


### PR DESCRIPTION
Re-opened against `main` after PR #75 was auto-closed when its base
branch (`audit/01-labelled-results`) was deleted by the squash-merge of
PR #73. Same diff, rebased onto current `main`.

## Summary

- Replace `getattr(self.volatility, "name", None) == "sv"` string sniffing with a declarative `VolatilityProcess.is_time_varying: bool` flag (Protocol + `Constant=False` + `StochasticVolatility=True`).
- `at='all'` on `impulse_response` / `fevd` now raises `ValueError` for constant Σ (the per-t result would be identical at every t — message points at `at=None` / `at='last'`).
- `historical_decomposition` short-circuits per-t identify + invert under constant volatility — identify once, invert once, broadcast across the time axis via `np.newaxis` / einsum (audit #6). SV per-t structural path unchanged.
- Drop `ClassVar` on `SVDynamics.has_explicit_level` (RandomWalk / AR1) so future MSV-style adapters can override per-instance (audit #7).

Closes #74. Supersedes #75 (closed). Second of four stacked PRs from `plans/2026-05-18-audit-cleanup-plan.md`.

## Breaking changes (pre-v0.1)

- `IdentifiedVAR.impulse_response(at='all')` and `IdentifiedVAR.fevd(at='all')` now raise `ValueError` for `Constant` volatility. Migration: drop the kwarg, or use `at='last'`.

## Test plan

- [x] `make check` clean after rebase.
- [x] No content changes vs the original PR #75; only the base was rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)