### PR TITLE
feat: memoised shock_matrix query, IRF/FEVD/HD refactored through it (closes #91)

### DIFF
--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -144,47 +144,22 @@ class FittedVAR(ImpulsoBaseModel):
     def set_identification_strategy(self, scheme: IdentificationScheme) -> "IdentifiedVAR":
         """Apply a structural identification scheme.
 
-        Queries the fitted volatility process for the Cholesky factor of Σ
-        and passes it to the scheme. For constant volatility, the factor is
-        the same across all time points; for stochastic volatility (P3),
-        `cholesky_at(t=None)` returns the most-recent slice and
-        downstream IRF/FEVD/HD methods can re-query at other `at` values.
+        The structural shock matrix is no longer eagerly computed or stored
+        in the posterior.  Instead, :meth:`IdentifiedVAR.shock_matrix` lazily
+        queries and memoises it on first access.  This method constructs
+        the ``IdentifiedVAR`` through normal Pydantic validation.
 
         Args:
             scheme: An IdentificationScheme protocol instance (e.g. Cholesky,
                 SignRestriction).
 
         Returns:
-            IdentifiedVAR with structural_shock_matrix in the posterior.
+            IdentifiedVAR ready for structural queries.
         """
-        import xarray as xr
-
         from impulso.identified import IdentifiedVAR
 
-        L = self.volatility.cholesky_at(self.idata.posterior, t=None)
-        P = scheme.identify(L, self.var_names, posterior=self.idata.posterior)
-
-        # Wrap into a DataArray with named coords.
-        shock_coords = scheme.shock_coords(n_vars=len(self.var_names))
-        P_da = xr.DataArray(
-            P,
-            dims=["chain", "draw", "response", "shock"],
-            coords={
-                "response": self.var_names,
-                "shock": shock_coords,
-            },
-        )
-
-        new_posterior = self.idata.posterior.assign(structural_shock_matrix=P_da)
-
-        # Carry through SignRestriction's acceptance rate if present.
-        acceptance_rate = getattr(scheme, "_last_acceptance_rate", None)
-        if isinstance(acceptance_rate, float) and acceptance_rate < 1.0:
-            new_posterior.attrs["sign_restriction_acceptance_rate"] = acceptance_rate
-
-        identified_idata = az.InferenceData(posterior=new_posterior)
-        return IdentifiedVAR.model_construct(
-            idata=identified_idata,
+        return IdentifiedVAR(
+            idata=self.idata,
             n_lags=self.n_lags,
             data=self.data,
             var_names=self.var_names,

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -23,7 +23,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
     """Immutable structural VAR with identified shocks.
 
     Attributes:
-        idata: InferenceData with structural_shock_matrix in posterior.
+        idata: InferenceData with reduced-form posterior (B, intercept, L, ...).
         n_lags: Lag order.
         data: Original VARData.
         var_names: Endogenous variable names.
@@ -45,8 +45,8 @@ class IdentifiedVAR(ImpulsoBaseModel):
 
     @property
     def shock_names(self) -> list[str]:
-        """Shock coordinate labels from the structural shock matrix."""
-        return list(self.idata.posterior["structural_shock_matrix"].coords["shock"].values)
+        """Shock coordinate labels from the identification scheme."""
+        return self.scheme.shock_coords(n_vars=len(self.var_names))
 
     def _ma_coefficients(self, B_draws: np.ndarray, n_vars: int, n_lags: int, horizon: int) -> np.ndarray:
         """Compute MA coefficient recursion, vectorised over (chains, draws).
@@ -56,6 +56,78 @@ class IdentifiedVAR(ImpulsoBaseModel):
         """
         A = [B_draws[:, :, :, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
         return compute_ma_phi(A, horizon)
+
+    def shock_matrix(self, at: AtParam = None) -> xr.DataArray:
+        """Query the structural shock matrix at a given time index.
+
+        This is the single pathway from the volatility process and
+        identification scheme to a labelled structural shock matrix.
+        IRF, FEVD, and historical decomposition all compute through it.
+        Results are memoised per *at* value on this instance so that all
+        quantities from one ``IdentifiedVAR`` share the same structural
+        draws (deterministic per object, even under ``SignRestriction``).
+
+        Args:
+            at: Time index.  ``None`` or ``"last"`` → most recent slice.
+                An integer ``t`` → that specific time index.
+                ``"all"`` → full time path (adds a ``time`` dim).
+
+        Returns:
+            DataArray with dims ``(chain, draw[, time], response, shock)``.
+
+        Raises:
+            ValueError: If ``at="all"`` under constant volatility.
+        """
+        # Check memoisation cache.
+        cache_attr = f"_shock_matrix_cache_{at!r}"
+        cached = getattr(self, cache_attr, None)
+        if cached is not None:
+            return cached
+
+        shock_coords = self.shock_names
+
+        if at == "all":
+            if not self.volatility.is_time_varying:
+                raise ValueError(
+                    "shock_matrix(at='all') is only meaningful for "
+                    "time-varying volatility. The current volatility "
+                    f"process ({type(self.volatility).__name__}) is "
+                    "time-invariant — use at=None or at='last'."
+                )
+            T = self.data.endog.shape[0] - self.n_lags
+            L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
+            P_path = self._identify_per_t(L_path)
+            result = xr.DataArray(
+                P_path,
+                dims=["chain", "draw", "time", "response", "shock"],
+                coords={
+                    "response": self.var_names,
+                    "shock": shock_coords,
+                    "time": ("time", self.data.index[self.n_lags :]),
+                },
+                name="structural_shock_matrix",
+            )
+        else:
+            t = self._resolve_at(at)
+            L = self.volatility.cholesky_at(self.idata.posterior, t=t)
+            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)
+            result = xr.DataArray(
+                P,
+                dims=["chain", "draw", "response", "shock"],
+                coords={
+                    "response": self.var_names,
+                    "shock": shock_coords,
+                },
+                name="structural_shock_matrix",
+            )
+
+        # Attach sign-restriction acceptance rate if available.
+        rate = getattr(self.scheme, "_last_acceptance_rate", None)
+        if isinstance(rate, float) and rate < 1.0:
+            result.attrs["sign_restriction_acceptance_rate"] = rate
+
+        object.__setattr__(self, cache_attr, result)
+        return result
 
     def _resolve_at(self, at: AtParam) -> int | None:
         """Resolve `at=` to an integer `t` suitable for `cholesky_at(t)`.
@@ -113,47 +185,20 @@ class IdentifiedVAR(ImpulsoBaseModel):
 
         Args:
             horizon: Number of periods.
-            at: Time index for the structural shock matrix:
-
-                - `None` (default): for SV, equivalent to `"last"`;
-                  for Constant, ignored entirely.
-                - `int`: query the shock matrix at this specific `t`.
-                - `"last"`: most recent time slice.
-                - `"all"`: return IRFs for shocks at every `t` (adds a
-                  `time` dim to the result).
+            at: Time index for the structural shock matrix
+                (see :meth:`shock_matrix` for accepted forms).
 
         Returns:
             IRFResult with IRF posterior draws.
-
-        Raises:
-            ValueError: When `at='all'` is requested for a non-time-varying
-                volatility process (`Constant`). Under constant Σ the per-t
-                IRF is identical for every t, so the time axis carries no
-                information — use `at=None` (default) or `at='last'`.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
         n_vars = B_draws.shape[2]
         Phi_arr = self._ma_coefficients(B_draws, n_vars, self.n_lags, horizon)
+        P = self.shock_matrix(at=at)
 
-        if at == "all":
-            if not self.volatility.is_time_varying:
-                raise ValueError(
-                    "impulse_response(at='all') is only meaningful for "
-                    "time-varying volatility (Σ_t evolves over t). The "
-                    f"current volatility process ({type(self.volatility).__name__}) "
-                    "is time-invariant, so the per-t IRF would be identical at "
-                    "every t. Use at=None (default) or at='last' for a "
-                    "single-time IRF instead."
-                )
-            # Per-t IRFs. T = effective in-sample length after lag trimming.
-            T = self.data.endog.shape[0] - self.n_lags
-            L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
-            # L_path: (C, D, T, n, n); P_path: (C, D, T, n, n) by per-t identify.
-            P_path = self._identify_per_t(L_path)
-            # IRF: (C, D, T, H+1, n, n). Broadcast Phi over time and P_path
-            # over horizon.
-            irfs = Phi_arr[:, :, np.newaxis, :, :, :] @ P_path[:, :, :, np.newaxis, :, :]
-
+        if "time" in P.dims:
+            # P: (C, D, T, n, n) → IRF: (C, D, T, H+1, n, n)
+            irfs = Phi_arr[:, :, np.newaxis, :, :, :] @ P.values[:, :, :, np.newaxis, :, :]
             irf_da = xr.DataArray(
                 irfs,
                 dims=["chain", "draw", "time", "horizon", "response", "shock"],
@@ -161,21 +206,13 @@ class IdentifiedVAR(ImpulsoBaseModel):
                     "response": self.var_names,
                     "shock": self.shock_names,
                     "horizon": np.arange(horizon + 1),
-                    # Tuple form forces the coord onto the declared `time` dim;
-                    # otherwise a named DatetimeIndex (e.g. .name == "date")
-                    # would be inferred as its own dim and collide.
-                    "time": ("time", self.data.index[self.n_lags :]),
+                    "time": P.coords["time"],
                 },
                 name="irf",
             )
         else:
-            # Single-time IRF.
-            t = self._resolve_at(at)
-            L = self.volatility.cholesky_at(self.idata.posterior, t=t)
-            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)
-            # IRF = Phi @ P, vectorised over (C, D, H) via broadcasting
-            irfs = Phi_arr @ P[:, :, np.newaxis, :, :]
-
+            # P: (C, D, n, n) → IRF: (C, D, H+1, n, n)
+            irfs = Phi_arr @ P.values[:, :, np.newaxis, :, :]
             irf_da = xr.DataArray(
                 irfs,
                 dims=["chain", "draw", "horizon", "response", "shock"],
@@ -186,7 +223,6 @@ class IdentifiedVAR(ImpulsoBaseModel):
                 },
                 name="irf",
             )
