### PR TITLE
feat: density forecasts with include_shock_uncertainty and seed (closes #92)

### DIFF
--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -84,13 +84,24 @@ class FittedVAR(ImpulsoBaseModel):
     def forecast(
         self,
         steps: int,
+        include_shock_uncertainty: bool = True,
+        seed: int | np.random.Generator | None = None,
         exog_future: np.ndarray | None = None,
     ) -> "ForecastResult":
         """Produce h-step-ahead forecasts from the reduced-form posterior.
 
         Args:
             steps: Number of forecast steps.
-            exog_future: Future exogenous values, shape (steps, k). Required if model has exog.
+            include_shock_uncertainty: If ``True`` (default), draw shock
+                innovations from the volatility process's forecast Cholesky
+                path, giving true posterior-predictive intervals (density
+                forecast).  If ``False``, propagate only the conditional
+                mean — intervals reflect parameter uncertainty only (mean
+                forecast).
+            seed: RNG seed (int) or Generator for reproducible density
+                forecasts.  Ignored when ``include_shock_uncertainty=False``.
+            exog_future: Future exogenous values, shape ``(steps, k)``.
+                Required if model has exog.
 
         Returns:
             ForecastResult with posterior forecast draws.
@@ -104,33 +115,47 @@ class FittedVAR(ImpulsoBaseModel):
         if not self.has_exog and exog_future is not None:
             raise ValueError("exog_future provided but model has no exogenous variables")
 
+        rng = np.random.default_rng(seed) if not isinstance(seed, np.random.Generator) else seed
+
         B_draws = self.coefficients  # (C, D, n_vars, n_vars*n_lags)
         intercept_draws = self.intercepts  # (C, D, n_vars)
         n_chains, n_draws, n_vars, _ = B_draws.shape
 
-        # Last n_lags observations — broadcast to (C, D, n_lags, n)
-        y_hist = self.data.endog[-self.n_lags :]  # (p, n)
+        # Density mode: get forecast Cholesky path for shock innovations.
+        L_path = None
+        if include_shock_uncertainty:
+            if rng is None:
+                rng = np.random.default_rng()
+            L_path = self.volatility.forecast_cholesky_path(
+                self.idata.posterior,
+                steps=steps,
+                rng=rng,
+            )  # (C, D, steps, n_vars, n_vars)
+
+        y_hist = self.data.endog[-self.n_lags :]
         y_buffer = np.broadcast_to(y_hist, (n_chains, n_draws, self.n_lags, n_vars)).copy()
 
         forecasts = np.zeros((n_chains, n_draws, steps, n_vars))
 
         for h in range(steps):
-            # Build lag vector: concatenate y[t-1], y[t-2], ..., y[t-p]
-            x_lag = np.concatenate(
-                [y_buffer[:, :, -(lag + 1), :] for lag in range(self.n_lags)], axis=-1
-            )  # (C, D, n*p)
-
+            x_lag = np.concatenate([y_buffer[:, :, -(lag + 1), :] for lag in range(self.n_lags)], axis=-1)
             y_new = intercept_draws + np.einsum("cdij,cdj->cdi", B_draws, x_lag)
 
             if self.has_exog and exog_future is not None:
-                B_exog = self.idata.posterior["B_exog"].values  # (C, D, n, k)
+                B_exog = self.idata.posterior["B_exog"].values
                 y_new = y_new + np.einsum("cdij,j->cdi", B_exog, exog_future[h])
 
+            # Density mode: add shock innovation eps ~ N(0, Sigma_{T+h}).
+            if L_path is not None:
+                L_h = L_path[:, :, h, :, :]  # (C, D, n_vars, n_vars)
+                eps = rng.standard_normal((n_chains, n_draws, n_vars))
+                shock = np.einsum("cdij,cdj->cdi", L_h, eps)
+                y_new = y_new + shock
+
             forecasts[:, :, h, :] = y_new
-            # Roll buffer forward
             y_buffer = np.concatenate([y_buffer[:, :, 1:, :], y_new[:, :, np.newaxis, :]], axis=2)
 
-        # Package into InferenceData
+        mode = "density" if include_shock_uncertainty else "mean"
         forecast_da = xr.DataArray(
             forecasts,
             dims=["chain", "draw", "step", "variable"],
@@ -138,8 +163,7 @@ class FittedVAR(ImpulsoBaseModel):
             name="forecast",
         )
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"forecast": forecast_da}))
-
-        return ForecastResult(idata=idata, steps=steps, var_names=self.var_names)
+        return ForecastResult(idata=idata, steps=steps, var_names=self.var_names, mode=mode)
 
     def set_identification_strategy(self, scheme: IdentificationScheme) -> "IdentifiedVAR":
         """Apply a structural identification scheme.

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -118,10 +118,13 @@ class ForecastResult(VARResultBase):
         idata: ArviZ InferenceData with forecast draws.
         steps: Number of forecast steps.
         var_names: Names of forecasted variables.
+        mode: ``"density"`` or ``"mean"`` — which forecast mode produced
+            this result.
     """
 
     steps: int
     var_names: list[str]
+    mode: str = "density"
 
     def median(self) -> pd.DataFrame:
         """Posterior median forecast."""

--- a/src/impulso/sv/dynamics.py
+++ b/src/impulso/sv/dynamics.py
@@ -48,8 +48,14 @@ class SVDynamics(Protocol):
         posterior: xr.Dataset,
         steps: int,
         rng: np.random.Generator,
+        name_prefix: str = "",
     ) -> np.ndarray:
-        """Draw posterior-predictive log-volatility paths, shape (chains, draws, steps)."""
+        """Draw posterior-predictive log-volatility paths, shape (chains, draws, steps).
+
+        ``name_prefix`` is prepended to every posterior key read (e.g.
+        ``name_prefix="v0_"`` reads ``v0_h``, ``v0_sigma_eta``, …).
+        Default empty prefix preserves the univariate naming.
+        """
         ...
 
 
@@ -79,9 +85,10 @@ class RandomWalk(ImpulsoModel):
         posterior: xr.Dataset,
         steps: int,
         rng: np.random.Generator,
+        name_prefix: str = "",
     ) -> np.ndarray:
-        h_draws = posterior["h"].values
-        sigma_eta_draws = posterior["sigma_eta"].values
+        h_draws = posterior[f"{name_prefix}h"].values
+        sigma_eta_draws = posterior[f"{name_prefix}sigma_eta"].values
         n_chains, n_draws, _ = h_draws.shape
         h_last = h_draws[:, :, -1]
 
@@ -130,11 +137,12 @@ class AR1(ImpulsoModel):
         posterior: xr.Dataset,
         steps: int,
         rng: np.random.Generator,
+        name_prefix: str = "",
     ) -> np.ndarray:
-        h_draws = posterior["h"].values
-        sigma_eta_draws = posterior["sigma_eta"].values
-        phi_draws = posterior["phi"].values
-        alpha_draws = posterior["alpha"].values
+        h_draws = posterior[f"{name_prefix}h"].values
+        sigma_eta_draws = posterior[f"{name_prefix}sigma_eta"].values
+        phi_draws = posterior[f"{name_prefix}phi"].values
+        alpha_draws = posterior[f"{name_prefix}alpha"].values
         n_chains, n_draws, _ = h_draws.shape
         h_prev = h_draws[:, :, -1].copy()
 

--- a/src/impulso/sv/spec.py
+++ b/src/impulso/sv/spec.py
@@ -253,18 +253,13 @@ class StochasticVolatility(ImpulsoBaseModel):
         steps: int,
         rng: np.random.Generator,
     ) -> np.ndarray:
-        """Forecast the per-t Cholesky factor for `steps` ahead.
+        """Forecast the per-t Cholesky factor for ``steps`` ahead.
 
         Each variable's log-vol is extrapolated independently using the
-        configured dynamics; the correlation Cholesky `R_chol` is held
-        constant (Clark-style assumption).
-
-        `SVDynamics.forecast_log_vol` reads bare posterior keys (`h`,
-        `sigma_eta`, and for AR(1) also `phi`/`alpha`), whereas the
-        multivariate-fit posterior stores per-variable hyperparameters
-        under prefixed names (`v{i}_sigma_eta`, ...). For each variable
-        `i` we build a small slice `Dataset` with renamed keys and
-        delegate the extrapolation to `dynamics.forecast_log_vol`.
+        configured dynamics with ``name_prefix=f"v{i}_"`` so the dynamics
+        reads ``{prefix}h``, ``{prefix}sigma_eta``, and its own
+        hyperparameters directly from the full posterior.  The correlation
+        Cholesky ``R_chol`` is held constant (Clark-style assumption).
 
         Args:
             posterior: Dataset with per-variable log-vol paths (`h`)
@@ -276,8 +271,6 @@ class StochasticVolatility(ImpulsoBaseModel):
         Returns:
             `(chains, draws, steps, n_vars, n_vars)`.
         """
-        import xarray as xr
-
         dynamics = self.resolved_dynamics
 
         h = posterior["h"].values  # (C, D, T, n_vars)
@@ -286,17 +279,13 @@ class StochasticVolatility(ImpulsoBaseModel):
 
         h_forecast = np.zeros((n_chains, n_draws, steps, n_vars))
         for i in range(n_vars):
-            slice_posterior = xr.Dataset({
-                "h": (("chain", "draw", "time"), h[:, :, :, i]),
-                "sigma_eta": (("chain", "draw"), posterior[f"v{i}_sigma_eta"].values),
-            })
-            # AR(1) also reads phi, alpha. For RW, only sigma_eta is needed.
-            for extra_var in ("phi", "alpha"):
-                key = f"v{i}_{extra_var}"
-                if key in posterior:
-                    slice_posterior[extra_var] = (("chain", "draw"), posterior[key].values)
-            h_forecast[:, :, :, i] = dynamics.forecast_log_vol(slice_posterior, steps, rng)
-
-        # Combine: L_t = diag(exp(h_t / 2)) @ R_chol for each forecast step.
-        sigma_t = np.exp(h_forecast / 2)  # (C, D, steps, n_vars)
+            h_forecast[:, :, :, i] = dynamics.forecast_log_vol(
+                posterior,
+                steps,
+                rng,
+                name_prefix=f"v{i}_",
+            )
+        # L_t = diag(exp(h_t / 2)) @ R_chol — ponytail: replaced by
+        # _clark_reconstruct once #89 merges.
+        sigma_t = np.exp(h_forecast / 2)
         return sigma_t[:, :, :, :, None] * R_chol[:, :, None, :, :]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,8 @@ def synthetic_sv_idata_2v():
     posterior = xr.Dataset({
         "h": (("chain", "draw", "time", "variable"), h),
         "R_chol": (("chain", "draw", "i", "j"), R_chol),
+        "v0_h": (("chain", "draw", "time"), h[:, :, :, 0]),
+        "v1_h": (("chain", "draw", "time"), h[:, :, :, 1]),
         "v0_mu": (("chain", "draw"), rng.standard_normal((n_chains, n_draws))),
         "v1_mu": (("chain", "draw"), rng.standard_normal((n_chains, n_draws))),
         "v0_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),

--- a/tests/test_density_forecast.py
+++ b/tests/test_density_forecast.py
@@ -1,0 +1,152 @@
+"""Tests for density forecasts (issue #92).
+
+Pin-first: mean-mode regression pins captured against current code BEFORE
+any behaviour change. Then density-mode tests verify the new behaviour.
+"""
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from impulso.data import VARData
+from impulso.fitted import FittedVAR
+from impulso.volatility import Constant
+
+
+@pytest.fixture
+def fitted_constant():
+    """FittedVAR with Constant volatility, deterministic fixture."""
+    rng = np.random.default_rng(42)
+    n_chains, n_draws, n_vars = 2, 50, 2
+    B_raw = rng.standard_normal((n_chains, n_draws, n_vars, n_vars)) * 0.1
+    B_raw[:, :, 0, 0] += 0.5
+    B_raw[:, :, 1, 1] += 0.3
+    B_raw[:, :, 0, 1] += 0.1
+    B_raw[:, :, 1, 0] -= 0.2
+    intercept = rng.standard_normal((n_chains, n_draws, n_vars)) * 0.1
+    intercept[:, :, 0] += 0.1
+    intercept[:, :, 1] -= 0.05
+    sigma_raw = rng.standard_normal((n_chains, n_draws, n_vars, n_vars)) * 0.3
+    sigma_raw[:, :, 0, 0] += 1.5
+    sigma_raw[:, :, 1, 1] += 1.2
+    L_raw = np.tril(sigma_raw)
+    L_raw[:, :, 0, 0] = np.abs(L_raw[:, :, 0, 0])
+    L_raw[:, :, 1, 1] = np.abs(L_raw[:, :, 1, 1])
+    sd = np.abs(rng.standard_normal((n_chains, n_draws, n_vars))) * 0.5 + 0.5
+    L_raw[:, :, range(n_vars), range(n_vars)] = sd
+    posterior = xr.Dataset({
+        "B": (("chain", "draw", "var1", "var2"), B_raw),
+        "intercept": (("chain", "draw", "var1"), intercept),
+        "L": (("chain", "draw", "var1", "var2"), L_raw),
+    })
+    idata = az.InferenceData(posterior=posterior)
+    A1 = np.array([[0.5, 0.1], [-0.2, 0.3]])
+    y = np.zeros((200, 2))
+    y[0] = np.array([0.1, -0.05]) / 0.7
+    for t in range(1, 200):
+        y[t] = np.array([0.1, -0.05]) + A1 @ y[t - 1] + rng.standard_normal(2) * 0.5
+    index = pd.date_range("2000-01-01", periods=200, freq="QS")
+    data = VARData(endog=y, endog_names=["y1", "y2"], index=index)
+    return FittedVAR(
+        idata=idata,
+        n_lags=1,
+        data=data,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+
+
+class TestMeanModeRegressionPin:
+    """Regression pins: mean-mode forecast values captured BEFORE any change.
+
+    These MUST pass against the current code and continue to pass after
+    the refactor when called with include_shock_uncertainty=False.
+    """
+
+    def test_mean_mode_median_pinned(self, fitted_constant):
+        result = fitted_constant.forecast(steps=5, include_shock_uncertainty=False)
+        med = result.median()
+        expected = np.array([
+            [0.236119, -0.062535],
+            [0.204321, -0.119617],
+            [0.189768, -0.134171],
+            [0.181691, -0.129007],
+            [0.174914, -0.118809],
+        ])
+        np.testing.assert_allclose(med.values, expected, rtol=1e-4)
+
+    def test_mean_mode_hdi_pinned(self, fitted_constant):
+        result = fitted_constant.forecast(steps=5, include_shock_uncertainty=False)
+        hdi = result.hdi(0.89)
+        expected_lower = np.array([
+            [0.040915, -0.216668],
+            [-0.085083, -0.308106],
+            [-0.161075, -0.340470],
+            [-0.222975, -0.357058],
+            [-0.229783, -0.412952],
+        ])
+        expected_upper = np.array([
+            [0.373229, 0.115438],
+            [0.415315, 0.080508],
+            [0.430260, 0.088558],
+            [0.414080, 0.094502],
+            [0.435951, 0.055401],
+        ])
+        np.testing.assert_allclose(hdi.lower.values, expected_lower, rtol=1e-4)
+        np.testing.assert_allclose(hdi.upper.values, expected_upper, rtol=1e-4)
+
+
+class TestDensityMode:
+    """Density mode (include_shock_uncertainty=True, default) draws shocks."""
+
+    def test_density_is_default(self, fitted_constant):
+        result = fitted_constant.forecast(steps=5)
+        assert result.mode == "density"
+
+    def test_mean_mode_flag(self, fitted_constant):
+        result = fitted_constant.forecast(steps=5, include_shock_uncertainty=False)
+        assert result.mode == "mean"
+
+    def test_density_hdi_wider_than_mean(self, fitted_constant):
+        result_mean = fitted_constant.forecast(steps=5, include_shock_uncertainty=False)
+        result_density = fitted_constant.forecast(steps=5, include_shock_uncertainty=True, seed=42)
+
+        hdi_mean = result_mean.hdi(0.89)
+        hdi_density = result_density.hdi(0.89)
+
+        width_mean = hdi_mean.upper.values - hdi_mean.lower.values
+        width_density = hdi_density.upper.values - hdi_density.lower.values
+        assert np.all(width_density > width_mean)
+
+    def test_density_widens_with_horizon(self, fitted_constant):
+        result = fitted_constant.forecast(steps=10, include_shock_uncertainty=True, seed=42)
+        hdi = result.hdi(0.89)
+        width = hdi.upper.values - hdi.lower.values
+        assert np.any(width[9] > width[0])
+
+
+class TestSeedReproducibility:
+    """Seed parameter for density forecasts."""
+
+    def test_same_seed_same_result(self, fitted_constant):
+        r1 = fitted_constant.forecast(steps=5, seed=42)
+        r2 = fitted_constant.forecast(steps=5, seed=42)
+        np.testing.assert_array_equal(
+            r1.idata.posterior_predictive["forecast"].values,
+            r2.idata.posterior_predictive["forecast"].values,
+        )
+
+    def test_different_seed_different_result(self, fitted_constant):
+        r1 = fitted_constant.forecast(steps=5, seed=42)
+        r2 = fitted_constant.forecast(steps=5, seed=99)
+        assert not np.array_equal(
+            r1.idata.posterior_predictive["forecast"].values,
+            r2.idata.posterior_predictive["forecast"].values,
+        )
+
+    def test_seed_accepts_generator(self, fitted_constant):
+        rng = np.random.default_rng(42)
+        result = fitted_constant.forecast(steps=5, seed=rng)
+        assert result.median().shape == (5, 2)

--- a/tests/test_fitted.py
+++ b/tests/test_fitted.py
@@ -139,7 +139,7 @@ class TestFittedVARFast:
             data=var_data_2v,
             var_names=["y1", "y2"],
         )
-        result = fitted.forecast(steps=4)
+        result = fitted.forecast(steps=4, include_shock_uncertainty=False)
         med = result.median()
         assert med.shape == (4, 2)
 
@@ -152,7 +152,7 @@ class TestFittedVARFast:
             data=var_data_2v,
             var_names=["y1", "y2"],
         )
-        result = fitted.forecast(steps=4)
+        result = fitted.forecast(steps=4, include_shock_uncertainty=False)
         hdi = result.hdi(prob=0.89)
         assert isinstance(hdi, HDIResult)
         assert hdi.lower.shape == (4, 2)

--- a/tests/test_prefix_forecast.py
+++ b/tests/test_prefix_forecast.py
@@ -1,0 +1,193 @@
+"""Tests for prefix-aware forecast_log_vol (issue #90).
+
+Pin tests: each dynamics forecasts correctly from a multivariate-shaped
+posterior with v{i}_* names, and per-variable results match the equivalent
+bare-name univariate call.
+"""
+
+import numpy as np
+import xarray as xr
+
+
+def _make_univariate_posterior(h_3d, sigma_eta):
+    """Build a minimal univariate-shaped posterior for bare-name calls."""
+    return xr.Dataset({
+        "h": (("chain", "draw", "time"), h_3d),
+        "sigma_eta": (("chain", "draw"), sigma_eta),
+    })
+
+
+def _make_univariate_ar1_posterior(h_3d, sigma_eta, phi, alpha):
+    """Build a minimal univariate AR(1) posterior for bare-name calls."""
+    return xr.Dataset({
+        "h": (("chain", "draw", "time"), h_3d),
+        "sigma_eta": (("chain", "draw"), sigma_eta),
+        "phi": (("chain", "draw"), phi),
+        "alpha": (("chain", "draw"), alpha),
+    })
+
+
+class TestRandomWalkPrefixAware:
+    """RandomWalk.forecast_log_vol reads {prefix}h and {prefix}sigma_eta."""
+
+    def test_accepts_name_prefix(self, synthetic_sv_idata_2v):
+        """forecast_log_vol must accept name_prefix kwarg."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        rng = np.random.default_rng(42)
+        # Should not raise — reads v0_h and v0_sigma_eta.
+        result = rw.forecast_log_vol(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+            name_prefix="v0_",
+        )
+        assert result.shape == (2, 50, 5)
+
+    def test_prefix_result_matches_bare_univariate(self, synthetic_sv_idata_2v):
+        """Calling with name_prefix='v0_' on the multivariate posterior
+        must produce the same result as calling bare on a univariate posterior
+        with the same h and sigma_eta values."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        posterior = synthetic_sv_idata_2v.posterior
+
+        # Bare univariate call with v0's data.
+        h_v0 = posterior["v0_h"].values  # (2, 50, 20)
+        sigma_eta_v0 = posterior["v0_sigma_eta"].values  # (2, 50)
+        uni_posterior = _make_univariate_posterior(h_v0, sigma_eta_v0)
+
+        rng_bare = np.random.default_rng(77)
+        rng_prefix = np.random.default_rng(77)
+
+        result_bare = rw.forecast_log_vol(uni_posterior, steps=5, rng=rng_bare)
+        result_prefix = rw.forecast_log_vol(
+            posterior,
+            steps=5,
+            rng=rng_prefix,
+            name_prefix="v0_",
+        )
+        np.testing.assert_array_equal(result_bare, result_prefix)
+
+    def test_different_prefixes_give_different_results(self, synthetic_sv_idata_2v):
+        """v0_ and v1_ have different sigma_eta, so forecasts must differ."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        rng = np.random.default_rng(42)
+
+        result_v0 = rw.forecast_log_vol(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+            name_prefix="v0_",
+        )
+        rng2 = np.random.default_rng(42)
+        result_v1 = rw.forecast_log_vol(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng2,
+            name_prefix="v1_",
+        )
+        # Different sigma_eta → different paths (with overwhelming probability).
+        assert not np.array_equal(result_v0, result_v1)
+
+    def test_default_empty_prefix_reads_bare_keys(self):
+        """Default name_prefix='' reads bare 'h' and 'sigma_eta'."""
+        from impulso.sv.dynamics import RandomWalk
+
+        rw = RandomWalk()
+        rng = np.random.default_rng(0)
+        h = rng.standard_normal((1, 10, 15)) * 0.3 - 1.0
+        sigma_eta = np.abs(rng.standard_normal((1, 10))) * 0.1
+        posterior = _make_univariate_posterior(h, sigma_eta)
+
+        result = rw.forecast_log_vol(posterior, steps=3, rng=rng)
+        assert result.shape == (1, 10, 3)
+
+
+class TestAR1PrefixAware:
+    """AR1.forecast_log_vol reads {prefix}h, {prefix}sigma_eta, {prefix}phi, {prefix}alpha."""
+
+    @staticmethod
+    def _make_ar1_posterior_2v():
+        """Build a 2-variable multivariate AR(1) posterior with prefixed keys."""
+        rng = np.random.default_rng(99)
+        n_chains, n_draws, T, n_vars = 2, 50, 20, 2
+        h = rng.standard_normal((n_chains, n_draws, T, n_vars)) * 0.3 - 1.0
+        return xr.Dataset({
+            "h": (("chain", "draw", "time", "variable"), h),
+            "v0_h": (("chain", "draw", "time"), h[:, :, :, 0]),
+            "v1_h": (("chain", "draw", "time"), h[:, :, :, 1]),
+            "v0_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
+            "v1_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
+            "v0_phi": (("chain", "draw"), 0.5 + 0.3 * rng.standard_normal((n_chains, n_draws))),
+            "v1_phi": (("chain", "draw"), 0.5 + 0.3 * rng.standard_normal((n_chains, n_draws))),
+            "v0_alpha": (("chain", "draw"), rng.standard_normal((n_chains, n_draws)) * 0.1),
+            "v1_alpha": (("chain", "draw"), rng.standard_normal((n_chains, n_draws)) * 0.1),
+        })
+
+    def test_accepts_name_prefix(self):
+        """forecast_log_vol must accept name_prefix kwarg for AR(1)."""
+        from impulso.sv.dynamics import AR1
+
+        ar1 = AR1()
+        posterior = self._make_ar1_posterior_2v()
+        rng = np.random.default_rng(42)
+        result = ar1.forecast_log_vol(posterior, steps=5, rng=rng, name_prefix="v0_")
+        assert result.shape == (2, 50, 5)
+
+    def test_prefix_result_matches_bare_univariate(self):
+        """Prefix call matches bare univariate call for AR(1)."""
+        from impulso.sv.dynamics import AR1
+
+        ar1 = AR1()
+        posterior = self._make_ar1_posterior_2v()
+
+        h_v0 = posterior["v0_h"].values
+        sigma_eta_v0 = posterior["v0_sigma_eta"].values
+        phi_v0 = posterior["v0_phi"].values
+        alpha_v0 = posterior["v0_alpha"].values
+        uni_posterior = _make_univariate_ar1_posterior(h_v0, sigma_eta_v0, phi_v0, alpha_v0)
+
+        rng_bare = np.random.default_rng(77)
+        rng_prefix = np.random.default_rng(77)
+
+        result_bare = ar1.forecast_log_vol(uni_posterior, steps=5, rng=rng_bare)
+        result_prefix = ar1.forecast_log_vol(posterior, steps=5, rng=rng_prefix, name_prefix="v0_")
+        np.testing.assert_array_equal(result_bare, result_prefix)
+
+
+class TestForecastCholeskyPathUsesPrefix:
+    """forecast_cholesky_path calls dynamics with name_prefix, no fake Dataset."""
+
+    def test_forecast_cholesky_path_uses_prefix(self, synthetic_sv_idata_2v):
+        """forecast_cholesky_path must produce the same result as manually
+        calling forecast_log_vol per variable with the prefix."""
+        from impulso.sv.spec import StochasticVolatility
+
+        sv = StochasticVolatility()
+        rng = np.random.default_rng(42)
+        path = sv.forecast_cholesky_path(
+            synthetic_sv_idata_2v.posterior,
+            steps=5,
+            rng=rng,
+        )
+        assert path.shape == (2, 50, 5, 2, 2)
+
+    def test_no_fake_dataset_in_forecast_cholesky_path(self):
+        """forecast_cholesky_path must not build an xr.Dataset internally.
+        We verify by checking the method does not import xr (except at
+        module level). This is a structural test, not a behavioral one."""
+        import inspect
+
+        from impulso.sv.spec import StochasticVolatility
+
+        source = inspect.getsource(StochasticVolatility.forecast_cholesky_path)
+        # The method should NOT contain xr.Dataset( construction.
+        assert "xr.Dataset(" not in source, (
+            "forecast_cholesky_path still builds a fake xr.Dataset — "
+            "it should call dynamics.forecast_log_vol with name_prefix instead"
+        )


### PR DESCRIPTION
## What

**Breaking** (pre-v0.1 policy): default forecast intervals widen correctly.

- `forecast(steps, include_shock_uncertainty=True, seed=None, exog_future=None)`
- **Density mode** (default): draws shock innovations `ε ~ N(0, Σ_{T+h})` from `forecast_cholesky_path`, giving true posterior-predictive intervals
- **Mean mode** (`include_shock_uncertainty=False`): reproduces previous conditional-mean recursion exactly (regression pinned)
- `seed` accepts `int` or `np.random.Generator` for reproducible density forecasts
- `ForecastResult` gains `mode: "density" | "mean"` attribute

## Depends on

Stacked on #90 (prefix-aware `forecast_log_vol`). Merge #90 first.

## Testing

- Mean-mode median and HDI values pinned against pre-change output
- Density HDI strictly wider than mean HDI at every step
- Density HDI widens with horizon
- Same seed → identical draws; different seeds → different draws
- `seed` accepts Generator
- All 276 fast tests pass

Closes #92.