### PR TITLE
feat(scenario): structural_scenario() — three-way partition solve

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -111,6 +111,15 @@ _Avoid_: "stochastic volatility" — the break is deterministic given its hyperp
 >
 > **User:** "Just a univariate SV fit."
 > **Library:** `StochasticVolatility(dynamics="ar1").fit(SVData(y))`. Same class, standalone code path.
+>
+> **User:** "What would food prices have done if the 2022 energy shock had never happened?"
+> **Library:** `identified.counterfactual(shocks=[ShockPath(shock="energy", values=0.0, start="2022-01", end="2022-12")])`. Realised shocks are edited and re-propagated; `result.difference()` is the shock's effect.
+>
+> **User:** "Forecast inflation if the policy rate follows this path for two years."
+> **Library:** `fitted.conditional_forecast(steps=8, conditions=[VariablePath(variable="rate", values=path)])`. All shocks adjust (Waggoner–Zha); no identification scheme needed. Add `path_uncertainty="unconditional"` to restrict the mean only and keep honest bands.
+>
+> **User:** "Same rate path, but make the *policy* shock do the work — and how believable is that?"
+> **Library:** `identified.structural_scenario(steps=8, conditions=[VariablePath(variable="rate", values=path)], adjusting=["policy"])`. Non-adjusting shocks keep their unconditional draws; `result.plausibility()` reports `q` and the calibrated `q_cal`.
 
 ## Conventions
 

--- a/docs/reference/plotting.md
+++ b/docs/reference/plotting.md
@@ -9,6 +9,7 @@
 
    plot_forecast
    plot_conditional_forecast
+   plot_structural_scenario
    plot_dynamic_multiplier
    plot_irf
    plot_fevd

--- a/docs/reference/results.md
+++ b/docs/reference/results.md
@@ -10,6 +10,7 @@
    VARResultBase
    ForecastResult
    ConditionalForecastResult
+   ScenarioResult
    DynamicMultiplierResult
    IRFResult
    FEVDResult

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         HistoricalDecompositionResult,
         IRFResult,
         LagOrderResult,
+        ScenarioResult,
         SVForecastResult,
         VolatilityResult,
     )