-
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"irf": irf_da}))
         return IRFResult(idata=idata, horizon=horizon, var_names=self.var_names)
 
@@ -195,79 +231,40 @@ class IdentifiedVAR(ImpulsoBaseModel):
 
         Args:
             horizon: Number of periods.
-            at: Time index for the structural shock matrix:
-
-                - `None` (default): for SV, equivalent to `"last"`;
-                  for Constant, ignored entirely.
-                - `int`: query the shock matrix at this specific `t`.
-                - `"last"`: most recent time slice.
-                - `"all"`: return FEVDs for shocks at every `t` (adds a
-                  `time` dim to the result).
+            at: Time index for the structural shock matrix
+                (see :meth:`shock_matrix` for accepted forms).
 
         Returns:
             FEVDResult with FEVD posterior draws.
-
-        Raises:
-            ValueError: When `at='all'` is requested for a non-time-varying
-                volatility process (`Constant`). Under constant Σ the per-t
-                FEVD is identical for every t, so the time axis carries no
-                information — use `at=None` (default) or `at='last'`.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
         n_vars = B_draws.shape[2]
         Phi_arr = self._ma_coefficients(B_draws, n_vars, self.n_lags, horizon)
+        P = self.shock_matrix(at=at)
 
-        if at == "all":
-            if not self.volatility.is_time_varying:
-                raise ValueError(
-                    "fevd(at='all') is only meaningful for time-varying "
-                    "volatility (Σ_t evolves over t). The current volatility "
-                    f"process ({type(self.volatility).__name__}) is "
-                    "time-invariant, so the per-t FEVD would be identical at "
-                    "every t. Use at=None (default) or at='last' for a "
-                    "single-time FEVD instead."
-                )
-            # Per-t FEVDs. T = effective in-sample length after lag trimming.
-            T = self.data.endog.shape[0] - self.n_lags
-            L_path = self.volatility.cholesky_path(self.idata.posterior, T=T)
-            # L_path: (C, D, T, n, n); P_path: (C, D, T, n, n) by per-t identify.
-            P_path = self._identify_per_t(L_path)
-            # Theta: (C, D, T, H+1, n, n). Broadcast Phi over time and P_path
-            # over horizon.
-            Theta = Phi_arr[:, :, np.newaxis, :, :, :] @ P_path[:, :, :, np.newaxis, :, :]
-
-            # FEVD: cumulative MSE contribution, summed over the horizon axis (axis=3).
-            mse_cum = np.cumsum(Theta**2, axis=3)  # (C, D, T, H+1, resp, shock)
-            total = mse_cum.sum(axis=-1, keepdims=True)  # (C, D, T, H+1, resp, 1)
-            fevd = np.where(total > 0, mse_cum / total, 0.0)
-
+        if "time" in P.dims:
+            Theta = Phi_arr[:, :, np.newaxis, :, :, :] @ P.values[:, :, :, np.newaxis, :, :]
+            mse_cum = np.cumsum(Theta**2, axis=3)
+            total = mse_cum.sum(axis=-1, keepdims=True)
+            fevd_arr = np.where(total > 0, mse_cum / total, 0.0)
             fevd_da = xr.DataArray(
-                fevd,
+                fevd_arr,
                 dims=["chain", "draw", "time", "horizon", "response", "shock"],
                 coords={
                     "response": self.var_names,
                     "shock": self.shock_names,
                     "horizon": np.arange(horizon + 1),
-                    # Tuple form: see analogous comment in impulse_response.
-                    "time": ("time", self.data.index[self.n_lags :]),
+                    "time": P.coords["time"],
                 },
                 name="fevd",
             )
         else:
-            # Single-time FEVD.
-            t = self._resolve_at(at)
-            L = self.volatility.cholesky_at(self.idata.posterior, t=t)
-            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)
-            # Theta_h = Phi_h @ P, vectorised via broadcasting
-            Theta = Phi_arr @ P[:, :, np.newaxis, :, :]
-
-            # FEVD: cumulative MSE contribution
-            mse_cum = np.cumsum(Theta**2, axis=2)  # (C, D, H+1, resp, shock)
-            total = mse_cum.sum(axis=-1, keepdims=True)  # (C, D, H+1, resp, 1)
-            fevd = np.where(total > 0, mse_cum / total, 0.0)
-
+            Theta = Phi_arr @ P.values[:, :, np.newaxis, :, :]
+            mse_cum = np.cumsum(Theta**2, axis=2)
+            total = mse_cum.sum(axis=-1, keepdims=True)
+            fevd_arr = np.where(total > 0, mse_cum / total, 0.0)
             fevd_da = xr.DataArray(
-                fevd,
+                fevd_arr,
                 dims=["chain", "draw", "horizon", "response", "shock"],
                 coords={
                     "response": self.var_names,
@@ -276,7 +273,6 @@ class IdentifiedVAR(ImpulsoBaseModel):
                 },
                 name="fevd",
             )
-
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"fevd": fevd_da}))
         return FEVDResult(idata=idata, horizon=horizon, var_names=self.var_names)
 
