### PR TITLE
ci: add catch-all category to the release-notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,3 +18,6 @@ changelog:
     - title: "📖 Documentation"
       labels:
         - documentation
+    - title: "🧩 Other"
+      labels:
+        - "*"


### PR DESCRIPTION
Two-line config change: adds a wildcard `Other` category to `.github/release.yml`.

**Why**: the generator only lists PRs whose labels match a category, and with no catch-all, unlabelled PRs vanish silently — which is exactly how the v0.0.7 and v0.0.8 releases shipped with empty "What's Changed" sections (both now fixed retroactively by labelling their PRs and regenerating). With this change, an unlabelled PR (or a dependabot bump, whose `dependencies`/`github_actions` labels match no category) lands under "Other" instead of disappearing; the labelled categories keep working exactly as before, since the generator assigns each PR to its first matching category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ijX6mGAsQQMYvVmxBFXmr