### PR TITLE
refactor: identify() receives data + n_lags; shared residual reconstruction

### DIFF
--- a/src/impulso/_residuals.py
+++ b/src/impulso/_residuals.py
@@ -1,0 +1,52 @@
+"""Reduced-form residual reconstruction from posterior draws.
+
+Shared by `IdentifiedVAR.historical_decomposition` and identification
+schemes that need residuals (e.g. `ProxySVAR`). Reconstruction from
+`B`/`intercept` draws is cheap and exact, so residuals are never stored
+in the posterior.
+"""
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+    from impulso.data import VARData
+
+
+def reduced_form_residuals(posterior: "xr.Dataset", data: "VARData", n_lags: int) -> np.ndarray:
+    """Reconstruct per-draw reduced-form residuals on the estimation sample.
+
+    Computes `u_t = y_t - intercept - B @ x_lag_t` for every posterior
+    draw, where `x_lag_t` stacks lags 1..n_lags (lag-1 block first). For
+    models with exogenous variables, the `B_exog @ x_exog_t` contribution
+    is subtracted as well.
+
+    Args:
+        posterior: Posterior Dataset holding `B` (chains, draws, n, n*p),
+            `intercept` (chains, draws, n) and, when the model has
+            exogenous variables, `B_exog`.
+        data: The VARData used at fit time.
+        n_lags: Lag order of the fitted VAR.
+
+    Returns:
+        Residual array of shape `(chains, draws, T - n_lags, n_vars)`,
+        time-aligned with `data.index[n_lags:]`.
+    """
+    B_draws = posterior["B"].values  # (C, D, n, n*p)
+    intercept_draws = posterior["intercept"].values  # (C, D, n)
+
+    y = data.endog  # (T, n)
+    T = y.shape[0]
+
+    x_lag = np.concatenate(
+        [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
+        axis=1,
+    )  # (T-p, n*p)
+    y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
+    if data.exog is not None and "B_exog" in posterior:
+        y_hat = y_hat + np.einsum("cdij,tj->cdti", posterior["B_exog"].values, data.exog[n_lags:])
+    y_obs = y[n_lags:]
+    return y_obs[np.newaxis, np.newaxis, :, :] - y_hat

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1,5 +1,7 @@
 """Identification schemes for structural VAR analysis."""
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import xarray as xr
 from pydantic import Field, PrivateAttr
@@ -7,6 +9,9 @@ from pydantic import Field, PrivateAttr
 from impulso._base import ImpulsoModel
 from impulso._linalg import sigma_from_cholesky
 from impulso._ma import compute_ma_phi
+
+if TYPE_CHECKING:
+    from impulso.data import VARData
 
 
 class Cholesky(ImpulsoModel):
@@ -27,6 +32,8 @@ class Cholesky(ImpulsoModel):
         L: np.ndarray,
         var_names: list[str],
         posterior: "xr.Dataset | None" = None,
+        data: "VARData | None" = None,
+        n_lags: int | None = None,
     ) -> np.ndarray:
         """Apply Cholesky identification.
 
@@ -39,11 +46,13 @@ class Cholesky(ImpulsoModel):
             L: Lower-triangular Cholesky factor, shape (chains, draws, n_vars, n_vars).
             var_names: Variable names in the data's natural order.
             posterior: Unused. Accepted for Protocol uniformity.
+            data: Unused. Accepted for Protocol uniformity.
+            n_lags: Unused. Accepted for Protocol uniformity.
 
         Returns:
             Structural shock matrix, shape (chains, draws, n_vars, n_vars).
         """
-        del posterior  # unused
+        del posterior, data, n_lags  # unused
 
         # Fast path: ordering matches data — identify is a no-op.
         if list(self.ordering) == list(var_names):
@@ -91,6 +100,8 @@ class SignRestriction(ImpulsoModel):
         L: np.ndarray,
         var_names: list[str],
         posterior: "xr.Dataset | None" = None,
+        data: "VARData | None" = None,
+        n_lags: int | None = None,
     ) -> np.ndarray:
         """Apply sign-restriction identification.
 
@@ -101,6 +112,8 @@ class SignRestriction(ImpulsoModel):
                 the multi-horizon check needs the VAR coefficients `B` from
                 the posterior. Ignored for impact-only restrictions
                 (`restriction_horizon == 0`).
+            data: Unused. Accepted for Protocol uniformity.
+            n_lags: Unused. Accepted for Protocol uniformity.
 
         Returns:
             Structural shock matrix, shape (chains, draws, n_vars, n_vars).
@@ -109,6 +122,7 @@ class SignRestriction(ImpulsoModel):
             via the `sign_restriction_acceptance_rate` attribute on the
             wrapping IdentifiedVAR's posterior (set by the pipeline).
         """