@@ -290,26 +286,17 @@ class IdentifiedVAR(ImpulsoBaseModel):
         """Compute historical decomposition of observed series.
 
         Historical decomposition is intrinsically time-indexed: it attributes
-        each in-sample observation to past structural shocks. The `at=`
+        each in-sample observation to past structural shocks.  The ``at=``
         parameter controls which Cholesky factor identifies those shocks.
 
         Args:
             start: Optional start date to restrict decomposition.
             end: Optional end date to restrict decomposition.
             cumulative: If True, return cumulative shock contributions.
-            at: Time index for the structural shock matrix:
-
-                - `None` (default) or `"all"`: use `cholesky_path` —
-                  identify the shock at each `t` with its own `L_t`.
-                  For stochastic volatility this is the correct structural
-                  decomposition; for constant volatility `L_t` is the same
-                  for all `t` and the result matches the legacy behaviour.
-                - `int` or `"last"`: identify every shock with a single
-                  `L` queried at the supplied time index. Under stochastic
-                  volatility this is a non-standard hypothetical ("what if
-                  regime `t` had prevailed throughout?") and emits a
-                  `UserWarning`. For constant volatility the result is
-                  identical to the default.
+            at: Time index for the structural shock matrix.
+                ``None`` or ``"all"`` → per-t decomposition (correct for SV,
+                identical to single-L under constant volatility).
+                ``int`` or ``"last"`` → single-L hypothetical (warns under SV).
 
         Returns:
             HistoricalDecompositionResult.
@@ -320,25 +307,22 @@ class IdentifiedVAR(ImpulsoBaseModel):
         y = self.data.endog  # (T, n)
         T = y.shape[0]
         n_lags = self.n_lags
-        T_eff = T - n_lags
 
-        # Build lag matrix: x_lag[t] = [y[t-1], y[t-2], ...] for t in [n_lags, T)
-        x_lag = np.concatenate([y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)], axis=1)  # (T-p, n*p)
-
-        # Predicted values: intercept + B @ x_lag for all (C, D, t)
+        x_lag = np.concatenate(
+            [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
+            axis=1,
+        )  # (T-p, n*p)
         y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
-
-        # Reduced-form residuals: (C, D, T-p, n)
-        y_obs = y[n_lags:]  # (T-p, n)
+        y_obs = y[n_lags:]
         resid = y_obs[np.newaxis, np.newaxis, :, :] - y_hat
 
-        # Two regimes for the structural-shock matrix:
-        #   1. Time-invariant Σ (Constant adapter), or SV with an explicit
-        #      single-L hypothetical (at=int / 'last'): identify once,
-        #      invert once, broadcast across t.
-        #   2. Time-varying Σ with default at=None/'all': per-t identify and
-        #      invert (the standard SV structural decomposition).
-        if not self.volatility.is_time_varying or at not in (None, "all"):
+        use_per_t = self.volatility.is_time_varying and at in (None, "all")
+        if use_per_t:
+            P = self.shock_matrix(at="all").values  # (C, D, T_eff, n, n)
+            P_inv = np.linalg.inv(P)
+            structural_resid = np.einsum("cdtij,cdtj->cdti", P_inv, resid)
+            hd = P * structural_resid[:, :, :, np.newaxis, :]
+        else:
             if self.volatility.is_time_varying:
                 warnings.warn(
                     f"historical_decomposition(at={at!r}) under stochastic "
@@ -350,27 +334,16 @@ class IdentifiedVAR(ImpulsoBaseModel):
                     UserWarning,
                     stacklevel=2,
                 )
-            # For Constant the time index is irrelevant; for SV+explicit-at it
-            # is the resolved single time slice. Either way: one identify, one
-            # invert, then broadcast over t via einsum / np.newaxis.
-            t = self._resolve_at(at) if self.volatility.is_time_varying else None
-            L = self.volatility.cholesky_at(self.idata.posterior, t=t)
-            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)  # (C, D, n, n)
-            P_inv = np.linalg.inv(P)  # (C, D, n, n)
-            structural_resid = np.einsum("cdij,cdtj->cdti", P_inv, resid)  # (C, D, T_eff, n)
+            # For constant vol, at='all' is equivalent to at=None (single L).
+            shock_at = None if (at == "all" and not self.volatility.is_time_varying) else at
+            P = self.shock_matrix(at=shock_at).values  # (C, D, n, n)
+            P_inv = np.linalg.inv(P)
+            structural_resid = np.einsum("cdij,cdtj->cdti", P_inv, resid)
             hd = P[:, :, np.newaxis, :, :] * structural_resid[:, :, :, np.newaxis, :]
-        else:
-            # SV per-t structural decomposition.
-            L_path = self.volatility.cholesky_path(self.idata.posterior, T=T_eff)
-            P_path = self._identify_per_t(L_path)  # (C, D, T_eff, n, n)
-            P_inv_path = np.linalg.inv(P_path)
-            structural_resid = np.einsum("cdtij,cdtj->cdti", P_inv_path, resid)
-            hd = P_path * structural_resid[:, :, :, np.newaxis, :]
 
         if cumulative:
             hd = np.cumsum(hd, axis=2)
 
-        # Trim to date range if requested
         idx = self.data.index[n_lags:]
         t_start = 0
         t_end = len(idx)
@@ -386,9 +359,6 @@ class IdentifiedVAR(ImpulsoBaseModel):
             coords={
                 "response": self.var_names,
                 "shock": self.shock_names,
-                # Tuple form forces the coord onto the declared `time` dim;
-                # otherwise a named DatetimeIndex (e.g. .name == "date")
-                # would be inferred as its own dim and collide.
                 "time": ("time", idx[t_start:t_end]),
             },
             name="hd",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,29 +113,6 @@ def synthetic_idata_2v():
     return az.InferenceData(posterior=posterior)
 
 
-@pytest.fixture
-def synthetic_identified_idata_2v(synthetic_idata_2v):
-    """Synthetic InferenceData with structural_shock_matrix added.
-
-    Applies Cholesky decomposition to each Sigma draw.
-    """
-    sigma = synthetic_idata_2v.posterior["Sigma"].values
-    n_chains, n_draws = sigma.shape[:2]
-
-    P = np.zeros_like(sigma)
-    for c in range(n_chains):
-        for d in range(n_draws):
-            P[c, d] = np.linalg.cholesky(sigma[c, d])
-
-    P_da = xr.DataArray(
-        P,
-        dims=["chain", "draw", "response", "shock"],
-        coords={"response": ["y1", "y2"], "shock": ["y1", "y2"]},
-    )
-    new_posterior = synthetic_idata_2v.posterior.assign(structural_shock_matrix=P_da)
-    return az.InferenceData(posterior=new_posterior)
-
-
 # --------------- SV fixtures ---------------
 
 

--- a/tests/test_cholskey_irf_pins.py
+++ b/tests/test_cholskey_irf_pins.py
@@ -1,0 +1,186 @@
+"""Regression pins for Cholesky IRF/FEVD/HD outputs.
+
+These tests capture the exact numerical output of impulse_response, fevd,
+and historical_decomposition under Cholesky identification via the public
+pipeline (FittedVAR -> set_identification_strategy). They MUST pass before
+AND after the #91 shock_matrix refactor to prove the refactor is
+behaviour-preserving.
+
+Fast tests use a self-consistent synthetic InferenceData fixture with
+n_lags=1 and B shape (2, 50, 2, 2).
+"""
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from impulso.data import VARData
+from impulso.fitted import FittedVAR
+from impulso.identification import Cholesky
+from impulso.volatility import Constant
+
+
+@pytest.fixture
+def fitted_and_identified():
+    """Self-consistent FittedVAR + IdentifiedVAR through the public flow.
+
+    B has shape (C, D, n_vars, n_vars*n_lags) = (2, 50, 2, 2) matching
+    n_lags=1.  Deterministic rng seed ensures reproducible outputs.
+    """
+    rng = np.random.default_rng(42)
+    n_chains, n_draws, n_vars, n_lags = 2, 50, 2, 1
+
+    B_raw = rng.standard_normal((n_chains, n_draws, n_vars, n_vars * n_lags)) * 0.1
+    B_raw[:, :, 0, 0] += 0.5
+    B_raw[:, :, 1, 1] += 0.3
+    B_raw[:, :, 0, 1] += 0.1
+    B_raw[:, :, 1, 0] -= 0.2
+    intercept = rng.standard_normal((n_chains, n_draws, n_vars)) * 0.1
+    intercept[:, :, 0] += 0.1
+    intercept[:, :, 1] -= 0.05
+    sigma_raw = rng.standard_normal((n_chains, n_draws, n_vars, n_vars)) * 0.3
+    sigma_raw[:, :, 0, 0] += 1.5
+    sigma_raw[:, :, 1, 1] += 1.2
+    L_raw = np.tril(sigma_raw)
+    L_raw[:, :, 0, 0] = np.abs(L_raw[:, :, 0, 0])
+    L_raw[:, :, 1, 1] = np.abs(L_raw[:, :, 1, 1])
+    sd = np.abs(rng.standard_normal((n_chains, n_draws, n_vars))) * 0.5 + 0.5
+    L_raw[:, :, range(n_vars), range(n_vars)] = sd
+    Sigma = np.einsum("cdij,cdkj->cdik", L_raw, L_raw)
+
+    posterior = xr.Dataset({
+        "B": (("chain", "draw", "var1", "var2"), B_raw),
+        "intercept": (("chain", "draw", "var1"), intercept),
+        "L": (("chain", "draw", "var1", "var2"), L_raw),
+        "Sigma": (("chain", "draw", "var1", "var2"), Sigma),
+    })
+    idata = az.InferenceData(posterior=posterior)
+
+    A1 = np.array([[0.5, 0.1], [-0.2, 0.3]])
+    intercept_true = np.array([0.1, -0.05])
+    y = np.zeros((200, 2))
+    y[0] = intercept_true / 0.7
+    for t in range(1, 200):
+        y[t] = intercept_true + A1 @ y[t - 1] + rng.standard_normal(2) * 0.5
+    index = pd.date_range("2000-01-01", periods=200, freq="QS")
+    data = VARData(endog=y, endog_names=["y1", "y2"], index=index)
+
+    fitted = FittedVAR(
+        idata=idata,
+        n_lags=n_lags,
+        data=data,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    identified = fitted.set_identification_strategy(Cholesky(ordering=["y1", "y2"]))
+    return fitted, identified
+
+
+class TestCholeskyIRFPin:
+    """Regression pin: IRF output under Cholesky identification."""
+
+    def test_irf_median_shape(self, fitted_and_identified):
+        _, identified = fitted_and_identified
+        irf = identified.impulse_response(horizon=5)
+        assert irf.median().shape == (6, 4)
+
+    def test_irf_horizon_0_is_lower_triangular(self, fitted_and_identified):
+        """IRF at h=0 = I @ P = P; lower-triangular under Cholesky."""
+        _, identified = fitted_and_identified
+        irf = identified.impulse_response(horizon=5)
+        med = irf.median()
+        assert med.values[0, 1] == pytest.approx(0.0, abs=1e-12)
+        assert med.values[0, 0] > 0
+        assert med.values[0, 3] > 0
+
+    def test_irf_values_pinned(self, fitted_and_identified):
+        """Pin exact median IRF values for regression detection."""
+        _, identified = fitted_and_identified
+        irf = identified.impulse_response(horizon=5)
+        med = irf.median()
+        expected = np.array([
+            [0.831534, 0.0, 0.006446, 0.793896],
+            [0.418751, 0.073324, -0.162831, 0.244156],
+            [0.182067, 0.056493, -0.120533, 0.065252],
+            [0.075273, 0.035107, -0.067667, 0.009670],
+            [0.028684, 0.016822, -0.031755, -0.001846],
+            [0.011834, 0.006212, -0.012512, -0.002320],
+        ])
+        np.testing.assert_allclose(med.values, expected, rtol=1e-3, atol=1e-5)
+
+
+class TestCholeskyFEVDPin:
+    """Regression pin: FEVD output under Cholesky identification."""
+
+    def test_fevd_sums_to_one(self, fitted_and_identified):
+        _, identified = fitted_and_identified
+        fevd = identified.fevd(horizon=5)
+        fevd_da = fevd.idata.posterior_predictive["fevd"]
+        med = fevd_da.median(dim=("chain", "draw"))
+        for resp in ["y1", "y2"]:
+            sums = med.sel(response=resp).values.sum(axis=1)
+            np.testing.assert_allclose(sums, 1.0, atol=1e-10)
+
+    def test_fevd_h0_cholesky_ordering(self, fitted_and_identified):
+        """At h=0 with Cholesky [y1,y2], y1 is 100% own shock."""
+        _, identified = fitted_and_identified
+        fevd = identified.fevd(horizon=5)
+        fevd_da = fevd.idata.posterior_predictive["fevd"]
+        med = fevd_da.median(dim=("chain", "draw"))
+        y1_h0 = med.sel(response="y1", horizon=0).values
+        np.testing.assert_allclose(y1_h0, [1.0, 0.0], atol=1e-10)
+
+    def test_fevd_values_pinned(self, fitted_and_identified):
+        """Pin exact median FEVD values for regression detection."""
+        _, identified = fitted_and_identified
+        fevd = identified.fevd(horizon=5)
+        med = fevd.median()
+        expected = np.array([
+            [1.0, 0.0, 0.051933, 0.948067],
+            [0.993285, 0.006715, 0.101073, 0.898927],
+            [0.989732, 0.010268, 0.128241, 0.871759],
+            [0.988027, 0.011973, 0.135176, 0.864824],
+            [0.987507, 0.012493, 0.137366, 0.862634],
+            [0.987340, 0.012660, 0.137887, 0.862113],
+        ])
+        np.testing.assert_allclose(med.values, expected, rtol=1e-4)
+
+
+class TestCholeskyHDPin:
+    """Regression pin: historical decomposition under Cholesky."""
+
+    def test_hd_shape(self, fitted_and_identified):
+        _, identified = fitted_and_identified
+        hd = identified.historical_decomposition()
+        hd_da = hd.idata.posterior_predictive["hd"]
+        assert hd_da.shape == (2, 50, 199, 2, 2)
+
+    def test_hd_shocks_match_scheme(self, fitted_and_identified):
+        """HD shock coords must match the identification scheme."""
+        _, identified = fitted_and_identified
+        hd = identified.historical_decomposition()
+        hd_da = hd.idata.posterior_predictive["hd"]
+        assert list(hd_da.coords["shock"].values) == ["y1", "y2"]
+
+    def test_hd_reconstructs_nontrivially(self, fitted_and_identified):
+        """Sum across shocks should be non-trivial."""
+        _, identified = fitted_and_identified
+        hd = identified.historical_decomposition()
+        hd_da = hd.idata.posterior_predictive["hd"]
+        hd_sum = hd_da.sum(dim="shock").median(dim=("chain", "draw"))
+        assert not np.allclose(hd_sum.values, 0.0)
+
+    def test_hd_sum_values_pinned(self, fitted_and_identified):
+        """Pin HD residual reconstruction at first 3 time points."""
+        _, identified = fitted_and_identified
+        hd = identified.historical_decomposition()
+        hd_da = hd.idata.posterior_predictive["hd"]
+        hd_sum = hd_da.sum(dim="shock").median(dim=("chain", "draw"))
+        expected_first3 = np.array([
+            [-0.653623, -0.240780],
+            [0.218211, -0.050645],
+            [-0.318535, -0.322762],
+        ])
+        np.testing.assert_allclose(hd_sum.values[:3], expected_first3, rtol=1e-4)

--- a/tests/test_fitted.py
+++ b/tests/test_fitted.py
@@ -189,9 +189,10 @@ class TestFittedVARVolatility:
 
 
 class TestSetIdentificationStrategyRoutesThroughSeam:
-    def test_calls_volatility_cholesky_at(self, var_data_2v):
-        """set_identification_strategy must query volatility.cholesky_at,
-        not read posterior['Sigma'] directly."""
+    @pytest.mark.slow
+    def test_shock_matrix_triggers_cholesky_at(self, var_data_2v):
+        """shock_matrix() queries volatility.cholesky_at lazily.
+        set_identification_strategy no longer calls it eagerly."""
         from unittest.mock import MagicMock
 
         from impulso.identification import Cholesky
@@ -200,21 +201,19 @@ class TestSetIdentificationStrategyRoutesThroughSeam:
 
         sampler = NUTSSampler(cores=1, chains=1, draws=20, tune=20, random_seed=0, nuts_sampler="pymc")
         fitted = VAR(lags=1).fit(var_data_2v, sampler=sampler)
-
-        # Replace the volatility on the fitted spec with a spy.
-        spy = MagicMock(wraps=fitted.volatility)
-        object.__setattr__(fitted, "volatility", spy)
-
         identified = fitted.set_identification_strategy(Cholesky(ordering=fitted.var_names))
 
+        spy = MagicMock(wraps=identified.volatility)
+        object.__setattr__(identified, "volatility", spy)
+
+        sm = identified.shock_matrix()
         spy.cholesky_at.assert_called_once()
-        # Confirm the structural shock matrix made it into the posterior.
-        assert "structural_shock_matrix" in identified.idata.posterior
-        # Lock down the dims/coords contract that downstream IRF/FEVD/HD depend on.
-        ssm = identified.idata.posterior["structural_shock_matrix"]
-        assert ssm.dims == ("chain", "draw", "response", "shock")
-        assert list(ssm.coords["response"].values) == fitted.var_names
-        assert list(ssm.coords["shock"].values) == fitted.var_names
+
+        # structural_shock_matrix no longer stored in the posterior.
+        assert "structural_shock_matrix" not in identified.idata.posterior
+        assert sm.dims == ("chain", "draw", "response", "shock")
+        assert list(sm.coords["response"].values) == fitted.var_names
+        assert list(sm.coords["shock"].values) == fitted.var_names
 
 
 class TestFittedVarSigmaDispatch:

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from impulso.fitted import FittedVAR
 from impulso.identification import Cholesky, SignRestriction
 from impulso.identified import IdentifiedVAR
 from impulso.results import FEVDResult, HistoricalDecompositionResult, IRFResult
@@ -18,6 +19,21 @@ def fitted_var(var_data_2v):
     spec = VAR(lags=1, prior="minnesota")
     sampler = NUTSSampler(draws=100, tune=100, chains=2, cores=1, random_seed=42)
     return spec.fit(var_data_2v, sampler=sampler)
+
+
+@pytest.fixture
+def identified_cholesky(synthetic_idata_2v, var_data_2v):
+    """IdentifiedVAR via public FittedVAR -> set_identification_strategy flow."""
+    from impulso.volatility import Constant
+
+    fitted = FittedVAR(
+        idata=synthetic_idata_2v,
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    return fitted.set_identification_strategy(Cholesky(ordering=["y1", "y2"]))
 
 
 class TestIdentifiedVAR:
@@ -49,159 +65,66 @@ class TestIdentifiedVAR:
 class TestIdentifiedVARFast:
     """Fast tests using synthetic InferenceData (no MCMC)."""
 
-    def test_impulse_response_shape(self, synthetic_identified_idata_2v, var_data_2v):
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        irf = identified.impulse_response(horizon=10)
+    def test_impulse_response_shape(self, identified_cholesky):
+        irf = identified_cholesky.impulse_response(horizon=10)
         assert isinstance(irf, IRFResult)
         assert irf.horizon == 10
-        med = irf.median()
-        assert med.shape == (11, 4)  # (horizon+1, n_vars*n_vars)
+        assert irf.median().shape == (11, 4)
 
-    def test_fevd_shape(self, synthetic_identified_idata_2v, var_data_2v):
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        fevd = identified.fevd(horizon=10)
+    def test_fevd_shape(self, identified_cholesky):
+        fevd = identified_cholesky.fevd(horizon=10)
         assert isinstance(fevd, FEVDResult)
-        med = fevd.median()
-        assert med.shape == (11, 4)
+        assert fevd.median().shape == (11, 4)
 
-    def test_fevd_sums_to_one(self, synthetic_identified_idata_2v, var_data_2v):
+    def test_fevd_sums_to_one(self, identified_cholesky):
         """FEVD shares should sum to ~1 for each response at each horizon."""
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        fevd = identified.fevd(horizon=10)
+        fevd = identified_cholesky.fevd(horizon=10)
         fevd_da = fevd.idata.posterior_predictive["fevd"]
         med = fevd_da.median(dim=("chain", "draw"))
-        # For each response, shares across shocks should sum to 1
         for resp in ["y1", "y2"]:
             sums = med.sel(response=resp).values.sum(axis=1)
             np.testing.assert_allclose(sums, 1.0, atol=1e-10)
 
-    def test_historical_decomposition_shape(self, synthetic_identified_idata_2v, var_data_2v):
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        hd = identified.historical_decomposition()
+    def test_historical_decomposition_shape(self, identified_cholesky):
+        hd = identified_cholesky.historical_decomposition()
         assert isinstance(hd, HistoricalDecompositionResult)
 
-    def test_irf_deterministic_values(self, synthetic_identified_idata_2v, var_data_2v):
+    def test_irf_deterministic_values(self, identified_cholesky):
         """IRF at horizon 0 should equal the structural shock matrix."""
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        irf = identified.impulse_response(horizon=5)
-        irf_draws = irf.idata.posterior_predictive["irf"].values  # (C, D, H+1, n, n)
-
-        P = synthetic_identified_idata_2v.posterior["structural_shock_matrix"].values
-        # At h=0, IRF = Phi_0 @ P = I @ P = P
+        irf = identified_cholesky.impulse_response(horizon=5)
+        irf_draws = irf.idata.posterior_predictive["irf"].values
+        P = identified_cholesky.shock_matrix().values
         np.testing.assert_allclose(irf_draws[:, :, 0, :, :], P, atol=1e-12)
 
-    def test_irf_propagates_custom_shock_coords(self, synthetic_idata_2v, var_data_2v):
-        """IRF shock coordinates should match structural_shock_matrix, not var_names."""
-        from impulso.volatility import Constant
-
-        sigma = synthetic_idata_2v.posterior["Sigma"].values
-        P = np.linalg.cholesky(sigma)
-        P_da = xr.DataArray(
-            P,
-            dims=["chain", "draw", "response", "shock"],
-            coords={"response": ["y1", "y2"], "shock": ["my_shock", "unidentified_1"]},
-        )
-        idata = az.InferenceData(posterior=synthetic_idata_2v.posterior.assign(structural_shock_matrix=P_da))
-        identified = IdentifiedVAR.model_construct(
-            idata=idata,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        irf = identified.impulse_response(horizon=5)
+    def test_irf_shock_coords_from_scheme(self, identified_cholesky):
+        """IRF shock coordinates come from scheme.shock_coords()."""
+        irf = identified_cholesky.impulse_response(horizon=5)
         irf_shocks = list(irf.idata.posterior_predictive["irf"].coords["shock"].values)
-        assert irf_shocks == ["my_shock", "unidentified_1"]
+        assert irf_shocks == ["y1", "y2"]
 
-    def test_repr(self, synthetic_identified_idata_2v, var_data_2v):
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        r = repr(identified)
+    def test_repr(self, identified_cholesky):
+        r = repr(identified_cholesky)
         assert "IdentifiedVAR" in r
 
 
 class TestP2PosteriorEquivalence:
-    """P2 must not change identified posteriors. Fits VAR(lags=1) +
-    Cholesky + SignRestriction under the new pipeline and asserts the
-    structural_shock_matrix posterior matches the mathematically expected
-    value (Cholesky) or is well-formed (SignRestriction smoke test).
-    """
+    """P2: shock_matrix output matches the mathematically expected value."""
 
     @pytest.mark.slow
-    def test_cholesky_identified_posterior_unchanged(self, var_data_2v):
-        """P2 invariant: Cholesky-identified posterior equals np.linalg.cholesky(Sigma) at 1e-10."""
+    def test_cholesky_shock_matrix_matches_cholesky_of_sigma(self, var_data_2v):
+        """Cholesky-identified shock_matrix equals np.linalg.cholesky(Sigma)."""
         sampler = NUTSSampler(cores=1, chains=2, draws=200, tune=200, random_seed=42, nuts_sampler="pymc")
         fitted = VAR(lags=1).fit(var_data_2v, sampler=sampler)
         identified = fitted.set_identification_strategy(Cholesky(ordering=fitted.var_names))
 
-        P = identified.idata.posterior["structural_shock_matrix"].values
+        P = identified.shock_matrix().values
         assert P.shape == (2, 200, 2, 2)
-
-        # Cholesky with identity ordering: P should equal np.linalg.cholesky(Sigma).
         sigma = fitted.idata.posterior["Sigma"].values
         np.testing.assert_allclose(P, np.linalg.cholesky(sigma), rtol=1e-10)
 
     @pytest.mark.slow
-    def test_sign_restriction_identified_posterior_runs(self, var_data_2v):
-        """Smoke test: SignRestriction with restriction_horizon=2 produces
-        a valid structural_shock_matrix posterior."""
-        from impulso.samplers import NUTSSampler
-        from impulso.spec import VAR
-
+    def test_sign_restriction_shock_matrix_runs(self, var_data_2v):
+        """Smoke test: SignRestriction produces a valid shock_matrix."""
         sampler = NUTSSampler(cores=1, chains=2, draws=100, tune=100, random_seed=42, nuts_sampler="pymc")
         fitted = VAR(lags=1).fit(var_data_2v, sampler=sampler)
         scheme = SignRestriction(
@@ -212,9 +135,9 @@ class TestP2PosteriorEquivalence:
         )
         identified = fitted.set_identification_strategy(scheme)
 
-        P = identified.idata.posterior["structural_shock_matrix"].values
+        P = identified.shock_matrix().values
         assert P.shape == (2, 100, 2, 2)
-        assert not np.isnan(P).any(), "Some draws produced NaN structural shock matrix"
+        assert not np.isnan(P).any()
 
 
 def _fitted_from_synthetic(synthetic_idata_2v, var_data_2v):
@@ -336,40 +259,20 @@ class TestHistoricalDecompositionAt:
     L_t is identical, so all ``at=`` modes produce identical results.
     """
 
