### PR TITLE
feat: PyMC interop primitives — dynamic multipliers, labelled posteriors, retained model

### DIFF
--- a/.github/workflows/full-render-notebooks.yml
+++ b/.github/workflows/full-render-notebooks.yml
@@ -28,6 +28,19 @@ jobs:
       - name: Register Jupyter kernel
         run: uv run python -m ipykernel install --user --name python3 --display-name "Python 3"
 
+      - name: Restore notebook execution cache
+        # Same accumulate-always cache as main.yml: the Sunday full render
+        # warms `.jupyter_cache`, so the next production deploy reuses real
+        # figures instead of re-executing hours of MCMC (or erroring out).
+        uses: actions/cache@v6
+        with:
+          path: |
+            docs/_build/.jupyter_cache
+            docs/_build/.jupyter_cache_ci
+          key: jupyter-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            jupyter-cache-
+
       - name: Full render (real MCMC, warnings as errors)
         run: uv run sphinx-build -W --keep-going -b html docs docs/_build/html
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,10 +113,23 @@ jobs:
             make docs-ci
           fi
 
-      - name: Upload docs artifact
+      - name: Upload docs artifact (production, full render only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
+
+      - name: Upload smoke-render artifact for PR review
+        # Plain artifact, downloadable from the run page. NEVER a Pages
+        # artifact: GitHub Pages "preview" deployments are unsupported on
+        # this plan and silently deploy to the production URL, which is how
+        # smoke renders kept replacing the published docs.
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-smoke-render
+          path: docs/_build/html
+          retention-days: 7
 
   docs-linkcheck:
     runs-on: ubuntu-latest
@@ -133,23 +146,6 @@ jobs:
 
       - name: Check external links (no notebook execution)
         run: uv run --group docs sphinx-build -b linkcheck -D nb_execution_mode=off docs docs/_build/linkcheck
-
-  deploy-docs-preview:
-    if: github.event_name == 'pull_request'
-    needs: build-docs
-    runs-on: ubuntu-latest
-    concurrency:
-      group: docs-preview-${{ github.head_ref }}
-      cancel-in-progress: true
-    environment:
-      name: docs-preview
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy preview
-        id: deployment
-        uses: actions/deploy-pages@v5
-        with:
-          preview: true
 
   deploy-docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     # Full render on main executes real MCMC; smoke render on PRs is fast.
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Check out
         uses: actions/checkout@v7

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,6 +35,10 @@ Lower-triangular Cholesky factor of the time-`t` structural-shock covariance: `�
 **Impulse response function (IRF)**:
 The dynamic response of each variable to a unit structural shock at horizons `0..h`. Computed from the reduced-form lag matrices `A_1, ..., A_p` and the structural shock matrix `B`. With a stochastic volatility process, IRFs depend on the shock period; the `at` parameter on `IdentifiedVAR.impulse_response` selects which time slice.
 
+**Dynamic multiplier**:
+The response of each endogenous variable to a unit impulse in an *exogenous* regressor at horizons `0..h`: `Psi_h = Phi_h @ B_exog`. Shares the moving-average coefficients `Phi_h` with the IRF, but needs no identification scheme — exogenous regressors are exogenous by assumption — so it lives on `FittedVAR`, not `IdentifiedVAR`, and takes no `at`. The cumulative variant is the response to a permanent unit *step* rather than a one-off impulse. All dynamics come from the endogenous lag structure; `B_exog` enters contemporaneously and carries no lags of its own.
+_Avoid_: "exogenous IRF" — IRF is reserved for responses to identified structural shocks.
+
 **at**:
 The time-index parameter on time-varying queries (`impulse_response(at=...)`, `fevd(at=...)`). Accepts an integer `t`, the literal `"last"` (most recent), `"all"` (full T-axis returned in the result), or `None` (default; resolves to `"last"` for stochastic volatility, ignored for constant volatility).
 
@@ -61,6 +65,7 @@ _Avoid_: "stochastic volatility" — the break is deterministic given its hyperp
 - A **FittedVAR** plus an **identification scheme** produces an **IdentifiedVAR**.
 - An **identification scheme** consumes an `L_t` (queried from the volatility process) and produces a structural shock matrix `B`.
 - An **IdentifiedVAR** computes **IRFs**, FEVDs, and historical decompositions by asking the volatility process for `L_t` at the requested `at`, then applying the identification scheme.
+- A **FittedVAR** fitted with exogenous regressors computes **dynamic multipliers** on its own; no identification scheme is involved, because the driver is already exogenous.
 - A **stochastic volatility** can plug into a **VAR** as its volatility process *or* be fitted standalone on a univariate series.
 - A **VAR** is estimated by NUTS; a **ConjugateVAR** is estimated analytically with a Metropolis step on hyperparameters. Both produce a **FittedVAR**.
 - A **ConjugateVAR** carries an **NIW prior** and optionally a **deterministic volatility break**; a **VAR** carries a **MinnesotaPrior** and a **PyMC volatility process** (`PyMCVolatilityProcess`, the `build_pymc_latent` extension of the `VolatilityProcess` query surface). Each estimator's fields accept only its compatible components, enforced by types + validators rather than a builder.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ VARData → VAR.fit() → FittedVAR → .set_identification_strategy() → Ident
 - **Impulse response functions** (IRFs) with uncertainty quantification
 - **Forecast error variance decomposition** (FEVD)
 - **Historical decomposition** of variables into structural shocks
+- **Dynamic multipliers**: Response of endogenous variables to exogenous (VARX) drivers
 - **Extensible protocols**: Plug in custom priors, samplers, and identification schemes
 - **Type-safe**: Frozen Pydantic models with full type hints
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,3 +151,26 @@ os.environ["IMPULSO_DOCS_BUILD"] = "1"
 # Smoke-render flag for CI (mirrors the old Quarto `ci` parameter). Tutorials
 # read this to shrink MCMC when set.
 os.environ.setdefault("IMPULSO_DOCS_CI", "0")
+
+# -- Render-mode stamp --------------------------------------------------------
+# Belt-and-braces against smoke renders masquerading as the production docs:
+# smoke builds carry a visible banner, and every HTML build writes
+# `render-mode.txt` at the site root so what is actually deployed can be
+# checked with `curl <site>/render-mode.txt`.
+if _smoke_render:
+    html_theme_options["announcement"] = (
+        "Smoke render: MCMC is shrunk for CI speed, so figures and diagnostics "
+        "are not publication-fidelity. The production docs are built with full sampling."
+    )
+
+
+def setup(app):
+    """Register the render-mode marker hook."""
+
+    def _write_render_mode(app, exception):
+        if exception is None and app.builder.name == "html":
+            mode = "smoke" if _smoke_render else "full"
+            with open(os.path.join(app.outdir, "render-mode.txt"), "w") as fh:
+                fh.write(mode + "\n")
+
+    app.connect("build-finished", _write_render_mode)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,6 +14,7 @@ fitted
 identified
 identification
 results
+primitives
 protocols
 plotting
 ```

--- a/docs/reference/plotting.md
+++ b/docs/reference/plotting.md
@@ -8,6 +8,7 @@
    :nosignatures:
 
    plot_forecast
+   plot_dynamic_multiplier
    plot_irf
    plot_fevd
    plot_historical_decomposition

--- a/docs/reference/primitives.md
+++ b/docs/reference/primitives.md
@@ -1,0 +1,16 @@
+# Primitives
+
+Moving-average building blocks shared by the IRF, FEVD, and
+dynamic-multiplier machinery, published for downstream libraries that
+compose with Impulso posteriors.
+
+```{eval-rst}
+.. currentmodule:: impulso
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   compute_ma_phi
+   lag_matrices
+```

--- a/docs/reference/results.md
+++ b/docs/reference/results.md
@@ -9,6 +9,7 @@
 
    VARResultBase
    ForecastResult
+   DynamicMultiplierResult
    IRFResult
    FEVDResult
    HistoricalDecompositionResult

--- a/docs/tutorials/conjugate-var.py
+++ b/docs/tutorials/conjugate-var.py
@@ -159,7 +159,15 @@ print(f"conjugate fit wall-clock                  = {conjugate_seconds:.2f} s")
 
 # %%
 if ci:
-    sampler = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=0)
+    sampler = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=0,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sampler = NUTSSampler(draws=1000, tune=1500, chains=2, cores=1, random_seed=0)
 

