### PR TITLE
chore(release): v0.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "impulso"
-version = "0.0.7"
+version = "0.0.8"
 description = "Bayesian Vector Autoregression (VAR) in Python."
 authors = [{ name = "Thomas Pinder", email = "tompinder@live.co.uk" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "impulso"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
Release v0.0.8. Version-only bump (`pyproject.toml` + `uv.lock`).

**Merge after #131** (the last layer of the scenario stack) so the release contains the full family.

Notable changes since v0.0.7:

- feat: PyMC interop primitives — dynamic multipliers, labelled posteriors, retained model (#118)
- fix: historical decomposition now propagates contributions through the lag dynamics, with an explicit baseline and exact additivity (#123, breaking pre-v0.1: `cumulative=` retired)
- feat: condition vocabulary (`ShockPath`, `VariablePath`) + historical counterfactuals via `IdentifiedVAR.counterfactual()` (#125)
- feat: conditional forecasting via `FittedVAR.conditional_forecast()` with plausibility statistics (`q`, ADPRR-calibrated `q_cal`) and the `path_uncertainty="unconditional"` mode (#127); fixes the conjugate forecast-volatility anchor (#120) and exog handling (#121)
- feat: structural scenarios via `IdentifiedVAR.structural_scenario()` — adjusting sets, prescribed shock paths, two-tier feasibility (#129)
- docs: counterfactuals & scenario-analysis tutorial + references (#131)

Merging to `main` then publishing a GitHub Release tagged `v0.0.8` triggers `release-main` → PyPI publish.

Local verification: `make check` clean; `pytest -m "not slow"` → 527 passed; `uv lock --locked` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ijX6mGAsQQMYvVmxBFXmr