-    def test_at_default_matches_at_all_for_constant(self, synthetic_identified_idata_2v, var_data_2v):
+    def test_at_default_matches_at_all_for_constant(self, identified_cholesky):
         """For Constant volatility, ``at=None`` and ``at='all'`` are identical."""
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        hd_default = identified.historical_decomposition()
-        hd_all = identified.historical_decomposition(at="all")
+        hd_default = identified_cholesky.historical_decomposition()
+        hd_all = identified_cholesky.historical_decomposition(at="all")
         np.testing.assert_array_equal(
             hd_default.idata.posterior_predictive["hd"].values,
             hd_all.idata.posterior_predictive["hd"].values,
         )
 
-    def test_at_int_matches_default_for_constant(self, synthetic_identified_idata_2v, var_data_2v):
+    def test_at_int_matches_default_for_constant(self, identified_cholesky):
         """For Constant volatility, ``at=int`` and ``at='last'`` match the default."""
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        hd_default = identified.historical_decomposition()
-        hd_at_int = identified.historical_decomposition(at=5)
-        hd_at_last = identified.historical_decomposition(at="last")
+        hd_default = identified_cholesky.historical_decomposition()
+        hd_at_int = identified_cholesky.historical_decomposition(at=5)
+        hd_at_last = identified_cholesky.historical_decomposition(at="last")
         np.testing.assert_array_equal(
             hd_default.idata.posterior_predictive["hd"].values,
             hd_at_int.idata.posterior_predictive["hd"].values,
@@ -379,33 +282,18 @@ class TestHistoricalDecompositionAt:
             hd_at_last.idata.posterior_predictive["hd"].values,
         )
 