@@ -63,6 +64,7 @@ __all__ = [
     "SVData",
     "SVDefaultPrior",
     "SVForecastResult",
+    "ScenarioResult",
     "ShockPath",
     "SignRestriction",
     "StochasticVolatility",
@@ -94,6 +96,7 @@ def __getattr__(name: str):
         "ForecastResult": "impulso.results",
         "ConditionalForecastResult": "impulso.results",
         "CounterfactualResult": "impulso.results",
+        "ScenarioResult": "impulso.results",
         "DynamicMultiplierResult": "impulso.results",
         "ShockPath": "impulso.scenario",
         "VariablePath": "impulso.scenario",

--- a/src/impulso/_scenario.py
+++ b/src/impulso/_scenario.py
@@ -446,3 +446,328 @@ def _calibrate_q(q: np.ndarray, r: int, path_uncertainty: str, d_total: int) -> 
     if path_uncertainty == "unconditional":
         return (1.0 + np.sqrt(1.0 - np.exp(-q / d_total))) / 2.0
     return np.ones_like(q)
+
+
+# --- structural scenarios (three-way partition; ADR-0005 layer 3) ---
+
+
+def resolve_shock_prescriptions(
+    shocks: list[ShockPath],
+    shock_names: list[str],
+    steps: int,
+) -> list[tuple[int, int, float]]:
+    """Resolve forecast-side `ShockPath` prescriptions to `(shock, step, value)`.
+
+    Forecast-side prescriptions are positional from step 1 and must not
+    carry `start`/`end` (those are in-sample-only); a scalar broadcasts to
+    all steps, an array of length `L <= steps` prescribes steps `1..L`,
+    `NaN` entries are free. Duplicates, unknown shocks, and
+    `unidentified_*` columns raise.
+
+    Returns:
+        List of `(shock_index, step_index, value)` with 0-based steps.
+    """
+    from impulso.scenario import ShockPath
+
+    prescriptions: list[tuple[int, int, float]] = []
+    seen: set[tuple[int, int]] = set()
+    for path in shocks:
+        if not isinstance(path, ShockPath):
+            raise TypeError(f"structural_scenario prescriptions must be ShockPath, got {type(path).__name__}")
+        if path.start is not None or path.end is not None:
+            raise ValueError(
+                f"ShockPath for {path.shock!r} carries start/end, which are in-sample-only "
+                "(counterfactual windows); forecast-side prescriptions are positional from step 1."
+            )
+        if path.shock not in shock_names:
+            raise ValueError(f"Unknown shock {path.shock!r}; available shocks: {shock_names}")
+        if path.shock.startswith("unidentified_"):
+            raise ValueError(f"Cannot prescribe {path.shock!r}: unidentified shock columns are rotation-arbitrary.")
+        j = shock_names.index(path.shock)
+        for h, v in enumerate(_prescription_values(path, steps)):
+            if np.isnan(v):
+                continue
+            if (j, h) in seen:
+                raise ValueError(f"Duplicate prescription for {path.shock!r} at step {h + 1}; merge the paths.")
+            seen.add((j, h))
+            prescriptions.append((j, h, float(v)))
+    return prescriptions
+
+
+def _prescription_values(path: ShockPath, steps: int) -> np.ndarray:
+    """Broadcast or validate a prescription's values against the horizon."""
+    if isinstance(path.values, float):
+        if np.isnan(path.values):
+            raise ValueError(f"ShockPath for {path.shock!r} is a scalar NaN — it prescribes nothing.")
+        return np.full(steps, path.values)
+    values = np.asarray(path.values, dtype=np.float64)
+    if values.shape[0] > steps:
+        raise ValueError(
+            f"ShockPath values for {path.shock!r} have length {values.shape[0]} "
+            f"but the forecast has only {steps} steps."
+        )
+    return values
+
+
+def _resolve_adjusting(adjusting: list[str] | None, shock_names: list[str]) -> list[int]:
+    """Resolve the adjusting set to shock indices (default: all shocks).
+
+    The set must contain none or all of the `unidentified_*` columns — a
+    proper subset would make the scenario depend on the arbitrary
+    orthogonal completion (the full block is completion-invariant, the
+    same logic as the HD remainder collapse).
+    """
+    if adjusting is None:
+        return list(range(len(shock_names)))
+    indices: list[int] = []
+    for name in adjusting:
+        if name not in shock_names:
+            raise ValueError(f"Unknown adjusting shock {name!r}; available shocks: {shock_names}")
+        indices.append(shock_names.index(name))
+    unident_all = {i for i, s in enumerate(shock_names) if s.startswith("unidentified_")}
+    unident_in = unident_all & set(indices)
+    if unident_in and unident_in != unident_all:
+        raise ValueError(
+            "The adjusting set must contain none or all of the unidentified_* columns: a proper "
+            "subset makes the scenario depend on the arbitrary orthogonal completion."
+        )
+    return sorted(set(indices))
+
+
+def _forecast_shock_matrices(identified: IdentifiedVAR, steps: int, rng: np.random.Generator) -> np.ndarray:
+    """Scheme-identified structural matrices for the forecast horizon.
+
+    Constant volatility broadcasts the memoised `shock_matrix(at=None)` —
+    never a fresh `identify()` call, so rotation draws stay shared with
+    counterfactual/HD on the same instance. Time-varying volatility
+    identifies each forecast Cholesky slice; rotation-sampling schemes
+    (the `_samples_rotations` capability flag, e.g. `SignRestriction`)
+    cannot yet pin one rotation per draw across steps and error there.
+    """
+    posterior = identified.idata.posterior
+    if not identified.volatility.is_time_varying:
+        P = identified.shock_matrix(at=None).values  # (C, D, n, n)
+        return np.broadcast_to(P[:, :, np.newaxis, :, :], (*P.shape[:2], steps, *P.shape[2:])).copy()
+    if getattr(identified.scheme, "_samples_rotations", False):
+        raise ValueError(
+            f"structural_scenario under time-varying volatility is not supported for "
+            f"rotation-sampling schemes ({type(identified.scheme).__name__}): rotations are "
+            "re-sampled per identify() call, so no single structural coordinate system "
+            "spans the forecast steps. Use a rotation-free scheme (Cholesky, ProxySVAR), "
+            "or constant volatility."
+        )
+    L_path = identified.volatility.forecast_cholesky_path(posterior, steps=steps, rng=rng)
+    P_path = np.zeros_like(L_path)
+    for h in range(steps):
+        P_path[:, :, h] = identified.scheme.identify(
+            L_path[:, :, h],
+            identified.var_names,
+            posterior=posterior,
+            data=identified.data,
+            n_lags=identified.n_lags,
+        )
+    return P_path
+
+
+def _scenario_feasibility(
+    pins: list[tuple[int, int, float]],
+    entries_A: list[tuple[int, int]],
+    n_prescribed: int,
+    steps: int,
+) -> None:
+    """Draw-independent feasibility checks (design section 2, two-tier).
+
+    Errors when the conditions outnumber the effective adjusting entries,
+    globally or in any leading horizon block (conditions at step `h` load
+    only on adjusting entries at steps `<= h`, by block-triangularity).
+    """
+    r = len(pins)
+    if r > len(entries_A):
+        raise ValueError(
+            f"{r} condition(s) but only {len(entries_A)} effective adjusting entr(ies) "
+            f"({n_prescribed} prescribed entr(ies) consumed adjusting capacity); the "
+            "scenario is over-determined. Widen the adjusting set or drop conditions."
+        )
+    for h in range(steps):
+        pins_leading = sum(1 for (_, ph, _) in pins if ph <= h)
+        adjusting_leading = sum(1 for (_, ah) in entries_A if ah <= h)
+        if pins_leading > adjusting_leading:
+            raise ValueError(
+                f"Conditions through step {h + 1} ({pins_leading}) exceed the adjusting "
+                f"entries available at steps <= {h + 1} ({adjusting_leading}); conditions "
+                "at a step load only on adjusting shocks at that step or earlier "
+                "(block-triangularity). Widen the adjusting set or move conditions later."
+            )
+
+
+def structural_scenario_engine(
+    identified: IdentifiedVAR,
+    steps: int,
+    conditions: list[VariablePath],
+    shocks: list[ShockPath],
+    adjusting: list[str] | None,
+    include_shock_uncertainty: bool,
+    seed: int | np.random.Generator | None,
+    exog_future: np.ndarray | None,
+    path_uncertainty: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """ADPRR structural scenario via the three-way partition solve.
+
+    Stacked shock entries split into `D` (prescribed — substituted at
+    their `ShockPath` values, never constraint rows), `A` (adjusting
+    entries not in `D` — absorb the `VariablePath` conditions), and `F`
+    (free — retain unconditional draws). Per free-block draw the solve is
+    `C_A E_A = cbar - C_D v_S - C_F eps_F` with the conditional-Gaussian
+    resolution of under-determination; feasibility is checked once at
+    validation (counting) and per draw (numerical rank of `C_A`).
+
+    Plausibility per draw: `q = ctilde'(C_A C_A')^{-1} ctilde + |v_S|^2`
+    — the prescribed shocks' own magnitude registers even though they are
+    substituted. The ADPRR calibration is finite only under
+    `path_uncertainty="unconditional"` with no prescriptions.
+
+    Returns:
+        Tuple `(paths, q, q_cal, r)` as in `conditional_forecast_engine`.
+    """
+    from impulso._linalg import lag_matrices
+    from impulso._ma import compute_ma_phi
+    from impulso._propagate import propagate
+
+    posterior = identified.idata.posterior
+    B_draws = posterior["B"].values
+    n_lags = identified.n_lags
+    n_chains, n_draws, n_vars, _ = B_draws.shape
+    d_total = steps * n_vars
+    shock_names = identified.shock_names
+
+    pins = resolve_variable_pins(conditions, identified.var_names, steps)
+    prescriptions = resolve_shock_prescriptions(shocks, shock_names, steps)
+    adjusting_idx = _resolve_adjusting(adjusting, shock_names)
+    r = len(pins)
+
+    flat = lambda j, h: h * n_vars + j
+    D_entries = {(j, h) for (j, h, _) in prescriptions}
+    entries_A = [(j, h) for h in range(steps) for j in adjusting_idx if (j, h) not in D_entries]
+    _scenario_feasibility(pins, entries_A, len(D_entries), steps)
+    A_flat = [flat(j, h) for (j, h) in entries_A]
+    D_flat = [flat(j, h) for (j, h, _) in prescriptions]
+    F_flat = sorted(set(range(d_total)) - set(A_flat) - set(D_flat))
+    v_S = np.array([v for (_, _, v) in prescriptions])
+
+    # Deterministic path b (mean recursion from the last observed lags).
+    intercept = posterior["intercept"].values
+    forcing = np.broadcast_to(intercept[:, :, np.newaxis, :], (n_chains, n_draws, steps, n_vars)).copy()
+    if exog_future is not None:
+        forcing += np.einsum("cdij,hj->cdhi", posterior["B_exog"].values, exog_future)
+    A_lags = lag_matrices(B_draws, n_lags)
+    b_path = propagate(A_lags, forcing, identified.data.endog[-n_lags:])
+
+    rng = seed if isinstance(seed, np.random.Generator) else np.random.default_rng(seed)
+    P_path = _forecast_shock_matrices(identified, steps, rng)
+
+    # One per-step innovation grid in forecast()'s stream order — the ξ
+    # source for the free block AND the adjusting-block solve, so the
+    # adjusting=all / no-prescriptions case matches conditional_forecast
+    # draw-for-draw under a shared seed.
+    eps_flat = np.zeros((n_chains, n_draws, d_total))
+    xi_flat = None
+    if include_shock_uncertainty:
+        xi = np.empty((n_chains, n_draws, steps, n_vars))
+        for h in range(steps):
+            xi[:, :, h, :] = rng.standard_normal((n_chains, n_draws, n_vars))
+        xi_flat = xi.reshape(n_chains, n_draws, d_total)
+        if F_flat:
+            eps_flat[:, :, F_flat] = xi_flat[:, :, F_flat]
+    if prescriptions:
+        eps_flat[:, :, D_flat] = v_S[np.newaxis, np.newaxis, :]
+
+    q = np.zeros((n_chains, n_draws))
+    if r:
+        Phi = compute_ma_phi(A_lags, steps - 1)
+        C_rows, _, cbar = _constraint_system(pins, b_path, Phi, P_path, n_vars, d_total)
+        q = _absorb_conditions(C_rows, cbar, eps_flat, xi_flat, A_flat, D_flat, F_flat, v_S, path_uncertainty)
+    elif xi_flat is not None and A_flat:
+        # No conditions: adjusting entries are simply free.
+        eps_flat[:, :, A_flat] = xi_flat[:, :, A_flat]
+
+    if prescriptions:
+        q = q + float(v_S @ v_S)
+
+    eps = eps_flat.reshape(n_chains, n_draws, steps, n_vars)
+    u = np.einsum("cdhij,cdhj->cdhi", P_path, eps)
+    deviation = propagate(A_lags, u, np.zeros((n_lags, n_vars)))
+    paths = b_path + deviation
+
+    q_cal = _calibrate_scenario_q(q, r, len(prescriptions), path_uncertainty, d_total)
+    return paths, q, q_cal, r
+
+
+def _absorb_conditions(
+    C_rows: np.ndarray,
+    cbar: np.ndarray,
+    eps_flat: np.ndarray,
+    xi_flat: np.ndarray | None,
+    A_flat: list[int],
+    D_flat: list[int],
+    F_flat: list[int],
+    v_S: np.ndarray,
+    path_uncertainty: str,
+) -> np.ndarray:
+    """Solve the adjusting block and write it into `eps_flat` (in place).
+
+    Reduces the full constraint rows to the adjusting columns, folds the
+    prescribed and free contributions into the rhs, checks per-draw
+    numerical rank, and fills the adjusting entries per the conditioning
+    mode. Returns the per-draw condition part of the plausibility
+    statistic, `ctilde'(C_A C_A')^{-1} ctilde`.
+    """
+    r = cbar.shape[-1]
+    C_A = C_rows[:, :, :, A_flat]
+    ctilde = cbar.copy()
+    if D_flat:
+        ctilde -= np.einsum("cdrk,k->cdr", C_rows[:, :, :, D_flat], v_S)
+    if F_flat:
+        ctilde -= np.einsum("cdrk,cdk->cdr", C_rows[:, :, :, F_flat], eps_flat[:, :, F_flat])
+
+    ranks = np.linalg.matrix_rank(C_A)
+    if ranks.min() < r:
+        raise ValueError(
+            f"The adjusting-block constraint matrix is rank-deficient for "
+            f"{int((ranks < r).sum())} posterior draw(s) (rank < {r}): the adjusting "
+            "shocks cannot absorb the conditions there (e.g. a Cholesky zero makes a "
+            "condition load on no adjusting shock at its step). Widen the adjusting set."
+        )
+    G_A = np.einsum("cdrk,cdsk->cdrs", C_A, C_A)
+    alpha = np.linalg.solve(G_A, ctilde[..., np.newaxis])[..., 0]
+    E_A_mean = np.einsum("cdrk,cdr->cdk", C_A, alpha)
+
+    if xi_flat is not None and path_uncertainty == "none":
+        xi_A = xi_flat[:, :, A_flat]
+        residual = np.einsum("cdrk,cdk->cdr", C_A, xi_A) - ctilde
+        beta = np.linalg.solve(G_A, residual[..., np.newaxis])[..., 0]
+        eps_flat[:, :, A_flat] = xi_A - np.einsum("cdrk,cdr->cdk", C_A, beta)
+    elif xi_flat is not None:
+        eps_flat[:, :, A_flat] = E_A_mean + xi_flat[:, :, A_flat]
+    else:
+        eps_flat[:, :, A_flat] = E_A_mean
+    return np.einsum("cdr,cdr->cd", ctilde, alpha)
+
+
+def _calibrate_scenario_q(
+    q: np.ndarray,
+    n_conditions: int,
+    n_prescribed: int,
+    path_uncertainty: str,
+    d_total: int,
+) -> np.ndarray:
+    """Scenario variant of the ADPRR calibration.
+
+    Finite only under `path_uncertainty="unconditional"` with no
+    prescriptions (hard substitutions keep the divergence infinite); the
+    ceiling is 1, the no-restriction floor 0.5.
+    """
+    if n_conditions + n_prescribed == 0:
+        return np.full_like(q, 0.5)
+    if path_uncertainty == "unconditional" and n_prescribed == 0:
+        return (1.0 + np.sqrt(1.0 - np.exp(-q / d_total))) / 2.0
+    return np.ones_like(q)

--- a/src/impulso/_scenario.py
+++ b/src/impulso/_scenario.py
@@ -402,12 +402,15 @@ def _constraint_system(
     L_path: np.ndarray,
     n_vars: int,
     d_total: int,
+    warn_on_ill_conditioning: bool = True,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Build the constraint rows `C`, Gram matrix `CC'`, and rhs `cbar`.
 
     Row `k` for pin `(i, h, value)` holds block `(Phi_{h-s} L_{T+s})[i, :]`
     at stacked positions `s*n..(s+1)*n` for `s <= h`; the rhs is
-    `value - b_{i,h}`. Warns when `CC'` is nearly singular.
+    `value - b_{i,h}`. Warns when `CC'` is nearly singular unless the
+    caller solves a column-restricted system and runs its own check on
+    the restricted Gram (`warn_on_ill_conditioning=False`).
     """
     n_chains, n_draws = b_path.shape[:2]
     r = len(pins)
@@ -419,7 +422,7 @@ def _constraint_system(
             block = np.einsum("cdk,cdkl->cdl", Phi[:, :, h - s, i, :], L_path[:, :, s])
             C_rows[:, :, k, s * n_vars : (s + 1) * n_vars] = block
     G = np.einsum("cdrk,cdsk->cdrs", C_rows, C_rows)
-    if np.max(np.linalg.cond(G)) > 1e8:
+    if warn_on_ill_conditioning and np.max(np.linalg.cond(G)) > 1e8:
         # stacklevel targets the public caller of conditional_forecast
         # (user -> conditional_forecast -> engine -> here -> warn).
         warnings.warn(
@@ -610,7 +613,7 @@ def structural_scenario_engine(
     seed: int | np.random.Generator | None,
     exog_future: np.ndarray | None,
     path_uncertainty: str,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int]:
     """ADPRR structural scenario via the three-way partition solve.
 
     Stacked shock entries split into `D` (prescribed — substituted at
@@ -627,7 +630,10 @@ def structural_scenario_engine(
     `path_uncertainty="unconditional"` with no prescriptions.
 
     Returns:
-        Tuple `(paths, q, q_cal, r)` as in `conditional_forecast_engine`.
+        Tuple `(paths, q, q_cond, q_cal, r)`: as in
+        `conditional_forecast_engine` plus `q_cond`, the condition-only
+        part of the plausibility (the `chi^2_r`-referenced quantity —
+        the prescribed `|v_S|^2` term has no chi-squared reference).
     """
     from impulso._linalg import lag_matrices
     from impulso._ma import compute_ma_phi
@@ -644,6 +650,19 @@ def structural_scenario_engine(
     prescriptions = resolve_shock_prescriptions(shocks, shock_names, steps)
     adjusting_idx = _resolve_adjusting(adjusting, shock_names)
     r = len(pins)
+
+    if any(v != 0.0 for (_, _, v) in prescriptions) and getattr(identified.scheme, "scale", None) is not None:
+        # stacklevel targets the public caller of structural_scenario
+        # (user -> structural_scenario -> engine -> warn).
+        warnings.warn(
+            "ShockPath values are in one-standard-deviation units, but the identification "
+            "scheme applies a unit-effect rescaling (scale is set); non-zero prescriptions "
+            "are not invariant to that normalisation and neither is their plausibility "
+            "contribution. Zero prescriptions are safe; for custom paths re-identify with "
+            "scale=None.",
+            UserWarning,
+            stacklevel=3,
+        )
 
     flat = lambda j, h: h * n_vars + j
     D_entries = {(j, h) for (j, h, _) in prescriptions}
@@ -681,17 +700,16 @@ def structural_scenario_engine(
     if prescriptions:
         eps_flat[:, :, D_flat] = v_S[np.newaxis, np.newaxis, :]
 
-    q = np.zeros((n_chains, n_draws))
+    q_cond = np.zeros((n_chains, n_draws))
     if r:
         Phi = compute_ma_phi(A_lags, steps - 1)
-        C_rows, _, cbar = _constraint_system(pins, b_path, Phi, P_path, n_vars, d_total)
-        q = _absorb_conditions(C_rows, cbar, eps_flat, xi_flat, A_flat, D_flat, F_flat, v_S, path_uncertainty)
+        C_rows, _, cbar = _constraint_system(pins, b_path, Phi, P_path, n_vars, d_total, warn_on_ill_conditioning=False)
+        q_cond = _absorb_conditions(C_rows, cbar, eps_flat, xi_flat, A_flat, D_flat, F_flat, v_S, path_uncertainty)
     elif xi_flat is not None and A_flat:
         # No conditions: adjusting entries are simply free.
         eps_flat[:, :, A_flat] = xi_flat[:, :, A_flat]
 
-    if prescriptions:
-        q = q + float(v_S @ v_S)
+    q = q_cond + float(v_S @ v_S) if prescriptions else q_cond
 
     eps = eps_flat.reshape(n_chains, n_draws, steps, n_vars)
     u = np.einsum("cdhij,cdhj->cdhi", P_path, eps)
@@ -699,7 +717,7 @@ def structural_scenario_engine(
     paths = b_path + deviation
 
     q_cal = _calibrate_scenario_q(q, r, len(prescriptions), path_uncertainty, d_total)
-    return paths, q, q_cal, r
+    return paths, q, q_cond, q_cal, r
 
 
 def _absorb_conditions(
@@ -738,6 +756,17 @@ def _absorb_conditions(
             "condition load on no adjusting shock at its step). Widen the adjusting set."
         )
     G_A = np.einsum("cdrk,cdsk->cdrs", C_A, C_A)
+    if np.max(np.linalg.cond(G_A)) > 1e8:
+        # stacklevel targets the public caller of structural_scenario
+        # (user -> structural_scenario -> engine -> here -> warn).
+        warnings.warn(
+            "The adjusting-block constraint system is nearly redundant (condition "
+            "number of C_A C_A' exceeds 1e8) — nearly-collinear condition loadings "
+            "on the adjusting shocks inflate the conditional adjustment and the "
+            "plausibility statistic without tripping the rank check.",
+            UserWarning,
+            stacklevel=4,
+        )
     alpha = np.linalg.solve(G_A, ctilde[..., np.newaxis])[..., 0]
     E_A_mean = np.einsum("cdrk,cdr->cdk", C_A, alpha)
 

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1,6 +1,6 @@
 """Identification schemes for structural VAR analysis."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import pandas as pd
@@ -88,6 +88,11 @@ class SignRestriction(ImpulsoModel):
     n_rotations: int = Field(default=1000, ge=1)
     restriction_horizon: int = Field(default=0, ge=0)
     random_seed: int | None = None
+
+    # Rotation-sampling schemes cannot yet pin one rotation per posterior
+    # draw across forecast steps; forecast-side scenario machinery checks
+    # this capability flag and refuses time-varying volatility.
+    _samples_rotations: ClassVar[bool] = True
 
     # Single-call scratchpad: identify() writes the rate; the pipeline
     # (IdentifiedVAR.shock_matrix) reads it immediately afterwards and

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -649,7 +649,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
         if self.data.exog is not None and exog_future is None:
             raise ValueError("exog_future is required when the model includes exogenous variables")
 
-        paths, q, q_cal, r = structural_scenario_engine(
+        paths, q, q_cond, q_cal, r = structural_scenario_engine(
             self,
             steps=steps,
             conditions=list(conditions or []),
@@ -673,7 +673,9 @@ class IdentifiedVAR(ImpulsoBaseModel):
             "plausibility_calibrated": xr.DataArray(q_cal, dims=["chain", "draw"], name="plausibility_calibrated"),
         })
         ds.attrs["n_restrictions"] = r
-        ds.attrs["chi2_tail_of_median"] = float(chi2.sf(float(np.median(q)), df=r)) if r else 1.0
+        # The chi^2_r reference applies to the condition-only part of q;
+        # the prescribed |v_S|^2 term carries no chi-squared law.
+        ds.attrs["chi2_tail_of_median"] = float(chi2.sf(float(np.median(q_cond)), df=r)) if r else 1.0
         return ScenarioResult(
             idata=az.InferenceData(posterior_predictive=ds),
             steps=steps,
@@ -681,6 +683,6 @@ class IdentifiedVAR(ImpulsoBaseModel):
             mode="density" if include_shock_uncertainty else "mean",
             path_uncertainty=path_uncertainty,
             conditions=list(conditions or []),
-            adjusting=list(adjusting or []),
+            adjusting=adjusting if adjusting is None else list(adjusting),
             shocks=list(shocks or []),
         )

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -14,10 +14,16 @@ from impulso._linalg import lag_matrices
 from impulso._ma import compute_ma_phi
 from impulso.data import VARData
 from impulso.protocols import IdentificationScheme, VolatilityProcess
-from impulso.results import CounterfactualResult, FEVDResult, HistoricalDecompositionResult, IRFResult
+from impulso.results import (
+    CounterfactualResult,
+    FEVDResult,
+    HistoricalDecompositionResult,
+    IRFResult,
+    ScenarioResult,
+)
 
 if TYPE_CHECKING:
-    from impulso.scenario import ShockPath
+    from impulso.scenario import ShockPath, VariablePath
 
 # Type alias for the `at=` parameter used by query methods.
 AtParam = int | Literal["last", "all"] | None
@@ -539,3 +545,142 @@ class IdentifiedVAR(ImpulsoBaseModel):
         )
         idata = az.InferenceData(posterior_predictive=xr.Dataset({"counterfactual": cf_da, "actual": actual_da}))
         return CounterfactualResult(idata=idata, var_names=self.var_names)
+
+    def structural_scenario(
+        self,
+        steps: int,
+        conditions: "list[VariablePath] | None" = None,
+        shocks: "list[ShockPath] | None" = None,
+        adjusting: list[str] | None = None,
+        include_shock_uncertainty: bool = True,
+        seed: int | np.random.Generator | None = None,
+        exog_future: np.ndarray | None = None,
+        path_uncertainty: Literal["none", "unconditional"] = "none",
+    ) -> ScenarioResult:
+        """Structural scenario: conditions absorbed by named shocks, paths prescribed.
+
+        The ADPRR structural scenario (Antolín-Díaz, Petrella &
+        Rubio-Ramírez 2021), combinable in both flavours:
+        *conditional-on-observables* — `VariablePath` pins that must be
+        absorbed by the `adjusting` shocks while non-adjusting shocks keep
+        their unconditional draws — and *conditional-on-shocks* —
+        forecast-side `ShockPath` prescriptions, substituted outright
+        (positional from step 1; a prescription always wins over
+        adjusting membership at its steps). With `adjusting=None` all
+        shocks adjust, and with no prescriptions the result reproduces
+        `conditional_forecast` (exactly per draw under natural-order
+        Cholesky identification with a matched `seed`).
+
+        Feasibility is enforced twice: once at validation (conditions
+        must not outnumber the effective adjusting entries, globally or
+        in any leading horizon block) and per posterior draw (numerical
+        rank of the adjusting-block constraint matrix — a Cholesky zero
+        can make a condition load on no adjusting shock at its step).
+        Infeasible draws error rather than being dropped, which would
+        condition the posterior on feasibility.
+
+        The per-draw plausibility statistic includes the prescribed
+        shocks' own magnitude: `q = c̃'(C_A C_A')⁻¹c̃ + |v_S|²` in
+        one-standard-deviation units — prescribing a 3-sd shock registers
+        as `q += 9` even though prescriptions are substituted. The
+        ADPRR-calibrated `q_cal` is finite only under
+        `path_uncertainty="unconditional"` with no prescriptions.
+
+        Note:
+            Under time-varying volatility the scheme-identified forecast
+            factors are built per simulated volatility path
+            (conditional-on-path; see ADR-0005), and `SignRestriction` is
+            not supported there — the scheme re-samples rotations per
+            call, so no single structural coordinate system spans the
+            forecast steps. Under constant volatility the memoised
+            `shock_matrix` is broadcast, sharing rotation draws with
+            `counterfactual` and the historical decomposition on this
+            instance.
+
+        Args:
+            steps: Number of forecast steps.
+            conditions: `VariablePath` pins to be absorbed by the
+                adjusting shocks.
+            shocks: Forecast-side `ShockPath` prescriptions (no
+                `start`/`end`; positional from step 1; `NaN` = free).
+            adjusting: Names of the shocks permitted to absorb the
+                conditions. `None` (default) lets every shock adjust.
+                Must contain none or all of any `unidentified_*` columns.
+            include_shock_uncertainty: Density mode (default) vs mean
+                mode (free block zeroed, conditional mean propagated).
+            seed: RNG seed (int) or Generator.
+            exog_future: Future exogenous values, shape `(steps, k)`.
+                Required if the posterior carries `B_exog`.
+            path_uncertainty: `"none"` (hard pins) or `"unconditional"`
+                (pins restrict the mean; bands keep unconditional width).
+
+        Returns:
+            ScenarioResult with forecast draws, the scenario ingredients
+            echoed, and the plausibility statistics.
+
+        Raises:
+            ValueError: On unknown shocks/variables, `unidentified_*`
+                references, in-sample windows on prescriptions, duplicate
+                pins or prescriptions, over-determination, per-draw rank
+                failure, `SignRestriction` under time-varying volatility,
+                an invalid `path_uncertainty`, or exogenous-data
+                mismatches.
+        """
+        from scipy.stats import chi2
+
+        from impulso._scenario import structural_scenario_engine
+
+        if path_uncertainty not in ("none", "unconditional"):
+            raise ValueError(f"path_uncertainty must be 'none' or 'unconditional', got {path_uncertainty!r}")
+        posterior = self.idata.posterior
+        if self.data.exog is not None and "B_exog" not in posterior:
+            raise ValueError(
+                "This IdentifiedVAR's data carries exogenous regressors the estimator "
+                "never consumed (no B_exog in the posterior); refit with an estimator "
+                "that supports them before scenario analysis."
+            )
+        if exog_future is not None:
+            if "B_exog" not in posterior:
+                raise ValueError("exog_future provided but the posterior carries no B_exog.")
+            exog_future = np.asarray(exog_future, dtype=float)
+            n_exog = posterior["B_exog"].shape[-1]
+            if exog_future.shape != (steps, n_exog):
+                raise ValueError(f"exog_future must have shape ({steps}, {n_exog}), got {exog_future.shape}.")
+        if self.data.exog is not None and exog_future is None:
+            raise ValueError("exog_future is required when the model includes exogenous variables")
+
+        paths, q, q_cal, r = structural_scenario_engine(
+            self,
+            steps=steps,
+            conditions=list(conditions or []),
+            shocks=list(shocks or []),
+            adjusting=adjusting,
+            include_shock_uncertainty=include_shock_uncertainty,
+            seed=seed,
+            exog_future=exog_future,
+            path_uncertainty=path_uncertainty,
+        )
+
+        forecast_da = xr.DataArray(
+            paths,
+            dims=["chain", "draw", "step", "variable"],
+            coords={"variable": self.var_names},
+            name="forecast",
+        )
+        ds = xr.Dataset({
+            "forecast": forecast_da,
+            "plausibility": xr.DataArray(q, dims=["chain", "draw"], name="plausibility"),
+            "plausibility_calibrated": xr.DataArray(q_cal, dims=["chain", "draw"], name="plausibility_calibrated"),
+        })
+        ds.attrs["n_restrictions"] = r
+        ds.attrs["chi2_tail_of_median"] = float(chi2.sf(float(np.median(q)), df=r)) if r else 1.0
+        return ScenarioResult(
+            idata=az.InferenceData(posterior_predictive=ds),
+            steps=steps,
+            var_names=self.var_names,
+            mode="density" if include_shock_uncertainty else "mean",
+            path_uncertainty=path_uncertainty,
+            conditions=list(conditions or []),
+            adjusting=list(adjusting or []),
+            shocks=list(shocks or []),
+        )

--- a/src/impulso/plotting/__init__.py
+++ b/src/impulso/plotting/__init__.py
@@ -7,6 +7,7 @@ from impulso.plotting._fevd import plot_fevd
 from impulso.plotting._forecast import plot_forecast
 from impulso.plotting._historical_decomposition import plot_historical_decomposition
 from impulso.plotting._irf import plot_irf
+from impulso.plotting._structural_scenario import plot_structural_scenario
 from impulso.plotting._sv_forecast import plot_sv_forecast
 from impulso.plotting._sv_volatility import plot_volatility
 
@@ -18,6 +19,7 @@ __all__ = [
     "plot_forecast",
     "plot_historical_decomposition",
     "plot_irf",
+    "plot_structural_scenario",
     "plot_sv_forecast",
     "plot_volatility",
 ]

--- a/src/impulso/plotting/_structural_scenario.py
+++ b/src/impulso/plotting/_structural_scenario.py
@@ -31,7 +31,8 @@ def plot_structural_scenario(
 
     fig = plot_conditional_forecast(result, prob=prob, figsize=figsize)
     title = fig._suptitle.get_text().replace("Conditional Forecast", "Structural Scenario")
-    if result.adjusting:
-        title += f" — adjusting: {', '.join(result.adjusting)}"
+    if result.adjusting is not None:
+        names = ", ".join(result.adjusting) if result.adjusting else "(none)"
+        title += f" — adjusting: {names}"
     fig.suptitle(title)
     return fig

--- a/src/impulso/plotting/_structural_scenario.py
+++ b/src/impulso/plotting/_structural_scenario.py
@@ -1,0 +1,37 @@
+"""Structural-scenario plotting."""
+
+from typing import TYPE_CHECKING
+
+from matplotlib.figure import Figure
+
+if TYPE_CHECKING:
+    from impulso.results import ScenarioResult
+
+
+def plot_structural_scenario(
+    result: "ScenarioResult",
+    prob: float = 0.89,
+    figsize: tuple[float, float] | None = None,
+) -> Figure:
+    """Plot a structural scenario, one panel per variable.
+
+    Shares the conditional-forecast fan layout (median, HDI band, pinned
+    values marked) with a scenario title; the adjusting set, when
+    restricted, is reported in the suptitle.
+
+    Args:
+        result: ScenarioResult.
+        prob: Probability mass for the HDI band. Default 0.89.
+        figsize: Figure size.  Defaults to (12, 3 * n_vars).
+
+    Returns:
+        Matplotlib Figure.
+    """
+    from impulso.plotting._conditional_forecast import plot_conditional_forecast
+
+    fig = plot_conditional_forecast(result, prob=prob, figsize=figsize)
+    title = fig._suptitle.get_text().replace("Conditional Forecast", "Structural Scenario")
+    if result.adjusting:
+        title += f" — adjusting: {', '.join(result.adjusting)}"
+    fig.suptitle(title)
+    return fig

--- a/src/impulso/protocols.py
+++ b/src/impulso/protocols.py
@@ -29,7 +29,16 @@ class Sampler(Protocol):
 
 @runtime_checkable
 class IdentificationScheme(Protocol):
-    """Contract for structural identification schemes."""
+    """Contract for structural identification schemes.
+
+    Optional capability flag: schemes that *sample* rotations inside
+    `identify` (a fresh draw per call, as `SignRestriction` does) must set
+    a truthy class attribute `_samples_rotations`. Forecast-side scenario
+    machinery reads it via `getattr(scheme, "_samples_rotations", False)`
+    and refuses time-varying volatility for such schemes — no single
+    structural coordinate system would span the forecast steps otherwise.
+    Deterministic schemes (`Cholesky`, `ProxySVAR`) omit the flag.
+    """
 
     def identify(
         self,

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -483,15 +483,18 @@ class ScenarioResult(ConditionalForecastResult):
     the adjusting set and any prescribed shock paths; the forecast and
     plausibility surface (`median`, `hdi`, `plausibility`) is inherited.
     The per-draw `plausibility` includes the prescribed shocks' own
-    magnitude `|v_S|^2` in one-standard-deviation units.
+    magnitude `|v_S|^2` in one-standard-deviation units; the chi-squared
+    tail probability in attrs refers to the condition-only part.
 
     Attributes:
-        adjusting: Names of the shocks permitted to absorb the conditions
-            (empty means all shocks were free to adjust).
+        adjusting: Names of the shocks permitted to absorb the conditions,
+            echoed verbatim from the call: `None` means every shock was
+            free to adjust; an empty list means none were (the pure
+            substitution case).
         shocks: The prescribed `ShockPath` sequences echoed from the call.
     """
 
-    adjusting: list[str] = Field(default_factory=list)
+    adjusting: list[str] | None = None
     shocks: list[ShockPath] = Field(default_factory=list, repr=False)
 
     def plot(self) -> Figure:

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -11,7 +11,7 @@ from matplotlib.figure import Figure
 from pydantic import Field
 
 from impulso._base import ImpulsoBaseModel
-from impulso.scenario import VariablePath
+from impulso.scenario import ShockPath, VariablePath
 
 
 def _wide_frame(da: xr.DataArray, row_dim: str, col_dim: str = "shock") -> pd.DataFrame:
@@ -474,6 +474,31 @@ class ConditionalForecastResult(VARResultBase):
         from impulso.plotting import plot_conditional_forecast
 
         return plot_conditional_forecast(self)
+
+
+class ScenarioResult(ConditionalForecastResult):
+    """Result from structural scenario analysis.
+
+    Extends `ConditionalForecastResult` with the structural ingredients —
+    the adjusting set and any prescribed shock paths; the forecast and
+    plausibility surface (`median`, `hdi`, `plausibility`) is inherited.
+    The per-draw `plausibility` includes the prescribed shocks' own
+    magnitude `|v_S|^2` in one-standard-deviation units.
+
+    Attributes:
+        adjusting: Names of the shocks permitted to absorb the conditions
+            (empty means all shocks were free to adjust).
+        shocks: The prescribed `ShockPath` sequences echoed from the call.
+    """
+
+    adjusting: list[str] = Field(default_factory=list)
+    shocks: list[ShockPath] = Field(default_factory=list, repr=False)
+
+    def plot(self) -> Figure:
+        """Plot the structural scenario fan chart with pinned values marked."""
+        from impulso.plotting import plot_structural_scenario
+
+        return plot_structural_scenario(self)
 
 
 class CounterfactualResult(VARResultBase):

--- a/tests/test_structural_scenario.py
+++ b/tests/test_structural_scenario.py
@@ -1,0 +1,265 @@
+"""Invariant tests for IdentifiedVAR.structural_scenario (PR 4 of the scenario stack).
+
+Core identities (design + ADR-0005): nesting to conditional_forecast under
+adjusting=all with no prescriptions (exact per draw, Cholesky + matched
+seed); the substitution edge (prescribing every shock equals deterministic
+propagation); two-tier feasibility; the combined flavour; and the
+prescribed-shock plausibility term.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from impulso._linalg import lag_matrices
+from impulso._propagate import propagate
+from impulso._scenario import _resolve_adjusting
+from impulso.fitted import FittedVAR
+from impulso.identification import Cholesky, SignRestriction
+from impulso.identified import IdentifiedVAR
+from impulso.results import ScenarioResult
+from impulso.scenario import ShockPath, VariablePath
+from impulso.volatility import Constant
+
+
+@pytest.fixture
+def fitted_2v(synthetic_idata_2v, var_data_2v):
+    return FittedVAR(
+        idata=synthetic_idata_2v,
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+
+
+@pytest.fixture
+def identified_2v(fitted_2v):
+    return fitted_2v.set_identification_strategy(Cholesky(ordering=["y1", "y2"]))
+
+
+class TestConditionalForecastNesting:
+    def test_all_adjusting_no_prescriptions_matches_conditional_forecast(self, identified_2v, fitted_2v):
+        """Invariant 6: exact per draw under Cholesky identification + matched seed."""
+        conditions = [VariablePath(variable="y1", values=0.4)]
+        scn = identified_2v.structural_scenario(steps=5, conditions=conditions, seed=21)
+        cf = fitted_2v.conditional_forecast(steps=5, conditions=conditions, seed=21)
+        np.testing.assert_allclose(
+            scn.idata.posterior_predictive["forecast"].values,
+            cf.idata.posterior_predictive["forecast"].values,
+            atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            scn.idata.posterior_predictive["plausibility"].values,
+            cf.idata.posterior_predictive["plausibility"].values,
+            atol=1e-10,
+        )
+
+    def test_no_ingredients_matches_forecast_nesting(self, identified_2v, fitted_2v):
+        scn = identified_2v.structural_scenario(steps=6, seed=7)
+        fc = fitted_2v.forecast(steps=6, seed=7)
+        np.testing.assert_allclose(
+            scn.idata.posterior_predictive["forecast"].values,
+            fc.idata.posterior_predictive["forecast"].values,
+            atol=1e-8,
+        )
+
+
+class TestSubstitutionEdge:
+    def test_prescribing_every_shock_is_deterministic_propagation(self, identified_2v, synthetic_idata_2v):
+        """Invariant 8: full prescription with an empty adjusting set, no solve."""
+        steps = 4
+        v1 = 0.1 * np.arange(1, steps + 1)
+        v2 = -0.05 * np.arange(1, steps + 1)
+        kwargs = {
+            "steps": steps,
+            "shocks": [ShockPath(shock="y1", values=v1), ShockPath(shock="y2", values=v2)],
+            "adjusting": [],
+        }
+        density = identified_2v.structural_scenario(**kwargs, seed=3)
+        mean = identified_2v.structural_scenario(**kwargs, include_shock_uncertainty=False)
+        # Deterministic given the posterior draw: density mode equals mean mode.
+        np.testing.assert_allclose(
+            density.idata.posterior_predictive["forecast"].values,
+            mean.idata.posterior_predictive["forecast"].values,
+            atol=1e-12,
+        )
+
+        # Hand propagation: y = b + propagate(P eps).
+        posterior = synthetic_idata_2v.posterior
+        B = posterior["B"].values
+        intercept = posterior["intercept"].values
+        P = identified_2v.shock_matrix(at=None).values
+        n_chains, n_draws, n, _ = B.shape
+        eps = np.stack([v1, v2], axis=-1)  # (steps, n)
+        u = np.einsum("cdij,hj->cdhi", P, eps)
+        A = lag_matrices(B, 1)
+        forcing = np.broadcast_to(intercept[:, :, np.newaxis, :], (n_chains, n_draws, steps, n)).copy()
+        b = propagate(A, forcing, identified_2v.data.endog[-1:])
+        expected = b + propagate(A, u, np.zeros((1, n)))
+        np.testing.assert_allclose(density.idata.posterior_predictive["forecast"].values, expected, atol=1e-8)
+
+
+class TestCombinedFlavours:
+    def test_pin_holds_while_other_shock_is_prescribed(self, identified_2v):
+        scn = identified_2v.structural_scenario(
+            steps=4,
+            conditions=[VariablePath(variable="y1", values=0.5)],
+            shocks=[ShockPath(shock="y2", values=1.0)],
+            adjusting=["y1"],
+            seed=2,
+        )
+        draws = scn.idata.posterior_predictive["forecast"].values
+        np.testing.assert_allclose(draws[:, :, :, 0], 0.5, atol=1e-8)
+        # Prescribed magnitude registers in the plausibility statistic.
+        assert scn.idata.posterior_predictive["plausibility"].values.min() >= 4.0 - 1e-10
+
+    def test_prescription_changes_the_path(self, identified_2v):
+        base = identified_2v.structural_scenario(
+            steps=4, shocks=[ShockPath(shock="y2", values=0.0)], adjusting=[], include_shock_uncertainty=False
+        )
+        pushed = identified_2v.structural_scenario(
+            steps=4, shocks=[ShockPath(shock="y2", values=2.0)], adjusting=[], include_shock_uncertainty=False
+        )
+        diff = np.abs(
+            base.idata.posterior_predictive["forecast"].values - pushed.idata.posterior_predictive["forecast"].values
+        )
+        assert diff.max() > 0.1
+
+
+class TestPlausibility:
+    def test_prescription_only_q_is_squared_magnitude(self, identified_2v):
+        scn = identified_2v.structural_scenario(
+            steps=3, shocks=[ShockPath(shock="y1", values=2.0)], adjusting=[], include_shock_uncertainty=False
+        )
+        pp = scn.idata.posterior_predictive
+        np.testing.assert_allclose(pp["plausibility"].values, 3 * 4.0, atol=1e-12)
+        np.testing.assert_array_equal(pp["plausibility_calibrated"].values, 1.0)
+
+    def test_ray_monotone_in_expectation_under_proper_adjusting(self, identified_2v):
+        """Invariant 9 (adjusting part): monotone in expectation over free draws."""
+
+        def mean_q(value: float) -> float:
+            scn = identified_2v.structural_scenario(
+                steps=3,
+                conditions=[VariablePath(variable="y1", values=value)],
+                adjusting=["y1"],
+                seed=5,
+            )
+            return float(scn.idata.posterior_predictive["plausibility"].values.mean())
+
+        assert mean_q(3.0) > mean_q(1.0)
+
+
+class TestFeasibility:
+    def test_over_determination_errors_at_validation(self, identified_2v):
+        with pytest.raises(ValueError, match="adjusting capacity"):
+            identified_2v.structural_scenario(
+                steps=4,
+                conditions=[VariablePath(variable="y1", values=0.5)],
+                shocks=[ShockPath(shock="y1", values=1.0)],
+                adjusting=["y1"],
+            )
+
+    def test_leading_block_counting_errors(self, identified_2v):
+        with pytest.raises(ValueError, match="through step 1"):
+            identified_2v.structural_scenario(
+                steps=4,
+                conditions=[
+                    VariablePath(variable="y1", values=np.array([0.5])),
+                    VariablePath(variable="y2", values=np.array([0.5])),
+                ],
+                adjusting=["y1"],
+            )
+
+    def test_per_draw_rank_failure_errors(self, identified_2v):
+        """Cholesky zero: variable 1 at step 1 loads on no adjusting shock 2 entry."""
+        with pytest.raises(ValueError, match="rank-deficient"):
+            identified_2v.structural_scenario(
+                steps=2,
+                conditions=[VariablePath(variable="y1", values=np.array([0.5]))],
+                adjusting=["y2"],
+            )
+
+
+class TestGuards:
+    def test_in_sample_window_on_prescription_errors(self, identified_2v, var_data_2v):
+        with pytest.raises(ValueError, match="in-sample-only"):
+            identified_2v.structural_scenario(
+                steps=4,
+                shocks=[ShockPath(shock="y1", values=0.0, start=var_data_2v.index[5])],
+            )
+
+    def test_unknown_adjusting_shock_errors(self, identified_2v):
+        with pytest.raises(ValueError, match="Unknown adjusting shock"):
+            identified_2v.structural_scenario(steps=4, adjusting=["oil"])
+
+    def test_duplicate_prescriptions_error(self, identified_2v):
+        with pytest.raises(ValueError, match="Duplicate prescription"):
+            identified_2v.structural_scenario(
+                steps=4,
+                shocks=[
+                    ShockPath(shock="y1", values=1.0),
+                    ShockPath(shock="y1", values=np.array([0.5])),
+                ],
+            )
+
+    def test_unidentified_adjusting_none_or_all_rule(self):
+        names = ["target", "unidentified_0", "unidentified_1"]
+        assert _resolve_adjusting(["target"], names) == [0]
+        assert _resolve_adjusting(["unidentified_0", "unidentified_1"], names) == [1, 2]
+        with pytest.raises(ValueError, match="none or all"):
+            _resolve_adjusting(["unidentified_0"], names)
+
+    def test_sign_restriction_under_time_varying_volatility_errors(self, synthetic_idata_2v, var_data_2v):
+        class _TimeVaryingStub:
+            name = "fake-sv"
+            is_time_varying = True
+
+        identified = IdentifiedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=_TimeVaryingStub(),
+            scheme=SignRestriction.model_construct(restrictions={"y1": {"demand": "+", "supply": "+"}}),
+        )
+        with pytest.raises(ValueError, match="SignRestriction"):
+            identified.structural_scenario(steps=3, conditions=[VariablePath(variable="y1", values=0.1)])
+
+
+class TestPathUncertainty:
+    def test_unconditional_mode_keeps_spread_while_mean_binds(self, identified_2v):
+        conditions = [VariablePath(variable="y1", values=0.4)]
+        hard = identified_2v.structural_scenario(steps=4, conditions=conditions, seed=9)
+        soft = identified_2v.structural_scenario(
+            steps=4, conditions=conditions, seed=9, path_uncertainty="unconditional"
+        )
+        hard_draws = hard.idata.posterior_predictive["forecast"].values
+        soft_draws = soft.idata.posterior_predictive["forecast"].values
+        np.testing.assert_allclose(hard_draws[:, :, :, 0], 0.4, atol=1e-8)
+        assert soft_draws[:, :, 0, 0].std() > 10 * hard_draws[:, :, 0, 0].std()
+
+
+class TestResultSurface:
+    def test_scenario_result_fields_and_plot(self, identified_2v):
+        scn = identified_2v.structural_scenario(
+            steps=4,
+            conditions=[VariablePath(variable="y1", values=0.2)],
+            adjusting=["y1", "y2"],
+            seed=1,
+        )
+        assert isinstance(scn, ScenarioResult)
+        assert scn.adjusting == ["y1", "y2"]
+        assert scn.median().shape == (4, 2)
+        summary = scn.plausibility()
+        assert summary["n_restrictions"] == 4
+        fig = scn.plot()
+        assert isinstance(fig, Figure)
+        title = fig._suptitle.get_text()
+        assert "Structural Scenario" in title
+        assert "adjusting: y1, y2" in title

--- a/tests/test_structural_scenario.py
+++ b/tests/test_structural_scenario.py
@@ -232,6 +232,258 @@ class TestGuards:
             identified.structural_scenario(steps=3, conditions=[VariablePath(variable="y1", values=0.1)])
 
 
+class _RngConsumingVol:
+    """Time-varying fake whose forecast Cholesky path consumes the generator."""
+
+    name = "fake-sv"
+    is_time_varying = True
+
+    def build_pymc_latent(self, n_vars, T):  # pragma: no cover
+        raise NotImplementedError
+
+    def cholesky_at(self, posterior, t):
+        return posterior["L"].values
+
+    def cholesky_path(self, posterior, T):  # pragma: no cover
+        raise NotImplementedError
+
+    def forecast_cholesky_path(self, posterior, steps, rng):
+        L = posterior["L"].values
+        n_chains, n_draws = L.shape[:2]
+        scales = 1.0 + 0.2 * np.abs(rng.standard_normal((n_chains, n_draws, steps)))
+        return L[:, :, np.newaxis, :, :] * scales[:, :, :, np.newaxis, np.newaxis]
+
+
+class TestTimeVaryingVolatility:
+    @pytest.fixture
+    def pair_sv(self, synthetic_idata_2v, var_data_2v):
+        fitted = FittedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=_RngConsumingVol(),
+        )
+        identified = IdentifiedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=_RngConsumingVol(),
+            scheme=Cholesky(ordering=["y1", "y2"]),
+        )
+        return fitted, identified
+
+    def test_per_slice_identify_happy_path_pins_hold(self, pair_sv):
+        """The per-slice identify branch runs and pins hold per draw."""
+        _, identified = pair_sv
+        scn = identified.structural_scenario(steps=4, conditions=[VariablePath(variable="y1", values=0.4)], seed=3)
+        draws = scn.idata.posterior_predictive["forecast"].values
+        np.testing.assert_allclose(draws[:, :, :, 0], 0.4, atol=1e-8)
+
+    def test_matched_seed_nesting_under_generator_consuming_volatility(self, pair_sv):
+        """The rng stream order through _forecast_shock_matrices matches PR3's engine."""
+        fitted, identified = pair_sv
+        conditions = [VariablePath(variable="y1", values=0.4)]
+        scn = identified.structural_scenario(steps=5, conditions=conditions, seed=17)
+        cf = fitted.conditional_forecast(steps=5, conditions=conditions, seed=17)
+        np.testing.assert_allclose(
+            scn.idata.posterior_predictive["forecast"].values,
+            cf.idata.posterior_predictive["forecast"].values,
+            atol=1e-8,
+        )
+
+
+def _single_draw_identified_exog():
+    """Single-draw exog posterior, Cholesky-identified."""
+    import arviz as az
+    import pandas as pd
+    import xarray as xr
+
+    from impulso.data import VARData
+
+    rng = np.random.default_rng(7)
+    posterior = xr.Dataset({
+        "B": (("chain", "draw", "var", "coeff"), np.array([[[[0.5, 0.1], [-0.2, 0.3]]]])),
+        "B_exog": (("chain", "draw", "var", "exog"), np.array([[[[0.8], [-0.3]]]])),
+        "intercept": (("chain", "draw", "var"), np.array([[[0.1, -0.05]]])),
+        "L": (("chain", "draw", "var1", "var2"), np.array([[np.linalg.cholesky(np.array([[1.0, 0.3], [0.3, 0.8]]))]])),
+    })
+    data = VARData(
+        endog=rng.standard_normal((12, 2)),
+        endog_names=["y1", "y2"],
+        exog=rng.standard_normal((12, 1)),
+        exog_names=["z"],
+        index=pd.date_range("2000-01-01", periods=12, freq="QS"),
+    )
+    fitted = FittedVAR(
+        idata=az.InferenceData(posterior=posterior),
+        n_lags=1,
+        data=data,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    return fitted, fitted.set_identification_strategy(Cholesky(ordering=["y1", "y2"]))
+
+
+class TestExog:
+    def test_matched_seed_nesting_with_exog(self):
+        fitted, identified = _single_draw_identified_exog()
+        exog_future = np.ones((5, 1))
+        conditions = [VariablePath(variable="y1", values=0.3)]
+        scn = identified.structural_scenario(steps=5, conditions=conditions, seed=9, exog_future=exog_future)
+        cf = fitted.conditional_forecast(steps=5, conditions=conditions, seed=9, exog_future=exog_future)
+        np.testing.assert_allclose(
+            scn.idata.posterior_predictive["forecast"].values,
+            cf.idata.posterior_predictive["forecast"].values,
+            atol=1e-8,
+        )
+
+    def test_exog_shifts_unpinned_path_while_pin_holds(self):
+        _, identified = _single_draw_identified_exog()
+        pin = [VariablePath(variable="y1", values=0.3)]
+        low = identified.structural_scenario(
+            steps=4, conditions=pin, include_shock_uncertainty=False, exog_future=np.zeros((4, 1))
+        )
+        high = identified.structural_scenario(
+            steps=4, conditions=pin, include_shock_uncertainty=False, exog_future=np.ones((4, 1))
+        )
+        low_draws = low.idata.posterior_predictive["forecast"].values
+        high_draws = high.idata.posterior_predictive["forecast"].values
+        np.testing.assert_allclose(low_draws[:, :, :, 0], 0.3, atol=1e-8)
+        np.testing.assert_allclose(high_draws[:, :, :, 0], 0.3, atol=1e-8)
+        assert np.abs(low_draws[:, :, :, 1] - high_draws[:, :, :, 1]).max() > 1e-3
+
+    def test_exog_guard_errors(self, identified_2v):
+        _, identified_exog = _single_draw_identified_exog()
+        with pytest.raises(ValueError, match="required"):
+            identified_exog.structural_scenario(steps=4)
+        with pytest.raises(ValueError, match="shape"):
+            identified_exog.structural_scenario(steps=4, exog_future=np.zeros((3, 1)))
+        with pytest.raises(ValueError, match="no B_exog"):
+            identified_2v.structural_scenario(steps=4, exog_future=np.zeros((4, 1)))
+
+
+class _PartialScheme:
+    """Fake partial identification: L as-is, first column labelled identified."""
+
+    def identify(self, L, var_names, posterior=None, data=None, n_lags=None):
+        del var_names, posterior, data, n_lags
+        return L
+
+    def shock_coords(self, n_vars: int) -> list[str]:
+        return ["target"] + [f"unidentified_{i}" for i in range(n_vars - 1)]
+
+
+class TestPartialIdentification:
+    @pytest.fixture
+    def identified_partial(self, synthetic_idata_2v, var_data_2v):
+        return IdentifiedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+            scheme=_PartialScheme(),
+        )
+
+    def test_prescribing_unidentified_errors(self, identified_partial):
+        with pytest.raises(ValueError, match="Cannot prescribe"):
+            identified_partial.structural_scenario(steps=3, shocks=[ShockPath(shock="unidentified_0", values=1.0)])
+
+    def test_end_to_end_prescribe_identified_column(self, identified_partial):
+        """Prescribe the identified column; the unidentified block absorbs a pin."""
+        scn = identified_partial.structural_scenario(
+            steps=3,
+            conditions=[VariablePath(variable="y2", values=np.array([0.4]))],
+            shocks=[ShockPath(shock="target", values=1.0)],
+            seed=4,
+        )
+        draws = scn.idata.posterior_predictive["forecast"].values
+        np.testing.assert_allclose(draws[:, :, 0, 1], 0.4, atol=1e-8)
+        assert scn.idata.posterior_predictive["plausibility"].values.min() >= 3.0 - 1e-10
+
+
+class TestNumericalGuards:
+    def test_near_collinear_adjusting_block_warns(self):
+        """cond(C_A C_A') check fires where the full-Gram check cannot."""
+        import arviz as az
+        import pandas as pd
+        import xarray as xr
+
+        from impulso.data import VARData
+
+        rng = np.random.default_rng(0)
+        B = np.array([[[[0.5, 1e-6], [1e-6, 0.5]]]])
+        posterior = xr.Dataset({
+            "B": (("chain", "draw", "var", "coeff"), B),
+            "intercept": (("chain", "draw", "var"), np.zeros((1, 1, 2))),
+            "L": (("chain", "draw", "var1", "var2"), np.eye(2)[np.newaxis, np.newaxis]),
+        })
+        data = VARData(
+            endog=rng.standard_normal((10, 2)),
+            endog_names=["y1", "y2"],
+            index=pd.date_range("2000-01-01", periods=10, freq="QS"),
+        )
+        fitted = FittedVAR(
+            idata=az.InferenceData(posterior=posterior),
+            n_lags=1,
+            data=data,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+        identified = fitted.set_identification_strategy(Cholesky(ordering=["y1", "y2"]))
+        with pytest.warns(UserWarning, match="adjusting-block"):
+            identified.structural_scenario(
+                steps=2,
+                conditions=[
+                    VariablePath(variable="y1", values=np.array([np.nan, 0.5])),
+                    VariablePath(variable="y2", values=np.array([np.nan, 0.5])),
+                ],
+                adjusting=["y1"],
+                include_shock_uncertainty=False,
+            )
+
+    def test_scale_normalisation_warns_on_prescriptions(self, synthetic_idata_2v, var_data_2v):
+        class _ScaledScheme:
+            scale = 10.0
+
+            def identify(self, L, var_names, posterior=None, data=None, n_lags=None):
+                return L
+
+            def shock_coords(self, n_vars):
+                return ["y1", "y2"]
+
+        identified = IdentifiedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+            scheme=_ScaledScheme(),
+        )
+        with pytest.warns(UserWarning, match="one-standard-deviation"):
+            identified.structural_scenario(
+                steps=3, shocks=[ShockPath(shock="y1", values=2.0)], adjusting=[], include_shock_uncertainty=False
+            )
+
+    def test_chi2_tail_uses_condition_only_q(self, identified_2v):
+        """The chi^2_r reference excludes the prescribed |v_S|^2 term."""
+        from scipy.stats import chi2
+
+        scn = identified_2v.structural_scenario(
+            steps=3,
+            conditions=[VariablePath(variable="y1", values=np.array([0.4]))],
+            shocks=[ShockPath(shock="y2", values=2.0)],
+            adjusting=["y1"],
+            include_shock_uncertainty=False,
+        )
+        pp = scn.idata.posterior_predictive
+        q_cond = pp["plausibility"].values - 3 * 4.0  # subtract |v_S|^2
+        expected = float(chi2.sf(float(np.median(q_cond)), df=1))
+        assert pp.attrs["chi2_tail_of_median"] == pytest.approx(expected)
+
+
 class TestPathUncertainty:
     def test_unconditional_mode_keeps_spread_while_mean_binds(self, identified_2v):
         conditions = [VariablePath(variable="y1", values=0.4)]


### PR DESCRIPTION
Closes #128. **Stacked on #127** (base: `feat/conditional-forecast`) — PR 4 of the scenario-analysis stack (ADR-0005). Completes the engine.

## What

ADPRR structural scenarios (Antolín-Díaz, Petrella & Rubio-Ramírez 2021) in both flavours, combinable:

- **Three-way substitution semantics** (the math-verify P0 amendment): stacked shock entries partition into *prescribed* (`ShockPath` values substituted into the path, never constraint rows — prescription wins over adjusting membership per entry), *adjusting* (absorb the `VariablePath` conditions), and *free* (retain unconditional draws). `adjusting=None` lets every shock adjust; `[]` pins none (pure substitution).
- **Two-tier feasibility**: validation-time counting (global and leading-horizon-block, by block-triangularity of the stacked-MA map) with prescriptions reported as consumed capacity; per-draw numerical rank of the adjusting-block matrix (a Cholesky zero can strand a condition — errors rather than dropping draws, which would condition the posterior on feasibility) plus a cond(C_A C_A′) near-redundancy warning on the *adjusting-block* Gram (the full-Gram check provably cannot fire under a proper subset).
- **Scheme-identified forecast factors**: constant volatility broadcasts the memoised `shock_matrix` (rotation draws shared with `counterfactual`/HD on the same instance); time-varying volatility identifies each forecast Cholesky slice, with rotation-sampling schemes rejected via a documented `_samples_rotations` capability flag on the protocol.
- **Plausibility with the prescribed term**: `q = c̃′(C_A C_A′)⁻¹c̃ + |v_S|²` (a prescribed 3-sd shock registers `q += 9` despite substitution; scale-normalised schemes warn); the χ²_r tail probability refers to the condition-only part; the ADPRR calibration stays finite only under `path_uncertainty="unconditional"` with no prescriptions.
- **`ScenarioResult`** extends `ConditionalForecastResult` with the structural ingredients (adjusting echoed verbatim — `None` vs `[]` preserved); scenario fan plot reports the adjusting set.
- CONTEXT.md gains the scenario-family example-dialogue exchange (all three methods).

## Invariants

Exact matched-seed nesting to `conditional_forecast` under `adjusting=all` (constant **and** generator-consuming volatility — the shared per-step innovation grid makes it draw-for-draw, not just distributional); substitution edge ≡ deterministic propagation (density ≡ mean mode, matches hand propagation); combined flavour (pin holds while another shock is prescribed); prescription-only `q = |v_S|²` exactly; ray monotonicity in expectation under a proper adjusting subset; the full feasibility/guard error matrix; exog end-to-end; partial identification end-to-end.

## Verification

15-agent adversarial review: 11 in-scope findings confirmed, 0 rejected, all folded (adjusting-block cond check with demonstrated silent-blowup repro, prescription scale warning, χ² reference correction, `None`-vs-`[]` metadata, protocol documentation, TV/exog/partial-ID coverage). 527 fast tests, prek/ruff/ty green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ijX6mGAsQQMYvVmxBFXmr