### PR TITLE
feat: prefix-aware forecast_log_vol (closes #90)

### DIFF
--- a/src/impulso/sv/dynamics.py
+++ b/src/impulso/sv/dynamics.py
@@ -48,8 +48,14 @@ class SVDynamics(Protocol):
         posterior: xr.Dataset,
         steps: int,
         rng: np.random.Generator,
+        name_prefix: str = "",
     ) -> np.ndarray:
-        """Draw posterior-predictive log-volatility paths, shape (chains, draws, steps)."""
+        """Draw posterior-predictive log-volatility paths, shape (chains, draws, steps).
+
+        ``name_prefix`` is prepended to every posterior key read (e.g.
+        ``name_prefix="v0_"`` reads ``v0_h``, ``v0_sigma_eta``, …).
+        Default empty prefix preserves the univariate naming.
+        """
         ...
 
 
@@ -79,9 +85,10 @@ class RandomWalk(ImpulsoModel):
         posterior: xr.Dataset,
         steps: int,
         rng: np.random.Generator,
+        name_prefix: str = "",
     ) -> np.ndarray:
-        h_draws = posterior["h"].values
-        sigma_eta_draws = posterior["sigma_eta"].values
+        h_draws = posterior[f"{name_prefix}h"].values
+        sigma_eta_draws = posterior[f"{name_prefix}sigma_eta"].values
         n_chains, n_draws, _ = h_draws.shape
         h_last = h_draws[:, :, -1]
 
@@ -130,11 +137,12 @@ class AR1(ImpulsoModel):
         posterior: xr.Dataset,
         steps: int,
         rng: np.random.Generator,
+        name_prefix: str = "",
     ) -> np.ndarray:
-        h_draws = posterior["h"].values
-        sigma_eta_draws = posterior["sigma_eta"].values
-        phi_draws = posterior["phi"].values
-        alpha_draws = posterior["alpha"].values
+        h_draws = posterior[f"{name_prefix}h"].values
+        sigma_eta_draws = posterior[f"{name_prefix}sigma_eta"].values
+        phi_draws = posterior[f"{name_prefix}phi"].values
+        alpha_draws = posterior[f"{name_prefix}alpha"].values
         n_chains, n_draws, _ = h_draws.shape
         h_prev = h_draws[:, :, -1].copy()
 

--- a/src/impulso/sv/spec.py
+++ b/src/impulso/sv/spec.py
@@ -253,18 +253,13 @@ class StochasticVolatility(ImpulsoBaseModel):
         steps: int,
         rng: np.random.Generator,
     ) -> np.ndarray:
-        """Forecast the per-t Cholesky factor for `steps` ahead.
+        """Forecast the per-t Cholesky factor for ``steps`` ahead.
 
         Each variable's log-vol is extrapolated independently using the
-        configured dynamics; the correlation Cholesky `R_chol` is held
-        constant (Clark-style assumption).
-
-        `SVDynamics.forecast_log_vol` reads bare posterior keys (`h`,
-        `sigma_eta`, and for AR(1) also `phi`/`alpha`), whereas the
-        multivariate-fit posterior stores per-variable hyperparameters
-        under prefixed names (`v{i}_sigma_eta`, ...). For each variable
-        `i` we build a small slice `Dataset` with renamed keys and
-        delegate the extrapolation to `dynamics.forecast_log_vol`.
+        configured dynamics with ``name_prefix=f"v{i}_"`` so the dynamics
+        reads ``{prefix}h``, ``{prefix}sigma_eta``, and its own
+        hyperparameters directly from the full posterior.  The correlation
+        Cholesky ``R_chol`` is held constant (Clark-style assumption).
 
         Args:
             posterior: Dataset with per-variable log-vol paths (`h`)
