### PR TITLE
fix(docs): render Quarto cell-options as MyST-NB metadata, not literal comments

### DIFF
--- a/docs/tutorials/monetary-policy.py
+++ b/docs/tutorials/monetary-policy.py
@@ -77,10 +77,7 @@ from impulso.samplers import NUTSSampler
 # We do not difference the data. {cite:t}`simsStockWatson1990` showed that Bayesian inference in levels VARs is valid regardless of whether the series have unit roots, and differencing can distort impulse responses when variables are cointegrated.
 # :::
 
-# %%
-# | code-fold: true
-# | label: data-series
-# | fig-cap: "The three time series of output, prices, and rate."
+# %% mystnb={"figure": {"caption": "The three time series of output, prices, and rate.", "name": "data-series"}} tags=["remove-input"]
 df = pd.read_csv("data/monetary_policy.csv", index_col="date", parse_dates=True)
 df = df.loc[:"2007-12"]
 df.describe().round(2)
@@ -194,8 +191,7 @@ ordering_c = ["rate", "output", "prices"]
 identified_chol_c = fitted.set_identification_strategy(Cholesky(ordering=ordering_c))
 irf_chol_c = identified_chol_c.impulse_response(horizon=48)
 
-# %%
-# | code-fold: true
+# %% tags=["remove-input"]
 
 response_vars = ["output", "prices", "rate"]
 response_labels = {
@@ -292,8 +288,7 @@ print(
     else f"Acceptance rate: {acceptance_rate}"
 )
 
-# %%
-# | code-fold: true
+# %% tags=["remove-input"]
 
 irf_sr_h6 = identified_sr_h6.impulse_response(horizon=48)
 irf_sr_data = irf_sr_h6.idata.posterior_predictive["irf"]
@@ -369,8 +364,7 @@ for h in [0, 6, 12]:
     }
     print(f"h={h:>2}: acceptance rate = {ar:.1%}")
 
-# %%
-# | code-fold: true
+# %% tags=["remove-input"]
 
 fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
 
@@ -405,8 +399,7 @@ fig.tight_layout()
 #
 # We now place the Cholesky baseline (ordering A) and the sign restriction baseline ($h = 6$) side by side. This is the payoff of running both approaches on the same data: we can see directly how different identifying assumptions lead to different conclusions about the same economic question.
 
-# %%
-# | code-fold: true
+# %% tags=["remove-input"]
 
 fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
 
@@ -492,8 +485,7 @@ for i, resp in enumerate(response_vars):
 axes[-1].set_xlabel("Months")
 fig.tight_layout()
 
-# %%
-# | code-fold: true
+# %% tags=["remove-input"]
 
 band_rows = []
 for horizon_month in [12, 24, 48]:

--- a/docs/tutorials/stochastic-volatility.py
+++ b/docs/tutorials/stochastic-volatility.py
@@ -64,10 +64,7 @@ print(inflation.tail())
 # %% [markdown]
 # The resulting series is monthly CPI inflation in percent. It starts in February 1965, one month after the raw CPI series begins, and runs through the most recent CPI release.
 
-# %%
-# | code-fold: true
-# | label: raw-inflation
-# | fig-cap: "US monthly CPI inflation and a 12-month rolling standard deviation."
+# %% mystnb={"figure": {"caption": "US monthly CPI inflation and a 12-month rolling standard deviation.", "name": "raw-inflation"}} tags=["remove-input"]
 rolling_window = 12
 rolling_sd = inflation.rolling(rolling_window).std()
 
@@ -143,18 +140,14 @@ fitted = StochasticVolatility(dynamics="random_walk").fit(data, sampler=sampler)
 #
 # `fitted.volatility()` returns a `VolatilityResult` whose `.plot()` method shows the posterior median of $\exp(h_t / 2)$ together with a highest-density interval.
 