--- a/docs/tutorials/monetary-policy.py
+++ b/docs/tutorials/monetary-policy.py
@@ -281,7 +281,7 @@ scheme_h6 = SignRestriction(
 )
 
 identified_sr_h6 = fitted.set_identification_strategy(scheme_h6)
-acceptance_rate = identified_sr_h6.idata.posterior.attrs.get("sign_restriction_acceptance_rate", "N/A")
+acceptance_rate = identified_sr_h6.shock_matrix().attrs.get("sign_restriction_acceptance_rate", "N/A")
 print(
     f"Acceptance rate: {acceptance_rate:.1%}"
     if isinstance(acceptance_rate, float)
@@ -356,7 +356,7 @@ for h in [0, 6, 12]:
         random_seed=42,
     )
     ident = fitted.set_identification_strategy(scheme)
-    ar = ident.idata.posterior.attrs.get("sign_restriction_acceptance_rate", float("nan"))
+    ar = ident.shock_matrix().attrs.get("sign_restriction_acceptance_rate", float("nan"))
     results_sr[h] = {
         "identified": ident,
         "irf": ident.impulse_response(horizon=48),

--- a/docs/tutorials/monetary-policy.py
+++ b/docs/tutorials/monetary-policy.py
@@ -110,7 +110,15 @@ fig.tight_layout()
 
 # %%
 if ci:
-    sampler = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=123)
+    sampler = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=123,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sampler = NUTSSampler(
         draws=1500,

--- a/docs/tutorials/proxy-svar.py
+++ b/docs/tutorials/proxy-svar.py
@@ -141,7 +141,15 @@ print(f"First stage: F = {first_stage_f(instrument.values, U_ols[:, 0]):.2f}, "
 
 # %%
 if ci:
-    sampler = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=42)
+    sampler = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=42,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sampler = NUTSSampler(
         draws=1000,
@@ -250,7 +258,15 @@ core = ["real_oil_price", "world_oil_production", "us_ip", "us_cpi"]
 data_sv = VARData(endog=data_df[core].values, endog_names=core, index=data_df.index)
 
 if ci:
-    sv_sampler = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=42)
+    sv_sampler = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=42,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sv_sampler = NUTSSampler(
         draws=500,

--- a/docs/tutorials/stochastic-volatility.py
+++ b/docs/tutorials/stochastic-volatility.py
@@ -121,7 +121,15 @@ fig.tight_layout()
 data = SVData.from_series(inflation, name="inflation")
 
 if ci:
-    sampler = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=123)
+    sampler = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=123,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sampler = NUTSSampler(
         draws=1500,
@@ -209,7 +217,15 @@ fig.tight_layout()
 
 # %%
 if ci:
-    sampler_ar1 = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=321)
+    sampler_ar1 = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=321,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sampler_ar1 = NUTSSampler(
         draws=1500,
@@ -251,7 +267,15 @@ from impulso.identification import Cholesky
 var_data = VARData.from_df(df, endog=["output", "prices", "rate"])
 
 if ci:
-    sampler_var = NUTSSampler(draws=10, tune=50, chains=1, cores=1, random_seed=7)
+    sampler_var = NUTSSampler(
+        draws=50,
+        tune=500,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=7,
+        nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
+    )
 else:
     sampler_var = NUTSSampler(
         draws=500,

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -1,8 +1,38 @@
 """Impulso: Bayesian Vector Autoregression in Python."""
 
+from typing import TYPE_CHECKING
+
 from impulso._lag_selection import select_lag_order
 from impulso.data import VARData
 from impulso.spec import VAR
+
+if TYPE_CHECKING:
+    from impulso._linalg import lag_matrices
+    from impulso._ma import compute_ma_phi
+    from impulso.conjugate import ConjugateVAR
+    from impulso.conjugate_volatility import ConjugateVolatility, PandemicBreak
+    from impulso.fitted import FittedVAR
+    from impulso.identification import Cholesky, ProxySVAR, SignRestriction
+    from impulso.identified import IdentifiedVAR
+    from impulso.priors import MinnesotaPrior, NIWPrior
+    from impulso.protocols import VolatilityProcess
+    from impulso.results import (
+        DynamicMultiplierResult,
+        FEVDResult,
+        ForecastResult,
+        HDIResult,
+        HistoricalDecompositionResult,
+        IRFResult,
+        LagOrderResult,
+        SVForecastResult,
+        VolatilityResult,
+    )
+    from impulso.samplers import NUTSSampler
+    from impulso.sv.data import SVData
+    from impulso.sv.fitted import FittedSV
+    from impulso.sv.priors import SVDefaultPrior
+    from impulso.sv.spec import StochasticVolatility
+    from impulso.volatility import Constant
 
 __all__ = [
     "VAR",

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "ConjugateVAR",
     "ConjugateVolatility",
     "Constant",
+    "DynamicMultiplierResult",
     "FEVDResult",
     "FittedSV",
     "FittedVAR",
@@ -32,7 +33,9 @@ __all__ = [
     "VARData",
     "VolatilityProcess",
     "VolatilityResult",
+    "compute_ma_phi",
     "enable_runtime_checks",
+    "lag_matrices",
     "select_lag_order",
 ]
 
@@ -52,6 +55,7 @@ def __getattr__(name: str):
         "PandemicBreak": "impulso.conjugate_volatility",
         "NUTSSampler": "impulso.samplers",
         "ForecastResult": "impulso.results",
+        "DynamicMultiplierResult": "impulso.results",
         "IRFResult": "impulso.results",
         "FEVDResult": "impulso.results",
         "HistoricalDecompositionResult": "impulso.results",
@@ -65,6 +69,8 @@ def __getattr__(name: str):
         "SVForecastResult": "impulso.results",
         "Constant": "impulso.volatility",
         "VolatilityProcess": "impulso.protocols",
+        "compute_ma_phi": "impulso._ma",
+        "lag_matrices": "impulso._linalg",
     }
     if name in _lazy_imports:
         import importlib

--- a/src/impulso/_linalg.py
+++ b/src/impulso/_linalg.py
@@ -24,3 +24,40 @@ def sigma_from_cholesky(L: np.ndarray) -> np.ndarray:
         shape as *L*.
     """
     return np.einsum("...ij,...kj->...ik", L, L)
+
+
+def lag_matrices(B: np.ndarray, n_lags: int) -> list[np.ndarray]:
+    """Split a stacked VAR coefficient matrix into its per-lag blocks.
+
+    Impulso stores the reduced-form coefficients as a single matrix whose
+    trailing axis concatenates the lag blocks in lag order, matching the
+    regressor layout built in `VAR.fit` (lag 1 first). This helper recovers
+    the individual lag matrices `A_1, ..., A_p` that the moving-average
+    recursion in `compute_ma_phi` consumes.
+
+    Like `sigma_from_cholesky`, the split is rank-agnostic: only the last
+    axis is partitioned, so leading batch axes pass through untouched.
+
+    Args:
+        B: Stacked coefficient matrix. The last two dimensions are
+            `(n, n * n_lags)`; all preceding dimensions are batch axes.
+            Common shapes are `(n, n * n_lags)` for a single draw and
+            `(chains, draws, n, n * n_lags)` for a posterior tensor.
+        n_lags: Number of lag blocks stacked along the trailing axis.
+            Must be positive and divide the trailing axis exactly.
+
+    Returns:
+        List of `n_lags` arrays in lag order, `A_1` first. Each entry has
+        the same leading batch axes as *B* and trailing shape `(n, n)`.
+
+    Raises:
+        ValueError: If `n_lags` is not positive, or if the trailing axis of
+            *B* is not divisible by `n_lags`.
+    """
+    if n_lags < 1:
+        raise ValueError(f"n_lags must be positive, got {n_lags}")
+    n_coeffs = B.shape[-1]
+    if n_coeffs % n_lags != 0:
+        raise ValueError(f"B trailing axis {n_coeffs} is not divisible by n_lags {n_lags}")
+    n_vars = n_coeffs // n_lags
+    return [B[..., j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -1,19 +1,20 @@
 """FittedVAR — reduced-form posterior from Bayesian VAR estimation."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import arviz as az
 import numpy as np
 from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
-from impulso._linalg import sigma_from_cholesky
+from impulso._linalg import lag_matrices, sigma_from_cholesky
+from impulso._ma import compute_ma_phi
 from impulso.data import VARData
 from impulso.protocols import IdentificationScheme, VolatilityProcess
 
 if TYPE_CHECKING:
     from impulso.identified import IdentifiedVAR
-    from impulso.results import ForecastResult
+    from impulso.results import DynamicMultiplierResult, ForecastResult
 
 
 class FittedVAR(ImpulsoBaseModel):
@@ -27,6 +28,13 @@ class FittedVAR(ImpulsoBaseModel):
         volatility: Volatility process used at fit time. Required;
             populated by VAR.fit from VAR.volatility (default at the
             spec level is "constant", which resolves to Constant()).
+        model: The `pymc.Model` built during estimation, or None when the
+            estimator never constructs one. `VAR.fit` populates it, which
+            lets callers inspect the graph, sample from it again, or merge
+            it into a larger PyMC model without refitting. `ConjugateVAR`
+            leaves it None because it draws in closed form and builds no
+            PyMC graph. Typed as Any so that importing `impulso.fitted`
+            does not pull in PyMC (see the lazy-import convention).
     """
 
     idata: az.InferenceData = Field(repr=False)
@@ -34,6 +42,7 @@ class FittedVAR(ImpulsoBaseModel):
     data: VARData
     var_names: list[str]
     volatility: VolatilityProcess
+    model: Any = Field(default=None, repr=False)
 
     @property
     def has_exog(self) -> bool:
@@ -163,6 +172,84 @@ class FittedVAR(ImpulsoBaseModel):
         )
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"forecast": forecast_da}))
         return ForecastResult(idata=idata, steps=steps, var_names=self.var_names, mode=mode)
+
+    def dynamic_multiplier(self, horizon: int = 20, cumulative: bool = False) -> "DynamicMultiplierResult":
+        """Response of the endogenous variables to a unit exogenous impulse.
+
+        The exogenous term enters the VAR contemporaneously
+        (`mu = intercept + X_lag @ B.T + X_exog @ B_exog.T`), so it acts as a
+        forcing term in the same position as the reduced-form shock. The
+        horizon-`h` dynamic multiplier is therefore
+
+            Psi_h = Phi_h @ B_exog
+
+        where `Phi_h` is the moving-average coefficient matrix already used by
+        `IdentifiedVAR.impulse_response`. All dynamics come from the
+        endogenous lag structure; `B_exog` itself carries no lags.
+
+        No structural identification is involved: exogenous regressors are
+        exogenous by assumption, so this lives on the reduced-form posterior
+        and needs neither an `IdentificationScheme` nor an `at=` time slice
+        (`B` and `B_exog` are time-invariant under every volatility process).
+
+        Args:
+            horizon: Highest horizon to compute. The result spans horizon
+                `0` through `horizon` inclusive. Must be non-negative.
+            cumulative: If True, return the cumulative (step-response)
+                multiplier — the response to a permanent unit step in the
+                exogenous variable from time 0 onward. If False (default),
+                return the per-horizon response to a one-off unit impulse.
+
+        Returns:
+            DynamicMultiplierResult with draws of shape
+            `(chains, draws, horizon + 1, n_vars, n_exog)`.
+
+        Raises:
+            ValueError: If `horizon` is negative, or if the fitted posterior
+                carries no `B_exog` (the model was fitted without exogenous
+                regressors, or by an estimator that ignores them).
+        """
+        import xarray as xr
+
+        from impulso.results import DynamicMultiplierResult
+
+        if horizon < 0:
+            raise ValueError(f"horizon must be non-negative, got {horizon}")
+        # Guard on the posterior, not on `has_exog`: an estimator may carry
+        # exogenous data it never actually consumed.
+        if "B_exog" not in self.idata.posterior:
+            raise ValueError(
+                "This FittedVAR has no B_exog in its posterior, so no dynamic "
+                "multiplier is defined. Fit a VAR with exogenous regressors "
+                "(VARData(..., exog=...)) using an estimator that supports them."
+            )
+
+        B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
+        B_exog_draws = self.idata.posterior["B_exog"].values  # (C, D, n, k)
+        Phi = compute_ma_phi(lag_matrices(B_draws, self.n_lags), horizon)  # (C, D, H+1, n, n)
+        psi = Phi @ B_exog_draws[:, :, np.newaxis, :, :]  # (C, D, H+1, n, k)
+        if cumulative:
+            psi = np.cumsum(psi, axis=2)
+
+        exog_names = self.data.exog_names or [f"exog_{i}" for i in range(psi.shape[-1])]
+        psi_da = xr.DataArray(
+            psi,
+            dims=["chain", "draw", "horizon", "response", "exog"],
+            coords={
+                "response": self.var_names,
+                "exog": exog_names,
+                "horizon": np.arange(horizon + 1),
+            },
+            name="dynamic_multiplier",
+        )
+        idata = az.InferenceData(posterior_predictive=xr.Dataset({"dynamic_multiplier": psi_da}))
+        return DynamicMultiplierResult(
+            idata=idata,
+            horizon=horizon,
+            var_names=self.var_names,
+            exog_names=list(exog_names),
+            cumulative=cumulative,
+        )
 
     def set_identification_strategy(self, scheme: IdentificationScheme) -> "IdentifiedVAR":
         """Apply a structural identification scheme.

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -28,13 +28,16 @@ class FittedVAR(ImpulsoBaseModel):
         volatility: Volatility process used at fit time. Required;
             populated by VAR.fit from VAR.volatility (default at the
             spec level is "constant", which resolves to Constant()).
-        model: The `pymc.Model` built during estimation, or None when the
-            estimator never constructs one. `VAR.fit` populates it, which
-            lets callers inspect the graph, sample from it again, or merge
-            it into a larger PyMC model without refitting. `ConjugateVAR`
-            leaves it None because it draws in closed form and builds no
-            PyMC graph. Typed as Any so that importing `impulso.fitted`
-            does not pull in PyMC (see the lazy-import convention).
+        pymc_model: The `pymc.Model` built during estimation, or None when
+            the estimator never constructs one (`ConjugateVAR` draws in
+            closed form and builds no PyMC graph). `VAR.fit` populates it so
+            callers can inspect the graph (`pm.model_to_graphviz`), draw
+            prior/posterior predictive samples, compute log-likelihoods, or
+            apply `pm.do` / `pm.observe` transformations without refitting.
+            The design matrices are baked into the graph as constants, so
+            the model cannot be re-conditioned on new data. Typed as Any so
+            that importing `impulso.fitted` does not pull in PyMC (see the
+            lazy-import convention).
     """
 
     idata: az.InferenceData = Field(repr=False)
@@ -42,7 +45,7 @@ class FittedVAR(ImpulsoBaseModel):
     data: VARData
     var_names: list[str]
     volatility: VolatilityProcess
-    model: Any = Field(default=None, repr=False)
+    pymc_model: Any = Field(default=None, repr=False)
 
     @property
     def has_exog(self) -> bool:
@@ -192,6 +195,11 @@ class FittedVAR(ImpulsoBaseModel):
         and needs neither an `IdentificationScheme` nor an `at=` time slice
         (`B` and `B_exog` are time-invariant under every volatility process).
 
+        Draws are read from the posterior as `(chain, draw, var, coeff)` and
+        `(chain, draw, var, exog)`. Hand-built posteriors that use those
+        dimension names are realigned automatically; posteriors without them
+        are trusted positionally in that order.
+
         Args:
             horizon: Highest horizon to compute. The result spans horizon
                 `0` through `horizon` inclusive. Must be non-negative.
@@ -205,9 +213,11 @@ class FittedVAR(ImpulsoBaseModel):
             `(chains, draws, horizon + 1, n_vars, n_exog)`.
 
         Raises:
-            ValueError: If `horizon` is negative, or if the fitted posterior
+            ValueError: If `horizon` is negative, if the fitted posterior
                 carries no `B_exog` (the model was fitted without exogenous
-                regressors, or by an estimator that ignores them).
+                regressors, or by an estimator that ignores them), or if
+                `data.exog_names` disagrees with the posterior's `B_exog`
+                column count.
         """
         import xarray as xr
 
@@ -224,14 +234,32 @@ class FittedVAR(ImpulsoBaseModel):
                 "(VARData(..., exog=...)) using an estimator that supports them."
             )
 
-        B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
-        B_exog_draws = self.idata.posterior["B_exog"].values  # (C, D, n, k)
+        B_da = self.idata.posterior["B"]
+        B_exog_da = self.idata.posterior["B_exog"]
+        # Hand-built posteriors may order dims arbitrarily. Realign by name
+        # when the canonical labels are present; otherwise trust the
+        # positional (chain, draw, var, coeff/exog) convention.
+        if set(B_da.dims) == {"chain", "draw", "var", "coeff"}:
+            B_da = B_da.transpose("chain", "draw", "var", "coeff")
+        if set(B_exog_da.dims) == {"chain", "draw", "var", "exog"}:
+            B_exog_da = B_exog_da.transpose("chain", "draw", "var", "exog")
+        B_draws = B_da.values  # (C, D, n, n*p)
+        B_exog_draws = B_exog_da.values  # (C, D, n, k)
+
+        n_exog = B_exog_draws.shape[-1]
+        exog_names = self.data.exog_names or [f"exog_{i}" for i in range(n_exog)]
+        if len(exog_names) != n_exog:
+            raise ValueError(
+                f"data.exog_names carries {len(exog_names)} names but the "
+                f"posterior's B_exog has {n_exog} exogenous columns; this "
+                "FittedVAR's data and posterior disagree."
+            )
+
         Phi = compute_ma_phi(lag_matrices(B_draws, self.n_lags), horizon)  # (C, D, H+1, n, n)
         psi = Phi @ B_exog_draws[:, :, np.newaxis, :, :]  # (C, D, H+1, n, k)
         if cumulative:
             psi = np.cumsum(psi, axis=2)
 
-        exog_names = self.data.exog_names or [f"exog_{i}" for i in range(psi.shape[-1])]
         psi_da = xr.DataArray(
             psi,
             dims=["chain", "draw", "horizon", "response", "exog"],

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -90,10 +90,10 @@ class SignRestriction(ImpulsoModel):
     random_seed: int | None = None
 
     # Single-call scratchpad: identify() writes the rate; the pipeline
-    # (set_identification_strategy) reads it immediately afterwards and
-    # attaches to idata.posterior.attrs. Not reentrant — overwritten on
-    # each identify() call. Do not rely on this between calls; the
-    # surviving public surface is the posterior attr.
+    # (IdentifiedVAR.shock_matrix) reads it immediately afterwards and
+    # attaches it to the shock-matrix DataArray's attrs. Not reentrant —
+    # overwritten on each identify() call. Do not rely on this between
+    # calls; the surviving public surface is the shock-matrix attr.
     _last_acceptance_rate: float = PrivateAttr(default=0.0)
 
     def identify(
@@ -119,9 +119,9 @@ class SignRestriction(ImpulsoModel):
         Returns:
             Structural shock matrix, shape (chains, draws, n_vars, n_vars).
             Per-draw fallback to the supplied `L` for draws where no
-            rotation satisfies the restrictions. Acceptance rate available
-            via the `sign_restriction_acceptance_rate` attribute on the
-            wrapping IdentifiedVAR's posterior (set by the pipeline).
+            rotation satisfies the restrictions. The acceptance rate is
+            available via the `sign_restriction_acceptance_rate` attr on
+            `IdentifiedVAR.shock_matrix()` (attached by the pipeline).
         """
         del data, n_lags  # unused
         from scipy.stats import special_ortho_group

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -8,7 +8,7 @@ import xarray as xr
 from pydantic import Field, PrivateAttr
 
 from impulso._base import ImpulsoBaseModel, ImpulsoModel
-from impulso._linalg import sigma_from_cholesky
+from impulso._linalg import lag_matrices, sigma_from_cholesky
 from impulso._ma import compute_ma_phi
 
 if TYPE_CHECKING:
@@ -217,13 +217,11 @@ class SignRestriction(ImpulsoModel):
         Returns:
             True if all restrictions satisfied at all horizons.
         """
-        n_vars = candidate.shape[0]
-
         # Always check impact (h=0)
         if not self._check_restrictions(candidate, var_names, shock_names):
             return False
 
-        A = [B_draw[:, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
+        A = lag_matrices(B_draw, n_lags)
         Phi = compute_ma_phi(A, self.restriction_horizon)  # (H+1, n, n)
 
         # Phi[0] (= I) handles the impact check above; iterate h=1..H here.

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -10,6 +10,7 @@ import xarray as xr
 from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
+from impulso._linalg import lag_matrices
 from impulso._ma import compute_ma_phi
 from impulso.data import VARData
 from impulso.protocols import IdentificationScheme, VolatilityProcess
@@ -48,14 +49,13 @@ class IdentifiedVAR(ImpulsoBaseModel):
         """Shock coordinate labels from the identification scheme."""
         return self.scheme.shock_coords(n_vars=len(self.var_names))
 
-    def _ma_coefficients(self, B_draws: np.ndarray, n_vars: int, n_lags: int, horizon: int) -> np.ndarray:
+    def _ma_coefficients(self, B_draws: np.ndarray, n_lags: int, horizon: int) -> np.ndarray:
         """Compute MA coefficient recursion, vectorised over (chains, draws).
 
         Returns:
             Array of shape (C, D, horizon+1, n_vars, n_vars).
         """
-        A = [B_draws[:, :, :, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
-        return compute_ma_phi(A, horizon)
+        return compute_ma_phi(lag_matrices(B_draws, n_lags), horizon)
 
     def shock_matrix(self, at: AtParam = None) -> xr.DataArray:
         """Query the structural shock matrix at a given time index.
@@ -204,8 +204,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
             IRFResult with IRF posterior draws.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
-        n_vars = B_draws.shape[2]
-        Phi_arr = self._ma_coefficients(B_draws, n_vars, self.n_lags, horizon)
+        Phi_arr = self._ma_coefficients(B_draws, self.n_lags, horizon)
         P = self.shock_matrix(at=at)
 
         if "time" in P.dims:
@@ -294,8 +293,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
             FEVDResult with FEVD posterior draws.
         """
         B_draws = self.idata.posterior["B"].values  # (C, D, n, n*p)
-        n_vars = B_draws.shape[2]
-        Phi_arr = self._ma_coefficients(B_draws, n_vars, self.n_lags, horizon)
+        Phi_arr = self._ma_coefficients(B_draws, self.n_lags, horizon)
         P = self.shock_matrix(at=at)
 
         if "time" in P.dims:

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -125,7 +125,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
 
         # Attach sign-restriction acceptance rate if available.
         rate = getattr(self.scheme, "_last_acceptance_rate", None)
-        if isinstance(rate, float) and rate < 1.0:
+        if isinstance(rate, float):
             result.attrs["sign_restriction_acceptance_rate"] = rate
 
         # Attach any scheme-specific diagnostics (e.g. ProxySVAR first-stage

--- a/src/impulso/plotting/__init__.py
+++ b/src/impulso/plotting/__init__.py
@@ -1,5 +1,6 @@
 """Plotting functions for VAR results."""
 
+from impulso.plotting._dynamic_multiplier import plot_dynamic_multiplier
 from impulso.plotting._fevd import plot_fevd
 from impulso.plotting._forecast import plot_forecast
 from impulso.plotting._historical_decomposition import plot_historical_decomposition
@@ -8,6 +9,7 @@ from impulso.plotting._sv_forecast import plot_sv_forecast
 from impulso.plotting._sv_volatility import plot_volatility
 
 __all__ = [
+    "plot_dynamic_multiplier",
     "plot_fevd",
     "plot_forecast",
     "plot_historical_decomposition",

--- a/src/impulso/plotting/_dynamic_multiplier.py
+++ b/src/impulso/plotting/_dynamic_multiplier.py
@@ -1,0 +1,54 @@
+"""Exogenous dynamic-multiplier plotting."""
+
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+if TYPE_CHECKING:
+    from impulso.results import DynamicMultiplierResult
+
+
+def plot_dynamic_multiplier(
+    result: "DynamicMultiplierResult",
+    variables: list[str] | None = None,
+    figsize: tuple[float, float] = (9, 6),
+) -> Figure:
+    """Plot exogenous dynamic multipliers with credible bands.
+
+    Lays out a grid of response variables (rows) by exogenous drivers
+    (columns), mirroring `plot_irf`'s response-by-shock grid.
+
+    Args:
+        result: DynamicMultiplierResult from FittedVAR.dynamic_multiplier().
+        variables: Optional subset of response variables to plot.
+        figsize: Figure size.
+
+    Returns:
+        Matplotlib Figure.
+    """
+    med = result.median()
+    hdi = result.hdi()
+    var_names = variables or result.var_names
+    exog_names = result.exog_names
+
+    fig, axes = plt.subplots(len(var_names), len(exog_names), figsize=figsize, squeeze=False)
+    kind = "Cumulative dynamic multipliers" if result.cumulative else "Dynamic multipliers"
+    fig.suptitle(kind)
+
+    horizons = range(result.horizon + 1)
+    for i, resp in enumerate(var_names):
+        for j, exog in enumerate(exog_names):
+            ax = axes[i][j]
+            ax.set_title(f"{exog} -> {resp}", fontsize=9)
+            ax.axhline(0, color="grey", linewidth=0.5, linestyle="--")
+            ax.plot(horizons, med[(resp, exog)].values)
+            ax.fill_between(
+                horizons,
+                hdi.lower[(resp, exog)].values,
+                hdi.upper[(resp, exog)].values,
+                alpha=0.3,
+            )
+
+    fig.tight_layout()
+    return fig

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -13,19 +13,25 @@ from pydantic import Field
 from impulso._base import ImpulsoBaseModel
 
 
-def _wide_frame(da: xr.DataArray, row_dim: str) -> pd.DataFrame:
-    """Reshape a (row_dim, response, shock) DataArray into a wide DataFrame.
+def _wide_frame(da: xr.DataArray, row_dim: str, col_dim: str = "shock") -> pd.DataFrame:
+    """Reshape a (row_dim, response, col_dim) DataArray into a wide DataFrame.
 
     The returned frame is indexed by the coord values of `row_dim` and has
-    a `MultiIndex(['response', 'shock'])` on columns built from those coords
+    a `MultiIndex(['response', col_dim])` on columns built from those coords
     in the order they appear on the DataArray.
+
+    Args:
+        da: Source array carrying `response`, `col_dim`, and `row_dim` dims.
+        row_dim: Dimension to use as the frame index.
+        col_dim: Dimension pairing with `response` on the columns. Defaults
+            to `shock` for structural results; exogenous results pass `exog`.
     """
-    da = da.transpose(row_dim, "response", "shock")
+    da = da.transpose(row_dim, "response", col_dim)
     row_values = da.coords[row_dim].values
     row_index = pd.DatetimeIndex(row_values, name="time") if row_dim == "time" else pd.Index(row_values, name=row_dim)
     columns = pd.MultiIndex.from_product(
-        [da.coords["response"].values.tolist(), da.coords["shock"].values.tolist()],
-        names=["response", "shock"],
+        [da.coords["response"].values.tolist(), da.coords[col_dim].values.tolist()],
+        names=["response", col_dim],
     )
     return pd.DataFrame(da.values.reshape(len(row_index), -1), index=row_index, columns=columns)
 
@@ -201,6 +207,60 @@ class IRFResult(VARResultBase):
         from impulso.plotting import plot_irf
 
         return plot_irf(self)
+
+
+class DynamicMultiplierResult(VARResultBase):
+    """Result from exogenous dynamic-multiplier computation.
+
+    Attributes:
+        idata: ArviZ InferenceData with dynamic-multiplier draws.
+        horizon: Highest horizon computed; the result spans 0..horizon.
+        var_names: Names of the endogenous (response) variables.
+        exog_names: Names of the exogenous (driver) variables.
+        cumulative: Whether the draws are cumulative (step-response)
+            multipliers rather than per-horizon impulse multipliers.
+    """
+
+    _PRIMARY_KEY: ClassVar[str] = "dynamic_multiplier"
+
+    horizon: int
+    var_names: list[str]
+    exog_names: list[str]
+    cumulative: bool = False
+
+    def median(self) -> pd.DataFrame:
+        """Posterior median dynamic multiplier.
+
+        Returns:
+            DataFrame indexed by horizon (integer 0..H) with a
+            `MultiIndex(['response', 'exog'])` on columns.
+        """
+        self._guard_no_time_dim()
+        dm = self.idata.posterior_predictive["dynamic_multiplier"]
+        return _wide_frame(dm.median(dim=("chain", "draw")), "horizon", col_dim="exog")
+
+    def hdi(self, prob: float = 0.89) -> HDIResult:
+        """HDI for the dynamic multiplier.
+
+        Returns:
+            HDIResult whose `lower` / `upper` DataFrames mirror the shape and
+            labels of `median()`.
+        """
+        self._guard_no_time_dim()
+        hdi_data = az.hdi(self.idata.posterior_predictive, hdi_prob=prob)["dynamic_multiplier"]
+        lower = _wide_frame(hdi_data.sel(hdi="lower"), "horizon", col_dim="exog")
+        upper = _wide_frame(hdi_data.sel(hdi="higher"), "horizon", col_dim="exog")
+        return HDIResult(lower=lower, upper=upper, prob=prob)
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert the dynamic multiplier to a DataFrame (passthrough to `median()`)."""
+        return self.median()
+
+    def plot(self) -> Figure:
+        """Plot dynamic multipliers."""
+        from impulso.plotting import plot_dynamic_multiplier
+
+        return plot_dynamic_multiplier(self)
 
 
 class FEVDResult(VARResultBase):

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -176,5 +176,5 @@ class VAR(ImpulsoBaseModel):
             data=data,
             var_names=data.endog_names,
             volatility=self.resolved_volatility,
-            model=model,
+            pymc_model=model,
         )

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -117,23 +117,36 @@ class VAR(ImpulsoBaseModel):
         B_ols, *_ = np.linalg.lstsq(X_full, Y, rcond=None)
         resid = Y - X_full @ B_ols
 
+        # Coordinates make the posterior self-describing: `B` comes back labelled
+        # by variable and by "L<lag>.<variable>" coefficient instead of positional
+        # `B_dim_0` / `B_dim_1`. Names match ConjugateVAR's posterior so both
+        # estimators agree. `coeff` is lag-major to mirror the X_lag hstack above.
+        coords: dict[str, object] = {
+            "var": data.endog_names,
+            "var1": data.endog_names,
+            "var2": data.endog_names,
+            "coeff": [f"L{lag}.{name}" for lag in range(1, n_lags + 1) for name in data.endog_names],
+            "time": data.index[n_lags:],
+        }
+        if data.exog_names is not None:
+            coords["exog"] = data.exog_names
+
         # Build PyMC model
-        with pm.Model() as model:
+        with pm.Model(coords=coords) as model:
             # Intercept
-            intercept = pm.Normal("intercept", mu=0, sigma=1, shape=n_vars)
+            intercept = pm.Normal("intercept", mu=0, sigma=1, dims="var")
 
             # VAR coefficients with Minnesota prior
             B = pm.Normal(
                 "B",
                 mu=prior_params["B_mu"],
                 sigma=prior_params["B_sigma"],
-                shape=(n_vars, n_vars * n_lags),
+                dims=("var", "coeff"),
             )
 
             # Exogenous coefficients
             if X_exog is not None:
-                n_exog = X_exog.shape[1]
-                B_exog = pm.Normal("B_exog", mu=0, sigma=1, shape=(n_vars, n_exog))
+                B_exog = pm.Normal("B_exog", mu=0, sigma=1, dims=("var", "exog"))
                 mu = intercept + pm.math.dot(X_lag, B.T) + pm.math.dot(X_exog, B_exog.T)
             else:
                 mu = intercept + pm.math.dot(X_lag, B.T)
@@ -147,12 +160,12 @@ class VAR(ImpulsoBaseModel):
             # for SV, materialising (T, n, n) per draw is wasteful; users can
             # reconstruct per-t Σ via `volatility.cholesky_at(posterior, t)`.
             if L.ndim == 2:
-                pm.Deterministic("Sigma", pm.math.dot(L, L.T))
+                pm.Deterministic("Sigma", pm.math.dot(L, L.T), dims=("var1", "var2"))
 
             # Likelihood. PyMC handles batched chol natively: for 2D L, every
             # observation uses the same chol; for 3D L (T, n, n), each
             # observation t uses chol[t].
-            pm.MvNormal("obs", mu=mu, chol=L, observed=Y)
+            pm.MvNormal("obs", mu=mu, chol=L, observed=Y, dims=("time", "var"))
 
         # Sample
         idata = sampler.sample(model)
@@ -163,4 +176,5 @@ class VAR(ImpulsoBaseModel):
             data=data,
             var_names=data.endog_names,
             volatility=self.resolved_volatility,
+            model=model,
         )

--- a/tests/test_dynamic_multiplier.py
+++ b/tests/test_dynamic_multiplier.py
@@ -194,6 +194,47 @@ class TestDynamicMultiplier:
         with pytest.raises(ValueError, match="no B_exog"):
             fitted.dynamic_multiplier(horizon=3)
 
+    def test_realigns_scrambled_dim_order(self, fitted_with_exog):
+        """A hand-built posterior with non-canonical dim order gives identical draws."""
+        post = fitted_with_exog.idata.posterior
+        scrambled = xr.Dataset({
+            "B": post["B"].transpose("chain", "draw", "coeff", "var"),
+            "B_exog": post["B_exog"].transpose("exog", "var", "chain", "draw"),
+            "intercept": post["intercept"],
+        })
+        fitted = FittedVAR(
+            idata=az.InferenceData(posterior=scrambled),
+            n_lags=fitted_with_exog.n_lags,
+            data=fitted_with_exog.data,
+            var_names=fitted_with_exog.var_names,
+            volatility=Constant(),
+        )
+        np.testing.assert_allclose(
+            fitted.dynamic_multiplier(horizon=4).idata.posterior_predictive["dynamic_multiplier"].values,
+            fitted_with_exog.dynamic_multiplier(horizon=4).idata.posterior_predictive["dynamic_multiplier"].values,
+        )
+
+    def test_rejects_exog_name_count_mismatch(self, fitted_with_exog):
+        """A hand-built FittedVAR whose data disagrees with its posterior fails loudly."""
+        rng = np.random.default_rng(3)
+        t = fitted_with_exog.data.endog.shape[0]
+        data = VARData(
+            endog=fitted_with_exog.data.endog,
+            endog_names=fitted_with_exog.data.endog_names,
+            exog=rng.standard_normal((t, 3)),
+            exog_names=["tv", "online", "print"],
+            index=fitted_with_exog.data.index,
+        )
+        fitted = FittedVAR(
+            idata=fitted_with_exog.idata,
+            n_lags=fitted_with_exog.n_lags,
+            data=data,
+            var_names=fitted_with_exog.var_names,
+            volatility=Constant(),
+        )
+        with pytest.raises(ValueError, match="carries 3 names"):
+            fitted.dynamic_multiplier(horizon=2)
+
 
 class TestDynamicMultiplierResult:
     def test_median_frame_labels(self, fitted_with_exog):
@@ -236,8 +277,8 @@ class TestFittedModelRetention:
             var_data_2v,
             sampler=NUTSSampler(draws=40, tune=40, chains=1, cores=1, random_seed=3, progressbar=False),
         )
-        assert isinstance(fitted.model, pm.Model)
-        assert {"intercept", "B"} <= {v.name for v in fitted.model.unobserved_RVs}
+        assert isinstance(fitted.pymc_model, pm.Model)
+        assert {"intercept", "B"} <= {v.name for v in fitted.pymc_model.unobserved_RVs}
 
     def test_defaults_to_none_when_not_supplied(self, synthetic_idata_2v, var_data_2v):
         """ConjugateVAR builds no PyMC graph, so the field must stay optional."""
@@ -248,7 +289,7 @@ class TestFittedModelRetention:
             var_names=["y1", "y2"],
             volatility=Constant(),
         )
-        assert fitted.model is None
+        assert fitted.pymc_model is None
 
 
 class TestPosteriorCoords:

--- a/tests/test_dynamic_multiplier.py
+++ b/tests/test_dynamic_multiplier.py
@@ -1,0 +1,301 @@
+"""Tests for the exogenous dynamic multiplier and its supporting primitives."""
+
+import arviz as az
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+matplotlib.use("Agg")
+
+import impulso
+from impulso._linalg import lag_matrices
+from impulso._ma import compute_ma_phi
+from impulso.data import VARData
+from impulso.fitted import FittedVAR
+from impulso.results import DynamicMultiplierResult
+from impulso.samplers import NUTSSampler
+from impulso.spec import VAR
+from impulso.volatility import Constant
+
+
+class TestLagMatrices:
+    """`lag_matrices` splits the stacked B into per-lag blocks, lag 1 first."""
+
+    def test_splits_single_draw_in_lag_order(self):
+        n, p = 2, 3
+        B = np.arange(n * n * p, dtype=float).reshape(n, n * p)
+        A = lag_matrices(B, p)
+        assert len(A) == p
+        for j, A_j in enumerate(A):
+            assert A_j.shape == (n, n)
+            np.testing.assert_array_equal(A_j, B[:, j * n : (j + 1) * n])
+
+    def test_preserves_leading_batch_axes(self):
+        c, d, n, p = 2, 5, 3, 2
+        B = np.random.default_rng(0).standard_normal((c, d, n, n * p))
+        A = lag_matrices(B, p)
+        assert [A_j.shape for A_j in A] == [(c, d, n, n)] * p
+        np.testing.assert_array_equal(A[1], B[..., n:])
+
+    def test_single_lag_returns_whole_matrix(self):
+        B = np.random.default_rng(1).standard_normal((4, 4))
+        (A_1,) = lag_matrices(B, 1)
+        np.testing.assert_array_equal(A_1, B)
+
+    @pytest.mark.parametrize("n_lags", [0, -1])
+    def test_rejects_non_positive_n_lags(self, n_lags):
+        with pytest.raises(ValueError, match="n_lags must be positive"):
+            lag_matrices(np.zeros((2, 4)), n_lags)
+
+    def test_rejects_indivisible_trailing_axis(self):
+        with pytest.raises(ValueError, match="not divisible"):
+            lag_matrices(np.zeros((2, 5)), 2)
+
+    def test_reproduces_the_idiom_it_replaced(self):
+        """Guards the call sites in identified.py and identification.py."""
+        rng = np.random.default_rng(7)
+        n_vars, n_lags = 3, 4
+        B = rng.standard_normal((2, 6, n_vars, n_vars * n_lags))
+        legacy = [B[:, :, :, j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
+        for new, old in zip(lag_matrices(B, n_lags), legacy, strict=True):
+            np.testing.assert_array_equal(new, old)
+
+
+class TestPublicApi:
+    """Both MA primitives are reachable without importing a private module."""
+
+    @pytest.mark.parametrize("name", ["compute_ma_phi", "lag_matrices", "DynamicMultiplierResult"])
+    def test_exported(self, name):
+        assert name in impulso.__all__
+        assert getattr(impulso, name) is not None
+
+    def test_primitives_compose(self):
+        B = np.random.default_rng(2).standard_normal((3, 6))
+        Phi = impulso.compute_ma_phi(impulso.lag_matrices(B, 2), horizon=3)
+        assert Phi.shape == (4, 3, 3)
+
+
+@pytest.fixture
+def fitted_with_exog():
+    """A FittedVAR carrying a synthetic VAR(2) posterior with B_exog. No MCMC."""
+    rng = np.random.default_rng(11)
+    n_chains, n_draws, n_vars, n_lags, n_exog, t = 2, 25, 2, 2, 2, 40
+    posterior = xr.Dataset({
+        "B": xr.DataArray(
+            rng.standard_normal((n_chains, n_draws, n_vars, n_vars * n_lags)) * 0.2,
+            dims=["chain", "draw", "var", "coeff"],
+        ),
+        "B_exog": xr.DataArray(
+            rng.standard_normal((n_chains, n_draws, n_vars, n_exog)),
+            dims=["chain", "draw", "var", "exog"],
+        ),
+        "intercept": xr.DataArray(
+            rng.standard_normal((n_chains, n_draws, n_vars)) * 0.01,
+            dims=["chain", "draw", "var"],
+        ),
+    })
+    data = VARData(
+        endog=rng.standard_normal((t, n_vars)),
+        endog_names=["ad", "brand"],
+        exog=rng.standard_normal((t, n_exog)),
+        exog_names=["tv", "online"],
+        index=pd.date_range("2023-01-02", periods=t, freq="W-MON"),
+    )
+    return FittedVAR(
+        idata=az.InferenceData(posterior=posterior),
+        n_lags=n_lags,
+        data=data,
+        var_names=["ad", "brand"],
+        volatility=Constant(),
+    )
+
+
+class TestDynamicMultiplier:
+    def test_equals_phi_at_b_exog(self, fitted_with_exog):
+        """Psi_h = Phi_h @ B_exog, recomputed independently from the posterior."""
+        horizon = 5
+        psi = fitted_with_exog.dynamic_multiplier(horizon=horizon)
+        post = fitted_with_exog.idata.posterior
+        Phi = compute_ma_phi(lag_matrices(post["B"].values, fitted_with_exog.n_lags), horizon)
+        expected = Phi @ post["B_exog"].values[:, :, np.newaxis, :, :]
+        np.testing.assert_allclose(psi.idata.posterior_predictive["dynamic_multiplier"].values, expected)
+
+    def test_impact_multiplier_is_b_exog(self, fitted_with_exog):
+        """Phi_0 = I, so the horizon-0 multiplier is B_exog itself."""
+        psi = fitted_with_exog.dynamic_multiplier(horizon=3)
+        np.testing.assert_allclose(
+            psi.idata.posterior_predictive["dynamic_multiplier"].values[:, :, 0, :, :],
+            fitted_with_exog.idata.posterior["B_exog"].values,
+        )
+
+    def test_cumulative_is_cumsum_over_horizon(self, fitted_with_exog):
+        impulse = fitted_with_exog.dynamic_multiplier(horizon=6)
+        step = fitted_with_exog.dynamic_multiplier(horizon=6, cumulative=True)
+        np.testing.assert_allclose(
+            step.idata.posterior_predictive["dynamic_multiplier"].values,
+            np.cumsum(impulse.idata.posterior_predictive["dynamic_multiplier"].values, axis=2),
+        )
+        assert step.cumulative is True
+        assert impulse.cumulative is False
+
+    def test_cumulative_matches_forced_recursion(self, fitted_with_exog):
+        """A permanent unit step in one exog, propagated through the VAR by hand."""
+        horizon = 4
+        post = fitted_with_exog.idata.posterior
+        B = post["B"].values
+        B_exog = post["B_exog"].values
+        A = lag_matrices(B, fitted_with_exog.n_lags)
+
+        # Drive exog column 0 at a constant unit level from t=0 with zero history.
+        hist: list[np.ndarray] = []
+        states = []
+        for _ in range(horizon + 1):
+            s = B_exog[..., 0].copy()
+            for j, A_j in enumerate(A):
+                if j < len(hist):
+                    s = s + np.einsum("cdik,cdk->cdi", A_j, hist[-(j + 1)])
+            hist.append(s)
+            states.append(s)
+
+        step = fitted_with_exog.dynamic_multiplier(horizon=horizon, cumulative=True)
+        np.testing.assert_allclose(
+            step.idata.posterior_predictive["dynamic_multiplier"].values[..., 0],
+            np.stack(states, axis=2),
+        )
+
+    def test_shape_dims_and_coords(self, fitted_with_exog):
+        psi = fitted_with_exog.dynamic_multiplier(horizon=4)
+        da = psi.idata.posterior_predictive["dynamic_multiplier"]
+        assert da.dims == ("chain", "draw", "horizon", "response", "exog")
+        assert da.shape == (2, 25, 5, 2, 2)
+        assert da.coords["response"].values.tolist() == ["ad", "brand"]
+        assert da.coords["exog"].values.tolist() == ["tv", "online"]
+        assert psi.exog_names == ["tv", "online"]
+
+    def test_horizon_zero_is_allowed(self, fitted_with_exog):
+        psi = fitted_with_exog.dynamic_multiplier(horizon=0)
+        assert psi.idata.posterior_predictive["dynamic_multiplier"].sizes["horizon"] == 1
+
+    def test_rejects_negative_horizon(self, fitted_with_exog):
+        with pytest.raises(ValueError, match="horizon must be non-negative"):
+            fitted_with_exog.dynamic_multiplier(horizon=-1)
+
+    def test_rejects_posterior_without_b_exog(self, synthetic_idata_2v, var_data_2v):
+        """Guards on the posterior, not on has_exog."""
+        fitted = FittedVAR(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+        with pytest.raises(ValueError, match="no B_exog"):
+            fitted.dynamic_multiplier(horizon=3)
+
+
+class TestDynamicMultiplierResult:
+    def test_median_frame_labels(self, fitted_with_exog):
+        med = fitted_with_exog.dynamic_multiplier(horizon=4).median()
+        assert isinstance(med, pd.DataFrame)
+        assert med.index.name == "horizon"
+        assert med.columns.names == ["response", "exog"]
+        assert ("brand", "online") in med.columns
+        assert len(med) == 5
+
+    def test_hdi_mirrors_median_shape(self, fitted_with_exog):
+        result = fitted_with_exog.dynamic_multiplier(horizon=4)
+        hdi = result.hdi(prob=0.8)
+        assert hdi.prob == 0.8
+        assert hdi.lower.shape == result.median().shape
+        assert list(hdi.upper.columns) == list(result.median().columns)
+        assert (hdi.lower <= hdi.upper).all().all()
+
+    def test_to_dataframe_matches_median(self, fitted_with_exog):
+        result = fitted_with_exog.dynamic_multiplier(horizon=3)
+        pd.testing.assert_frame_equal(result.to_dataframe(), result.median())
+
+    def test_is_result_type(self, fitted_with_exog):
+        assert isinstance(fitted_with_exog.dynamic_multiplier(horizon=2), DynamicMultiplierResult)
+
+    def test_plot_returns_figure(self, fitted_with_exog):
+        from matplotlib.figure import Figure
+
+        assert isinstance(fitted_with_exog.dynamic_multiplier(horizon=3).plot(), Figure)
+
+
+class TestFittedModelRetention:
+    """`VAR.fit` keeps the PyMC model it built."""
+
+    @pytest.mark.slow
+    def test_fit_retains_pymc_model(self, var_data_2v):
+        import pymc as pm
+
+        fitted = VAR(lags=1).fit(
+            var_data_2v,
+            sampler=NUTSSampler(draws=40, tune=40, chains=1, cores=1, random_seed=3, progressbar=False),
+        )
+        assert isinstance(fitted.model, pm.Model)
+        assert {"intercept", "B"} <= {v.name for v in fitted.model.unobserved_RVs}
+
+    def test_defaults_to_none_when_not_supplied(self, synthetic_idata_2v, var_data_2v):
+        """ConjugateVAR builds no PyMC graph, so the field must stay optional."""
+        fitted = FittedVAR(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+        assert fitted.model is None
+
+
+class TestPosteriorCoords:
+    """The fitted posterior labels itself instead of using B_dim_0 / B_dim_1."""
+
+    @pytest.mark.slow
+    def test_named_dims_and_coords(self, var_data_2v):
+        fitted = VAR(lags=2).fit(
+            var_data_2v,
+            sampler=NUTSSampler(draws=40, tune=40, chains=1, cores=1, random_seed=4, progressbar=False),
+        )
+        post = fitted.idata.posterior
+        assert post["B"].dims == ("chain", "draw", "var", "coeff")
+        assert post["intercept"].dims == ("chain", "draw", "var")
+        assert post["Sigma"].dims == ("chain", "draw", "var1", "var2")
+        assert post["B"].coords["var"].values.tolist() == var_data_2v.endog_names
+        # coeff is lag-major, mirroring the X_lag hstack in VAR.fit
+        assert post["B"].coords["coeff"].values.tolist() == [
+            f"L{lag}.{name}" for lag in (1, 2) for name in var_data_2v.endog_names
+        ]
+
+    @pytest.mark.slow
+    def test_label_selection_matches_positional(self, var_data_2v):
+        fitted = VAR(lags=2).fit(
+            var_data_2v,
+            sampler=NUTSSampler(draws=40, tune=40, chains=1, cores=1, random_seed=5, progressbar=False),
+        )
+        post = fitted.idata.posterior
+        name_1 = var_data_2v.endog_names[1]
+        selected = post["B"].sel(var=name_1, coeff=f"L2.{var_data_2v.endog_names[0]}")
+        np.testing.assert_allclose(selected.values, post["B"].values[:, :, 1, 2])
+
+    @pytest.mark.slow
+    def test_exog_names_reach_the_posterior(self, var_data_2v):
+        rng = np.random.default_rng(6)
+        t = var_data_2v.endog.shape[0]
+        data = VARData(
+            endog=var_data_2v.endog,
+            endog_names=var_data_2v.endog_names,
+            exog=rng.standard_normal((t, 2)),
+            exog_names=["tv", "online"],
+            index=var_data_2v.index,
+        )
+        fitted = VAR(lags=1).fit(
+            data,
+            sampler=NUTSSampler(draws=40, tune=40, chains=1, cores=1, random_seed=7, progressbar=False),
+        )
+        b_exog = fitted.idata.posterior["B_exog"]
+        assert b_exog.dims == ("chain", "draw", "var", "exog")
+        assert b_exog.coords["exog"].values.tolist() == ["tv", "online"]

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -154,6 +154,24 @@ def _fitted_from_synthetic(synthetic_idata_2v, var_data_2v):
     )
 
 
+class TestShockMatrixDiagnostics:
+    """Scheme diagnostics surface on the shock-matrix attrs (the tutorials read them)."""
+
+    def test_sign_restriction_acceptance_rate_attr(self, synthetic_idata_2v, var_data_2v):
+        """Attr must be present even at 100% acceptance (regression: `rate < 1.0` guard dropped it)."""
+        fitted = _fitted_from_synthetic(synthetic_idata_2v, var_data_2v)
+        scheme = SignRestriction(
+            restrictions={"y1": {"shock_a": "+"}},
+            n_rotations=50,
+            restriction_horizon=1,
+            random_seed=7,
+        )
+        sm = fitted.set_identification_strategy(scheme).shock_matrix()
+        rate = sm.attrs["sign_restriction_acceptance_rate"]
+        assert isinstance(rate, float)
+        assert 0.0 < rate <= 1.0
+
+
 class TestIdentifiedVarCarriesVolatilityAndScheme:
     def test_carries_volatility_and_scheme(self, synthetic_idata_2v, var_data_2v):
         from impulso.protocols import IdentificationScheme, VolatilityProcess


### PR DESCRIPTION
## Summary

Primitives for composing Impulso with external PyMC codebases (pymc-marketing being the driving consumer):

- **Exogenous dynamic multipliers** — `FittedVAR.dynamic_multiplier(horizon, cumulative)` computes `Psi_h = Phi_h @ B_exog` on the reduced-form posterior (no identification involved), returned as a `DynamicMultiplierResult` with the standard `median()` / `hdi()` / `to_dataframe()` / `plot()` surface. Terminology pinned in `CONTEXT.md` ("dynamic multiplier", never "exogenous IRF").
- **Labelled posteriors** — `VAR.fit` builds its PyMC model with named coords (`var`, `coeff` as `L<lag>.<name>`, `var1`/`var2`, `exog`, `time`), so `az.summary` rows and `.sel(...)` are label-addressable instead of positional. Dim names match `ConjugateVAR`'s posterior.
- **Retained PyMC model** — `FittedVAR.pymc_model` keeps the graph built at fit time for inspection (`pm.model_to_graphviz`), prior/posterior predictive sampling, log-likelihood computation, and `pm.do` / `pm.observe` surgery. `None` for `ConjugateVAR`, which builds no PyMC graph.
- **Published MA primitives** — `compute_ma_phi` and `lag_matrices` are exported from the top-level namespace; the lag-split idiom in `identified.py` / `identification.py` is consolidated onto `lag_matrices`.

## Review hardening

- Renamed `FittedVAR.model` to `pymc_model` before external consumers depend on it.
- `dynamic_multiplier` realigns `B` / `B_exog` by dimension name when hand-built posteriors carry the canonical labels (a scrambled dim order previously produced silently wrong numbers) and rejects `data.exog_names` vs `B_exog` column-count mismatches with an actionable error.
- The lazy public API is now typed for static checkers via a `TYPE_CHECKING` re-import block in `impulso/__init__.py`.
- API reference: added `DynamicMultiplierResult`, `plot_dynamic_multiplier`, and a new Primitives page for `compute_ma_phi` / `lag_matrices`.

## Verification

- Fast suite: 422 passed. Slow MCMC tests for this feature: 4 passed — coords and `pymc_model` verified against the real PyMC/nutpie pipeline.
- `ruff check`, `ruff format --check`, and `ty check` clean.
- Cumulative multipliers validated against an independent forced-step simulation; label-based selection proven equal to positional access on a real posterior.

## Follow-ups (out of scope, to file as issues)

- `forecast()` crashes for `ConjugateVAR` fitted on exog-bearing data: it guards on data-based `has_exog`, demands `exog_future`, then `KeyError`s on `posterior["B_exog"]`. Pre-existing; needs the same posterior-based guard `dynamic_multiplier` uses.
- `ConjugateVAR` posteriors share dim names with `VAR.fit` but carry no coord labels, so `.sel(var=...)` works on one estimator only.
- `cumulative=` option for `impulse_response`, mirroring `dynamic_multiplier`.