@@ -276,8 +271,6 @@ class StochasticVolatility(ImpulsoBaseModel):
         Returns:
             `(chains, draws, steps, n_vars, n_vars)`.
         """
-        import xarray as xr
-
         dynamics = self.resolved_dynamics
 
         h = posterior["h"].values  # (C, D, T, n_vars)
@@ -286,17 +279,13 @@ class StochasticVolatility(ImpulsoBaseModel):
 
         h_forecast = np.zeros((n_chains, n_draws, steps, n_vars))
         for i in range(n_vars):
-            slice_posterior = xr.Dataset({
-                "h": (("chain", "draw", "time"), h[:, :, :, i]),
-                "sigma_eta": (("chain", "draw"), posterior[f"v{i}_sigma_eta"].values),
-            })
-            # AR(1) also reads phi, alpha. For RW, only sigma_eta is needed.
-            for extra_var in ("phi", "alpha"):
-                key = f"v{i}_{extra_var}"
-                if key in posterior:
-                    slice_posterior[extra_var] = (("chain", "draw"), posterior[key].values)
-            h_forecast[:, :, :, i] = dynamics.forecast_log_vol(slice_posterior, steps, rng)
-
-        # Combine: L_t = diag(exp(h_t / 2)) @ R_chol for each forecast step.
-        sigma_t = np.exp(h_forecast / 2)  # (C, D, steps, n_vars)
+            h_forecast[:, :, :, i] = dynamics.forecast_log_vol(
+                posterior,
+                steps,
+                rng,
+                name_prefix=f"v{i}_",
+            )
+        # L_t = diag(exp(h_t / 2)) @ R_chol — ponytail: replaced by
+        # _clark_reconstruct once #89 merges.
+        sigma_t = np.exp(h_forecast / 2)
         return sigma_t[:, :, :, :, None] * R_chol[:, :, None, :, :]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,8 @@ def synthetic_sv_idata_2v():
     posterior = xr.Dataset({
         "h": (("chain", "draw", "time", "variable"), h),
         "R_chol": (("chain", "draw", "i", "j"), R_chol),
+        "v0_h": (("chain", "draw", "time"), h[:, :, :, 0]),
+        "v1_h": (("chain", "draw", "time"), h[:, :, :, 1]),
         "v0_mu": (("chain", "draw"), rng.standard_normal((n_chains, n_draws))),
         "v1_mu": (("chain", "draw"), rng.standard_normal((n_chains, n_draws))),
         "v0_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),

--- a/tests/test_prefix_forecast.py
+++ b/tests/test_prefix_forecast.py
@@ -1,0 +1,193 @@
+"""Tests for prefix-aware forecast_log_vol (issue #90).
+
+Pin tests: each dynamics forecasts correctly from a multivariate-shaped
+posterior with v{i}_* names, and per-variable results match the equivalent
+bare-name univariate call.
+"""
+
+import numpy as np
+import xarray as xr
+
+
+def _make_univariate_posterior(h_3d, sigma_eta):
+    """Build a minimal univariate-shaped posterior for bare-name calls."""
+    return xr.Dataset({
+        "h": (("chain", "draw", "time"), h_3d),
+        "sigma_eta": (("chain", "draw"), sigma_eta),
+    })
+
+
+def _make_univariate_ar1_posterior(h_3d, sigma_eta, phi, alpha):
+    """Build a minimal univariate AR(1) posterior for bare-name calls."""
+    return xr.Dataset({
+        "h": (("chain", "draw", "time"), h_3d),
+        "sigma_eta": (("chain", "draw"), sigma_eta),
+        "phi": (("chain", "draw"), phi),
+        "alpha": (("chain", "draw"), alpha),
+    })
+
+
+class TestRandomWalkPrefixAware:
+    """RandomWalk.forecast_log_vol reads {prefix}h and {prefix}sigma_eta."""
+
+    def test_accepts_name_prefix(self, synthetic_sv_idata_2v):
+        """forecast_log_vol must accept name_prefix kwarg."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        rng = np.random.default_rng(42)
+        # Should not raise — reads v0_h and v0_sigma_eta.
+        result = rw.forecast_log_vol(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+            name_prefix="v0_",
+        )
+        assert result.shape == (2, 50, 5)
+
+    def test_prefix_result_matches_bare_univariate(self, synthetic_sv_idata_2v):
+        """Calling with name_prefix='v0_' on the multivariate posterior
+        must produce the same result as calling bare on a univariate posterior
+        with the same h and sigma_eta values."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        posterior = synthetic_sv_idata_2v.posterior
+
+        # Bare univariate call with v0's data.
+        h_v0 = posterior["v0_h"].values  # (2, 50, 20)
+        sigma_eta_v0 = posterior["v0_sigma_eta"].values  # (2, 50)
+        uni_posterior = _make_univariate_posterior(h_v0, sigma_eta_v0)
+
+        rng_bare = np.random.default_rng(77)
+        rng_prefix = np.random.default_rng(77)
+
+        result_bare = rw.forecast_log_vol(uni_posterior, steps=5, rng=rng_bare)
+        result_prefix = rw.forecast_log_vol(
+            posterior,
+            steps=5,
+            rng=rng_prefix,
+            name_prefix="v0_",
+        )
+        np.testing.assert_array_equal(result_bare, result_prefix)
+
+    def test_different_prefixes_give_different_results(self, synthetic_sv_idata_2v):
+        """v0_ and v1_ have different sigma_eta, so forecasts must differ."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        rng = np.random.default_rng(42)
+
+        result_v0 = rw.forecast_log_vol(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+            name_prefix="v0_",
+        )
+        rng2 = np.random.default_rng(42)
+        result_v1 = rw.forecast_log_vol(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng2,
+            name_prefix="v1_",
+        )
+        # Different sigma_eta → different paths (with overwhelming probability).
+        assert not np.array_equal(result_v0, result_v1)
+
+    def test_default_empty_prefix_reads_bare_keys(self):
+        """Default name_prefix='' reads bare 'h' and 'sigma_eta'."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        rng = np.random.default_rng(0)
+        h = rng.standard_normal((1, 10, 15)) * 0.3 - 1.0
+        sigma_eta = np.abs(rng.standard_normal((1, 10))) * 0.1
+        posterior = _make_univariate_posterior(h, sigma_eta)
+
+        result = rw.forecast_log_vol(posterior, steps=3, rng=rng)
+        assert result.shape == (1, 10, 3)
+
+
+class TestAR1PrefixAware:
+    """AR1.forecast_log_vol reads {prefix}h, {prefix}sigma_eta, {prefix}phi, {prefix}alpha."""
+
+    @staticmethod
+    def _make_ar1_posterior_2v():
+        """Build a 2-variable multivariate AR(1) posterior with prefixed keys."""
+        rng = np.random.default_rng(99)
+        n_chains, n_draws, T, n_vars = 2, 50, 20, 2
+        h = rng.standard_normal((n_chains, n_draws, T, n_vars)) * 0.3 - 1.0
+        return xr.Dataset({
+            "h": (("chain", "draw", "time", "variable"), h),
+            "v0_h": (("chain", "draw", "time"), h[:, :, :, 0]),
+            "v1_h": (("chain", "draw", "time"), h[:, :, :, 1]),
+            "v0_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
+            "v1_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
+            "v0_phi": (("chain", "draw"), 0.5 + 0.3 * rng.standard_normal((n_chains, n_draws))),
+            "v1_phi": (("chain", "draw"), 0.5 + 0.3 * rng.standard_normal((n_chains, n_draws))),
+            "v0_alpha": (("chain", "draw"), rng.standard_normal((n_chains, n_draws)) * 0.1),
+            "v1_alpha": (("chain", "draw"), rng.standard_normal((n_chains, n_draws)) * 0.1),
+        })
+
+    def test_accepts_name_prefix(self):
+        """forecast_log_vol must accept name_prefix kwarg for AR(1)."""
+        from impulso.sv.dynamics import AR1
+
+        ar1 = AR1()
+        posterior = self._make_ar1_posterior_2v()
+        rng = np.random.default_rng(42)
+        result = ar1.forecast_log_vol(posterior, steps=5, rng=rng, name_prefix="v0_")
+        assert result.shape == (2, 50, 5)
+
+    def test_prefix_result_matches_bare_univariate(self):
+        """Prefix call matches bare univariate call for AR(1)."""
+        from impulso.sv.dynamics import AR1
+
+        ar1 = AR1()
+        posterior = self._make_ar1_posterior_2v()
+
+        h_v0 = posterior["v0_h"].values
+        sigma_eta_v0 = posterior["v0_sigma_eta"].values
+        phi_v0 = posterior["v0_phi"].values
+        alpha_v0 = posterior["v0_alpha"].values
+        uni_posterior = _make_univariate_ar1_posterior(h_v0, sigma_eta_v0, phi_v0, alpha_v0)
+
+        rng_bare = np.random.default_rng(77)
+        rng_prefix = np.random.default_rng(77)
+
+        result_bare = ar1.forecast_log_vol(uni_posterior, steps=5, rng=rng_bare)
+        result_prefix = ar1.forecast_log_vol(posterior, steps=5, rng=rng_prefix, name_prefix="v0_")
+        np.testing.assert_array_equal(result_bare, result_prefix)
+
+
+class TestForecastCholeskyPathUsesPrefix:
+    """forecast_cholesky_path calls dynamics with name_prefix, no fake Dataset."""
+
+    def test_forecast_cholesky_path_uses_prefix(self, synthetic_sv_idata_2v):
+        """forecast_cholesky_path must produce the same result as manually
+        calling forecast_log_vol per variable with the prefix."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        rng = np.random.default_rng(42)
+        path = sv.forecast_cholesky_path(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+        )
+        assert path.shape == (2, 50, 5, 2, 2)
+
+    def test_no_fake_dataset_in_forecast_cholesky_path(self):
+        """forecast_cholesky_path must not build an xr.Dataset internally.
+        We verify by checking the method does not import xr (except at
+        module level). This is a structural test, not a behavioral one."""
+        import inspect
+
+        from impulso.sv.spec import StochasticVolatility
+
+        source = inspect.getsource(StochasticVolatility.forecast_cholesky_path)
+        # The method should NOT contain xr.Dataset( construction.
+        assert "xr.Dataset(" not in source, (
+            "forecast_cholesky_path still builds a fake xr.Dataset — "
+            "it should call dynamics.forecast_log_vol with name_prefix instead"
+        )


### PR DESCRIPTION
## What

Makes the SV posterior naming contract symmetric and dynamics-owned:

- `SVDynamics.forecast_log_vol` gains `name_prefix: str = ""`, matching `build_latent_path`
- RandomWalk reads `{prefix}h`, `{prefix}sigma_eta`
- AR1 reads `{prefix}h`, `{prefix}sigma_eta`, `{prefix}phi`, `{prefix}alpha`
- `forecast_cholesky_path` calls dynamics with `name_prefix=f"v{i}_"` directly on the full posterior
- Fake renamed Dataset machinery and hard-coded `("phi", "alpha")` extras loop deleted
- `synthetic_sv_idata_2v` fixture gains per-variable `v{i}_h` keys

## Testing

- Pin tests: each dynamics forecasts correctly from a multivariate-shaped posterior with `v{i}_*` names, matching bare-name univariate call
- Structural test: no `xr.Dataset()` construction in `forecast_cholesky_path`
- All 267 fast tests pass

Closes #90.