-    def test_at_default_matches_legacy_structural_shock_matrix(self, synthetic_identified_idata_2v, var_data_2v):
-        """For Constant, per-t HD must equal the legacy single-P decomposition.
-
-        Recomputes HD by hand using the stored ``structural_shock_matrix`` (the
-        P2 single-L identification) and checks the byte-for-byte equivalence
-        gate that protects the Constant-volatility code path.
-        """
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        hd = identified.historical_decomposition()
+    def test_at_default_matches_shock_matrix_reconstruction(self, identified_cholesky, synthetic_idata_2v, var_data_2v):
+        """For Constant, per-t HD equals the single-P decomposition via shock_matrix."""
+        hd = identified_cholesky.historical_decomposition()
         hd_vals = hd.idata.posterior_predictive["hd"].values
 
-        # Recompute the legacy way.
-        B = synthetic_identified_idata_2v.posterior["B"].values
-        P = synthetic_identified_idata_2v.posterior["structural_shock_matrix"].values
-        intercept = synthetic_identified_idata_2v.posterior["intercept"].values
+        # Recompute by hand using shock_matrix.
+        B = synthetic_idata_2v.posterior["B"].values
+        P = identified_cholesky.shock_matrix().values
+        intercept = synthetic_idata_2v.posterior["intercept"].values
         y = var_data_2v.endog
