### PR TITLE
chore(release): v0.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "impulso"
-version = "0.0.6"
+version = "0.0.7"
 description = "Bayesian Vector Autoregression (VAR) in Python."
 authors = [{ name = "Thomas Pinder", email = "tompinder@live.co.uk" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "impulso"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
Release v0.0.7. Version-only bump (`pyproject.toml` + `uv.lock`).

Notable changes since v0.0.6:

- feat: conjugate NIW VAR estimator + Lenza–Primiceri (2020) tutorial (#115)
- feat: ProxySVAR external-instrument identification + Känzig (2021) tutorial (#110)
- feat: density forecasts with `include_shock_uncertainty` and seed (#96)
- feat: prefix-aware `forecast_log_vol` (#94)
- feat: memoised `shock_matrix` query; IRF/FEVD/HD refactored through it (#95)
- refactor: `identify()` receives data + n_lags; shared residual reconstruction (#101)
- docs: migrate documentation to Sphinx + MyST-NB, Shibuya theme, autosummary API, jupytext notebooks
- build(deps): CI action bumps (checkout, cache, deploy-pages, codecov, etc.)

Merging to `main` then publishing a GitHub Release tagged `v0.0.7` triggers `release-main` → PyPI publish.

Local verification: `make check` clean; `pytest -m "not slow"` → 395 passed.