-# %%
-# | label: vol-path
-# | fig-cap: "Posterior conditional SD of US CPI inflation from the random-walk SV fit."
+# %% mystnb={"figure": {"caption": "Posterior conditional SD of US CPI inflation from the random-walk SV fit.", "name": "vol-path"}}
 fig = fitted.volatility().plot()
 fig.tight_layout()
 
 # %% [markdown]
 # To see how the volatility path lines up with the macroeconomic narrative we overlay NBER recession dates that fall within the sample. These are the recessions dated by the NBER Business Cycle Dating Committee from 1965 onward.
 
-# %%
-# | label: vol-path-nber
-# | fig-cap: "Posterior conditional SD with NBER recessions shaded."
+# %% mystnb={"figure": {"caption": "Posterior conditional SD with NBER recessions shaded.", "name": "vol-path-nber"}}
 fig = fitted.volatility().plot()
 ax = plt.gcf().axes[0]
 nber_recessions = [
@@ -178,9 +171,7 @@ fig.tight_layout()
 #
 # How does the SV posterior compare with the naive 12-month rolling estimator we plotted earlier? We overlay them on the same axes.
 
-# %%
-# | label: vol-vs-rolling
-# | fig-cap: "Posterior median conditional SD from the SV model (blue) versus a 12-month rolling SD (grey)."
+# %% mystnb={"figure": {"caption": "Posterior median conditional SD from the SV model (blue) versus a 12-month rolling SD (grey).", "name": "vol-vs-rolling"}}
 posterior_sd = fitted.volatility().median()
 
 fig, ax = plt.subplots(figsize=(9, 4))
@@ -241,9 +232,7 @@ fig_ar1.tight_layout()
 #
 # With the random-walk SV fit we can generate a density forecast. For each posterior draw we simulate forward 12 months by evolving $h_{T+h}$ as $h_T + \sum_{s=1}^{h} \sigma_\eta \eta_s$ and then drawing $y_{T+h} = \mu + \exp(h_{T+h}/2)\, \varepsilon_{T+h}$.
 
-# %%
-# | label: sv-forecast
-# | fig-cap: "12-step density forecast from the random-walk SV model."
+# %% mystnb={"figure": {"caption": "12-step density forecast from the random-walk SV model.", "name": "sv-forecast"}}
 forecast = fitted.forecast(steps=12)
 fig_fcst = forecast.plot()
 fig_fcst.tight_layout()


### PR DESCRIPTION
## Problem

The `.qmd → jupytext .py` migration (#105) left **Quarto cell-options** in the tutorial notebooks:

```python
# %%
# | code-fold: true
# | label: raw-inflation
# | fig-cap: "US monthly CPI inflation and a 12-month rolling standard deviation."
```

MyST-NB doesn't understand Quarto directives, so these lines were treated as ordinary Python comments and **printed verbatim into the rendered code blocks** instead of being actioned as figure captions / labels / code-folding.

## Fix

Translate each to MyST-NB cell metadata on the `# %%` line:

| Quarto | MyST-NB |
|---|---|
| `# \| label:` + `# \| fig-cap:` | `mystnb={"figure": {"caption": …, "name": …}}` — a numbered, `{numref}`-referenceable figure |
| `# \| code-fold: true` | `tags=["remove-input"]` |

`remove-input` is MyST-NB-native; `hide-input` (the closer analogue of `code-fold`) would need `sphinx-togglebutton`, which isn't installed — so `remove-input` is the dependency-free choice and honours the author's "fold this boilerplate" intent.

## Scope

- **`stochastic-volatility.py`** — 5 cells (the ones originally reported)
- **`monetary-policy.py`** — 6 cells (identical defect)

Legitimate Markdown table rows (also `# |`, but inside `# %% [markdown]` cells) are left untouched.

## Validation

A minimal Sphinx + MyST-NB build confirms the rendered output: caption renders as "Fig. 1", the input cell is removed, `{numref}` resolves, and no raw `# |` text leaks. All figure labels were verified to be cosmetic (no existing cross-references), so figure numbering just works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jak7ih2sTx12ugFuCrzFYE