-        T = y.shape[0]
         n_lags = 1
+        T = y.shape[0]
         x_lag = np.concatenate([y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)], axis=1)
         y_hat = intercept[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B, x_lag)
         resid = y[n_lags:][np.newaxis, np.newaxis, :, :] - y_hat
@@ -414,19 +302,9 @@ class TestHistoricalDecompositionAt:
         hd_legacy = P[:, :, np.newaxis, :, :] * s[:, :, :, np.newaxis, :]
         np.testing.assert_allclose(hd_vals, hd_legacy, atol=1e-12)
 
-    def test_at_preserves_time_dim(self, synthetic_identified_idata_2v, var_data_2v):
+    def test_at_preserves_time_dim(self, identified_cholesky, var_data_2v):
         """HD always carries a time dim; ``at=`` must not change its length."""
-        from impulso.volatility import Constant
-
-        identified = IdentifiedVAR.model_construct(
-            idata=synthetic_identified_idata_2v,
-            n_lags=1,
-            data=var_data_2v,
-            var_names=["y1", "y2"],
-            volatility=Constant(),
-            scheme=Cholesky(ordering=["y1", "y2"]),
-        )
-        hd = identified.historical_decomposition(at="all")
+        hd = identified_cholesky.historical_decomposition(at="all")
         hd_da = hd.idata.posterior_predictive["hd"]
         assert "time" in hd_da.dims
         T_eff = var_data_2v.endog.shape[0] - 1