+        del data, n_lags  # unused
         from scipy.stats import special_ortho_group
 
         n_chains, n_draws, n_vars, _ = L.shape

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -110,7 +110,9 @@ class IdentifiedVAR(ImpulsoBaseModel):
         else:
             t = self._resolve_at(at)
             L = self.volatility.cholesky_at(self.idata.posterior, t=t)
-            P = self.scheme.identify(L, self.var_names, posterior=self.idata.posterior)
+            P = self.scheme.identify(
+                L, self.var_names, posterior=self.idata.posterior, data=self.data, n_lags=self.n_lags
+            )
             result = xr.DataArray(
                 P,
                 dims=["chain", "draw", "response", "shock"],
@@ -125,6 +127,12 @@ class IdentifiedVAR(ImpulsoBaseModel):
         rate = getattr(self.scheme, "_last_acceptance_rate", None)
         if isinstance(rate, float) and rate < 1.0:
             result.attrs["sign_restriction_acceptance_rate"] = rate
+
+        # Attach any scheme-specific diagnostics (e.g. ProxySVAR first-stage
+        # strength) the same way — identify() stashes them, we surface them.
+        diagnostics = getattr(self.scheme, "_last_diagnostics", None)
+        if diagnostics:
+            result.attrs.update(diagnostics)
 
         object.__setattr__(self, cache_attr, result)
         return result
@@ -176,7 +184,11 @@ class IdentifiedVAR(ImpulsoBaseModel):
         P_path = np.zeros_like(L_path)
         for t in range(T):
             P_path[:, :, t, :, :] = self.scheme.identify(
-                L_path[:, :, t, :, :], self.var_names, posterior=self.idata.posterior
+                L_path[:, :, t, :, :],
+                self.var_names,
+                posterior=self.idata.posterior,
+                data=self.data,
+                n_lags=self.n_lags,
             )
         return P_path
 
@@ -301,20 +313,10 @@ class IdentifiedVAR(ImpulsoBaseModel):
         Returns:
             HistoricalDecompositionResult.
         """
-        B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
-        intercept_draws = self.idata.posterior["intercept"].values  # (C, D, n)
+        from impulso._residuals import reduced_form_residuals
 
-        y = self.data.endog  # (T, n)
-        T = y.shape[0]
         n_lags = self.n_lags
-
-        x_lag = np.concatenate(
-            [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
-            axis=1,
-        )  # (T-p, n*p)
-        y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
-        y_obs = y[n_lags:]
-        resid = y_obs[np.newaxis, np.newaxis, :, :] - y_hat
+        resid = reduced_form_residuals(self.idata.posterior, self.data, n_lags)
 
         use_per_t = self.volatility.is_time_varying and at in (None, "all")
         if use_per_t:

--- a/src/impulso/protocols.py
+++ b/src/impulso/protocols.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     import pytensor.tensor as pt
     import xarray as xr
 
+    from impulso.data import VARData
+
 
 @runtime_checkable
 class Prior(Protocol):
@@ -34,6 +36,8 @@ class IdentificationScheme(Protocol):
         L: np.ndarray,
         var_names: list[str],
         posterior: "xr.Dataset | None" = None,
+        data: "VARData | None" = None,
+        n_lags: int | None = None,
     ) -> np.ndarray:
         """Identify the structural shock matrix from a Cholesky factor.
 
@@ -50,6 +54,13 @@ class IdentificationScheme(Protocol):
                 may ignore this argument. Schemes that need `posterior`
                 for context but receive `None` should raise a clear
                 `ValueError`.
+            data: The VARData used at fit time. Optional; provided by the
+                pipeline so schemes that need the observed sample — e.g.
+                `ProxySVAR`, which reconstructs reduced-form residuals and
+                aligns an instrument by date — can reach for it. Schemes
+                that only need L may ignore this argument.
+            n_lags: Lag order of the fitted VAR. Provided alongside `data`
+                because residual reconstruction needs it.
 
         Returns:
             Structural shock matrix array of shape (chains, draws, n_vars, n_vars).

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -41,6 +41,8 @@ class TestIdentificationSchemeNewSignature:
 
         sig = inspect.signature(IdentificationScheme.identify)
         params = list(sig.parameters.values())
-        # self, L, var_names, posterior=None
-        assert [p.name for p in params] == ["self", "L", "var_names", "posterior"]
+        # self, L, var_names, posterior=None, data=None, n_lags=None
+        assert [p.name for p in params] == ["self", "L", "var_names", "posterior", "data", "n_lags"]
         assert params[3].default is None
+        assert params[4].default is None
+        assert params[5].default is None

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -1,0 +1,81 @@
+"""Tests for reduced-form residual reconstruction (`_residuals.py`)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from impulso._residuals import reduced_form_residuals
+from impulso.data import VARData
+
+
+@pytest.fixture
+def var_data_2v_short():
+    """Small 2-var VARData matching the synthetic_idata_2v posterior shapes."""
+    rng = np.random.default_rng(7)
+    T, n = 30, 2
+    y = np.zeros((T, n))
+    for t in range(1, T):
+        y[t] = 0.5 * y[t - 1] + rng.standard_normal(n) * 0.1
+    index = pd.date_range("2000-01-01", periods=T, freq="QS")
+    return VARData(endog=y, endog_names=["y1", "y2"], index=index)
+
+
+class TestReducedFormResiduals:
+    def test_shape(self, synthetic_idata_2v, var_data_2v_short):
+        resid = reduced_form_residuals(synthetic_idata_2v.posterior, var_data_2v_short, n_lags=1)
+        assert resid.shape == (2, 50, 29, 2)  # (C, D, T - p, n)
+
+    def test_golden_equality_with_inline_computation(self, synthetic_idata_2v, var_data_2v_short):
+        """Helper reproduces the inline computation it replaced in
+        historical_decomposition, exactly."""
+        posterior = synthetic_idata_2v.posterior
+        n_lags = 1
+        B_draws = posterior["B"].values
+        intercept_draws = posterior["intercept"].values
+        y = var_data_2v_short.endog
+        T = y.shape[0]
+        x_lag = np.concatenate(
+            [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
+            axis=1,
+        )
+        y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
+        expected = y[n_lags:][np.newaxis, np.newaxis, :, :] - y_hat
+
+        actual = reduced_form_residuals(posterior, var_data_2v_short, n_lags)
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_zero_residuals_when_posterior_matches_dgp(self):
+        """Data generated exactly from (intercept, B) gives zero residuals."""
+        import arviz as az
+        import xarray as xr
+
+        rng = np.random.default_rng(0)
+        T, n = 40, 2
+        B_true = np.array([[0.5, 0.1], [0.0, 0.4]])
+        c_true = np.array([0.2, -0.1])
+        y = np.zeros((T, n))
+        for t in range(1, T):
+            y[t] = c_true + B_true @ y[t - 1]
+        y[0] = rng.standard_normal(n)
+        # Re-simulate with the random start propagated
+        for t in range(1, T):
+            y[t] = c_true + B_true @ y[t - 1]
+
+        data = VARData(
+            endog=y,
+            endog_names=["a", "b"],
+            index=pd.date_range("2000-01-01", periods=T, freq="MS"),
+        )
+        posterior = xr.Dataset({
+            "B": xr.DataArray(
+                np.broadcast_to(B_true, (1, 3, n, n)).copy(),
+                dims=["chain", "draw", "var", "coeff"],
+            ),
+            "intercept": xr.DataArray(
+                np.broadcast_to(c_true, (1, 3, n)).copy(),
+                dims=["chain", "draw", "var"],
+            ),
+        })
+        idata = az.InferenceData(posterior=posterior)
+        resid = reduced_form_residuals(idata.posterior, data, n_lags=1)
+        np.testing.assert_allclose(resid, 0.0, atol=1e-12)


### PR DESCRIPTION
Closes #98. **PR 1 of 3** in the WS3 `ProxySVAR` stack (plan §4.1) — followed by #99 (ProxySVAR) and #100 (tutorial).

## What

- `IdentificationScheme.identify` gains `data: VARData | None = None` and `n_lags: int | None = None` so schemes can reconstruct reduced-form residuals and align an instrument by date. `Cholesky` and `SignRestriction` accept and ignore them. **Pre-v0.1 breaking change** to the protocol signature.
- `IdentifiedVAR.shock_matrix` / `_identify_per_t` thread the new params through, and a generic `_last_diagnostics` side channel lets any scheme attach diagnostics to `shock_matrix().attrs` (mirrors the existing sign-restriction acceptance-rate pattern).
- Residual reconstruction extracted from `historical_decomposition` into `src/impulso/_residuals.py::reduced_form_residuals(posterior, data, n_lags)`; HD refactored through it. The helper handles `B_exog` — the inline code it replaces did not (latent bug for exog models).

**Rejected alternative** (per the plan): registering residuals as a `pm.Deterministic` — stores `(C, D, T, n)` in every posterior forever and still doesn't solve date alignment; reconstruction from draws is cheap and exact.

## Tests

- Golden equality: the helper reproduces the inline computation it replaced, exactly (`synthetic_idata_2v`).
- Exact-DGP zero-residual check.
- Protocol signature test updated; all existing scheme tests pass unmodified.

`make check` clean; 301 fast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2A2U9JSQHmhyf7JCs3FUX