### PR TITLE
refactor: rank-agnostic sigma_from_cholesky + single Clark reconstruction home (closes #89)

### DIFF
--- a/src/impulso/_linalg.py
+++ b/src/impulso/_linalg.py
@@ -1,0 +1,26 @@
+"""Linear-algebra helpers shared across the Impulso pipeline.
+
+These are rank-agnostic utilities that do not vary across adapters
+and therefore live outside the ``VolatilityProcess`` seam.
+"""
+
+import numpy as np
+
+
+def sigma_from_cholesky(L: np.ndarray) -> np.ndarray:
+    """Reconstruct the covariance matrix from its lower-triangular Cholesky factor.
+
+    Computes ``Sigma = L @ L.T`` over arbitrary leading batch dimensions
+    using a single ellipsis einsum.
+
+    Args:
+        L: Lower-triangular Cholesky factor.  The last two dimensions are
+            ``(n, n)``; all preceding dimensions are batch axes.  Common
+            shapes include ``(chains, draws, n, n)`` (constant volatility)
+            and ``(chains, draws, T, n, n)`` (time-varying volatility).
+
+    Returns:
+        Symmetric positive-(semi)definite covariance matrix with the same
+        shape as *L*.
+    """
+    return np.einsum("...ij,...kj->...ik", L, L)

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -7,6 +7,7 @@ import numpy as np
 from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
+from impulso._linalg import sigma_from_cholesky
 from impulso.data import VARData
 from impulso.protocols import IdentificationScheme, VolatilityProcess
 
@@ -75,11 +76,9 @@ class FittedVAR(ImpulsoBaseModel):
         if self.volatility.is_time_varying:
             T = self.data.endog.shape[0] - self.n_lags
             L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
-            # Σ_t = L_t @ L_t.T, broadcast over (chains, draws, T).
-            return np.einsum("cdtij,cdtkj->cdtik", L_path, L_path)
+            return sigma_from_cholesky(L_path)
         L = self.volatility.cholesky_at(self.idata.posterior, t=None)
-        # Σ = L @ L.T, broadcast over (chains, draws).
-        return np.einsum("cdij,cdkj->cdik", L, L)
+        return sigma_from_cholesky(L)
 
     def forecast(
         self,

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -5,6 +5,7 @@ import xarray as xr
 from pydantic import Field, PrivateAttr
 
 from impulso._base import ImpulsoModel
+from impulso._linalg import sigma_from_cholesky
 from impulso._ma import compute_ma_phi
 
 
@@ -49,7 +50,7 @@ class Cholesky(ImpulsoModel):
             return L
 
         # Reordering: reconstruct Sigma, permute, re-decompose.
-        sigma = np.einsum("cdij,cdkj->cdik", L, L)
+        sigma = sigma_from_cholesky(L)
         perm = [var_names.index(v) for v in self.ordering]
         ix0, ix1 = np.ix_(perm, perm)
         sigma_ordered = sigma[:, :, ix0, ix1]

--- a/src/impulso/sv/spec.py
+++ b/src/impulso/sv/spec.py
@@ -204,6 +204,30 @@ class StochasticVolatility(ImpulsoBaseModel):
         # with renamed keys before calling forecast_log_vol.
         return L
 
+    @staticmethod
+    def _clark_reconstruct(h: np.ndarray, R_chol: np.ndarray) -> np.ndarray:
+        """Clark reconstruction: L = diag(exp(h / 2)) @ R_chol.
+
+        Private NumPy home for the per-variable-SD-times-mixing-factor
+        computation shared by ``cholesky_at``, ``cholesky_path``, and
+        ``forecast_cholesky_path``.
+
+        Args:
+            h: Log-volatility, shape ``(..., n_vars)`` where ``...`` is
+                any leading batch dimensions (e.g. ``(C, D)`` for a single
+                time slice or ``(C, D, T)`` for a full path).
+            R_chol: Unit-diagonal lower-triangular mixing factor, shape
+                ``(C, D, n_vars, n_vars)``.
+
+        Returns:
+            Cholesky factor ``L`` with shape ``(..., n_vars, n_vars)``.
+        """
+        # Insert singleton axes between R_chol's batch dims and its (n, n)
+        # trailing dims so it broadcasts against h's extra leading axes.
+        extra = h.ndim - (R_chol.ndim - 1)
+        R = R_chol.shape[:-2] + (1,) * extra + R_chol.shape[-2:]
+        return np.exp(h / 2)[..., :, np.newaxis] * R_chol.reshape(R)
+
     def cholesky_at(self, posterior: "xr.Dataset", t: int | None) -> np.ndarray:
         """Return L_t = diag(exp(h_t / 2)) @ R_chol for the requested t.
 
@@ -224,8 +248,7 @@ class StochasticVolatility(ImpulsoBaseModel):
         if not (0 <= t < h.shape[2]):
             raise ValueError(f"t={t} is out of range for T={h.shape[2]}")
 
-        sigma_t = np.exp(h[:, :, t, :] / 2)  # (C, D, n_vars)
-        return sigma_t[:, :, :, None] * R_chol  # (C, D, n_vars, n_vars)
+        return self._clark_reconstruct(h[:, :, t, :], R_chol)
 
     def cholesky_path(self, posterior: "xr.Dataset", T: int) -> np.ndarray:
         """Return the full L_t path for t in 0..T-1.
@@ -244,8 +267,7 @@ class StochasticVolatility(ImpulsoBaseModel):
         if h.shape[2] != T:
             raise ValueError(f"posterior['h'] has T={h.shape[2]}, requested T={T}")
 
-        sigma_t = np.exp(h / 2)  # (C, D, T, n_vars)
-        return sigma_t[:, :, :, :, None] * R_chol[:, :, None, :, :]  # (C, D, T, n_vars, n_vars)
+        return self._clark_reconstruct(h, R_chol)
 
     def forecast_cholesky_path(
         self,
@@ -297,6 +319,4 @@ class StochasticVolatility(ImpulsoBaseModel):
                     slice_posterior[extra_var] = (("chain", "draw"), posterior[key].values)
             h_forecast[:, :, :, i] = dynamics.forecast_log_vol(slice_posterior, steps, rng)
 
-        # Combine: L_t = diag(exp(h_t / 2)) @ R_chol for each forecast step.
-        sigma_t = np.exp(h_forecast / 2)  # (C, D, steps, n_vars)
-        return sigma_t[:, :, :, :, None] * R_chol[:, :, None, :, :]
+        return self._clark_reconstruct(h_forecast, R_chol)

--- a/tests/test_sigma_from_cholesky.py
+++ b/tests/test_sigma_from_cholesky.py
@@ -1,0 +1,182 @@
+"""Tests for sigma_from_cholesky helper and Clark reconstruction home.
+
+Equality pins: these tests lock down the numerical output of the
+existing per-site einsums and Clark reconstructions so the refactor
+to the shared helpers is provably behaviour-preserving.
+
+Testing rule: public interfaces only — no model_construct, no
+reaching through .idata internals.
+"""
+
+import numpy as np
+
+
+class TestSigmaFromCholesky:
+    """sigma_from_cholesky(L) = L @ L.T over leading batch dims."""
+
+    def test_4d_matches_einsum(self, rng):
+        """4-D input (chains, draws, n, n) matches the hand-written einsum."""
+        from impulso._linalg import sigma_from_cholesky
+
+        L = rng.standard_normal((3, 50, 2, 2))
+        L = np.tril(L)
+        L[:, :, range(2), range(2)] = np.abs(L[:, :, range(2), range(2)]) + 0.1
+
+        result = sigma_from_cholesky(L)
+        expected = np.einsum("cdij,cdkj->cdik", L, L)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    def test_5d_matches_einsum(self, rng):
+        """5-D input (chains, draws, T, n, n) matches the hand-written einsum."""
+        from impulso._linalg import sigma_from_cholesky
+
+        L = rng.standard_normal((2, 20, 10, 3, 3))
+        L = np.tril(L)
+        L[:, :, :, range(3), range(3)] = np.abs(L[:, :, :, range(3), range(3)]) + 0.1
+
+        result = sigma_from_cholesky(L)
+        expected = np.einsum("cdtij,cdtkj->cdtik", L, L)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    def test_output_is_symmetric(self, rng):
+        """Σ = L @ L.T is always symmetric."""
+        from impulso._linalg import sigma_from_cholesky
+
+        L = np.tril(rng.standard_normal((2, 10, 4, 4)))
+        sigma = sigma_from_cholesky(L)
+        np.testing.assert_allclose(sigma, np.swapaxes(sigma, -1, -2), atol=1e-12)
+
+    def test_output_is_positive_definite(self, rng):
+        """Σ = L @ L.T is PD when L has positive diagonal."""
+        from impulso._linalg import sigma_from_cholesky
+
+        L = np.tril(rng.standard_normal((2, 10, 3, 3)))
+        L[:, :, range(3), range(3)] = np.abs(L[:, :, range(3), range(3)]) + 0.5
+        sigma = sigma_from_cholesky(L)
+        eigvals = np.linalg.eigvalsh(sigma)
+        assert np.all(eigvals > 0)
+
+    def test_identity_cholesky_gives_identity(self):
+        """L = I → Σ = I."""
+        from impulso._linalg import sigma_from_cholesky
+
+        L = np.eye(3)
+        result = sigma_from_cholesky(L)
+        np.testing.assert_allclose(result, np.eye(3), atol=1e-12)
+
+
+class TestClarkReconstructionSingleHome:
+    """All three Clark callers (cholesky_at, cholesky_path,
+    forecast_cholesky_path) produce lower-triangular L_t consistent
+    with each other, after the refactor to the shared private helper.
+
+    Equality pins compare against manual ``exp(h/2) * R_chol``
+    computed from the fixture posterior, so a wrong shared helper
+    cannot hide behind all three callers sharing the same bug.
+    """
+
+    def test_cholesky_at_equals_manual_exp_h_half_R_chol(self, synthetic_sv_idata_2v):
+        """Pin: cholesky_at(t) == diag(exp(h_t/2)) @ R_chol, computed manually."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        posterior = synthetic_sv_idata_2v.posterior
+        h = posterior["h"].values  # (2, 50, 20, 2)
+        R_chol = posterior["R_chol"].values  # (2, 50, 2, 2)
+
+        for t in [0, 7, 19]:
+            L_t = sv.cholesky_at(posterior, t=t)
+            expected = np.exp(h[:, :, t, :] / 2)[:, :, :, None] * R_chol
+            np.testing.assert_allclose(L_t, expected, rtol=1e-12, err_msg=f"cholesky_at({t}) != manual")
+
+    def test_cholesky_path_equals_manual_exp_h_half_R_chol(self, synthetic_sv_idata_2v):
+        """Pin: cholesky_path == diag(exp(h/2)) @ R_chol broadcast over T."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        posterior = synthetic_sv_idata_2v.posterior
+        h = posterior["h"].values  # (2, 50, 20, 2)
+        R_chol = posterior["R_chol"].values  # (2, 50, 2, 2)
+
+        path = sv.cholesky_path(posterior, T=20)
+        sigma_t = np.exp(h / 2)  # (2, 50, 20, 2)
+        expected = sigma_t[:, :, :, :, None] * R_chol[:, :, None, :, :]
+        np.testing.assert_allclose(path, expected, rtol=1e-12)
+
+    def test_cholesky_at_is_lower_triangular(self, synthetic_sv_idata_2v):
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        for t in [0, 5, 19]:
+            L_t = sv.cholesky_at(synthetic_sv_idata_2v.posterior, t=t)
+            assert L_t.shape == (2, 50, 2, 2)
+            assert np.allclose(np.triu(L_t, k=1), 0.0)
+
+    def test_cholesky_path_slices_match_cholesky_at(self, synthetic_sv_idata_2v):
+        """Each time slice of cholesky_path must equal cholesky_at(t)."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        path = sv.cholesky_path(synthetic_sv_idata_2v.posterior, T=20)
+        assert path.shape == (2, 50, 20, 2, 2)
+
+        for t in range(20):
+            L_at = sv.cholesky_at(synthetic_sv_idata_2v.posterior, t=t)
+            np.testing.assert_allclose(path[:, :, t, :, :], L_at, rtol=1e-12)
+
+    def test_cholesky_path_is_lower_triangular_per_slice(self, synthetic_sv_idata_2v):
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        path = sv.cholesky_path(synthetic_sv_idata_2v.posterior, T=20)
+        for t in range(20):
+            assert np.allclose(np.triu(path[:, :, t, :, :], k=1), 0.0)
+
+    def test_forecast_cholesky_path_is_lower_triangular(self, synthetic_sv_idata_2v):
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        rng = np.random.default_rng(99)
+        path = sv.forecast_cholesky_path(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+        )
+        assert path.shape == (2, 50, 5, 2, 2)
+        for s in range(5):
+            assert np.allclose(np.triu(path[:, :, s, :, :], k=1), 0.0)
+
+    def test_forecast_cholesky_path_extends_beyond_sample(self, synthetic_sv_idata_2v):
+        """Forecast L_t values must differ from in-sample last-period L_t
+        (with high probability under RW dynamics), confirming the Clark
+        reconstruction is called on extrapolated h, not a broadcast."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        rng = np.random.default_rng(99)
+        forecast_path = sv.forecast_cholesky_path(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+        )
+        last_in_sample = sv.cholesky_at(synthetic_sv_idata_2v.posterior, t=None)
+        # At least one forecast step should differ from the last in-sample slice.
+        differs = [not np.allclose(forecast_path[:, :, s, :, :], last_in_sample, atol=1e-10) for s in range(5)]
+        assert any(differs), "Forecast path is identical to last in-sample — Clark not called on extrapolated h"
+
+    def test_forecast_cholesky_path_reproducible_with_rng(self, synthetic_sv_idata_2v):
+        """Same rng seed → identical forecast path."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        path_a = sv.forecast_cholesky_path(
+            synthetic_sv_idata_2v.posterior,
+            steps=3,
+            rng=np.random.default_rng(42),
+        )
+        path_b = sv.forecast_cholesky_path(
+            synthetic_sv_idata_2v.posterior,
+            steps=3,
+            rng=np.random.default_rng(42),
+        )
+        np.testing.assert_array_equal(path_a, path_b)


### PR DESCRIPTION
## What

Behaviour-preserving refactor that gives two scattered reconstructions single homes:

1. **`sigma_from_cholesky(L)`** — rank-agnostic `np.einsum("...ij,...kj->...ik", L, L)` helper in new `_linalg.py`, replacing hand-written einsums in `FittedVAR.sigma()` and `Cholesky.identify()`.
2. **`StochasticVolatility._clark_reconstruct(h, R_chol)`** — private NumPy helper for `diag(exp(h/2)) @ R_chol`, replacing 3 inline sites in `cholesky_at`, `cholesky_path`, and `forecast_cholesky_path`. The PyTensor build in `build_pymc_latent` keeps its own symbolic expression (inherent split).

## Why

- `Σ = L @ L.T` was hand-written in 3 callers; `_clark_reconstruct` was written 4 times.
- Per ADR-0001, `sigma_from_cholesky` stays off the `VolatilityProcess` Protocol — squaring is invariant across adapters.

## Testing

- Equality pin tests on 4-D and 5-D `sigma_from_cholesky` inputs
- Manual `exp(h/2) * R_chol` equality pins for `cholesky_at` and `cholesky_path`
- `forecast_cholesky_path` consistency, lower-triangular, reproducibility
- All 272 fast tests pass, no regressions

Closes #89.