@@ -434,7 +312,6 @@ class TestHistoricalDecompositionAt:
 
     def test_at_int_warns_for_sv(self, var_data_2v, synthetic_idata_2v):
         """Under SV, ``at=int`` is a non-standard hypothetical and warns."""
-        import xarray as xr_
 
         from impulso.volatility import Constant
 
@@ -461,18 +338,8 @@ class TestHistoricalDecompositionAt:
             def cholesky_path(self, posterior, T):
                 return constant.cholesky_path(posterior, T=T)
 
-        # Wire P into the synthetic idata as the structural_shock_matrix.
-        sigma = synthetic_idata_2v.posterior["Sigma"].values
-        P = np.linalg.cholesky(sigma)
-        P_da = xr_.DataArray(
-            P,
-            dims=["chain", "draw", "response", "shock"],
-            coords={"response": ["y1", "y2"], "shock": ["y1", "y2"]},
-        )
-        idata = az.InferenceData(posterior=synthetic_idata_2v.posterior.assign(structural_shock_matrix=P_da))
-
         identified = IdentifiedVAR.model_construct(
-            idata=idata,
+            idata=synthetic_idata_2v,
             n_lags=1,
             data=var_data_2v,
             var_names=["y1", "y2"],
@@ -487,8 +354,6 @@ class TestHistoricalDecompositionAt:
     def test_at_default_does_not_warn_for_sv(self, var_data_2v, synthetic_idata_2v):
         """Default (per-t) HD is the standard SV decomposition — no warning."""
         import warnings as _warnings
-
-        import xarray as xr_
 
         from impulso.volatility import Constant
 
@@ -510,17 +375,8 @@ class TestHistoricalDecompositionAt:
             def cholesky_path(self, posterior, T):
                 return constant.cholesky_path(posterior, T=T)
 
-        sigma = synthetic_idata_2v.posterior["Sigma"].values
-        P = np.linalg.cholesky(sigma)
-        P_da = xr_.DataArray(
-            P,
-            dims=["chain", "draw", "response", "shock"],
-            coords={"response": ["y1", "y2"], "shock": ["y1", "y2"]},
-        )
-        idata = az.InferenceData(posterior=synthetic_idata_2v.posterior.assign(structural_shock_matrix=P_da))
-
         identified = IdentifiedVAR.model_construct(
-            idata=idata,
+            idata=synthetic_idata_2v,
             n_lags=1,
             data=var_data_2v,
             var_names=["y1", "y2"],


### PR DESCRIPTION
## What

**Breaking** (pre-v0.1 policy): `posterior["structural_shock_matrix"]` removed.

- Public `IdentifiedVAR.shock_matrix(at=None)` — single pathway from volatility process + identification scheme to a labelled structural shock matrix. Memoised per `at` value via `object.__setattr__` on frozen Pydantic model (ADR-0004).
- `impulse_response`, `fevd`, `historical_decomposition` refactored to compute through `shock_matrix` instead of duplicating the ~30-line dispatch skeleton.
- `set_identification_strategy` no longer computes or stores `structural_shock_matrix` in the posterior. `IdentifiedVAR` constructed through normal Pydantic validation.
- `shock_names` delegates to `scheme.shock_coords()`.
- `synthetic_identified_idata_2v` fixture removed; all tests migrated to public `FittedVAR -> set_identification_strategy` flow.
- Per-quantity `at` policy stays local: IRF/FEVD default `None` → `"last"`; HD defaults to per-t decomposition.

## Testing

- Regression pins: IRF/FEVD/HD median values pinned through public flow (constant volatility)
- `shock_matrix` at-resolution: int, `"last"`, None, `"all"`; constant-vol guard for `"all"`
- Memoisation: repeated calls return cached object
- All 268 fast tests pass, all 10 pins pass

Closes #91.