### PR TITLE
chore(ci): weekly grouped Dependabot on the uv ecosystem

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -7,9 +7,9 @@ inputs:
     required: true
     default: "3.12"
   uv-version:
-    description: "uv version to use"
+    description: "uv version to use ('latest' tracks the newest release)"
     required: true
-    default: "0.9.28"
+    default: "latest"
 
 runs:
   using: "composite"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,44 @@
 version: 2
+
 updates:
-  - package-ecosystem: "pip"
+  # Python dependencies: pyproject.toml + uv.lock.
+  #
+  # Must be the `uv` ecosystem, not `pip`. Only `uv` re-resolves uv.lock; `pip`
+  # would edit pyproject.toml and leave the lock stale, which fails CI because
+  # .github/actions/setup-python-env installs with `uv sync --frozen`.
+  # Covers [project.dependencies], [project.optional-dependencies] and the
+  # PEP 735 [dependency-groups] tables (dev, docs).
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "05:00" # UTC
+    # One PR per run for every Python dependency, rather than one PR each.
+    groups:
+      python:
+        patterns:
+          - "*"
+    # impulso is a library, so its `>=` floors are a compatibility promise.
+    # Land the bump in uv.lock and only touch a floor if it genuinely excludes
+    # the new release.
+    versioning-strategy: "increase-if-necessary"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  # Workflow actions. A separate ecosystem, so necessarily a separate PR from
+  # the Python one, but grouped so it is a single PR, not one per action.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "05:00" # UTC
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
The `pip` ecosystem edits pyproject.toml but never re-resolves uv.lock, so
every Dependabot PR would fail CI against `uv sync --frozen`. Switch to the
`uv` ecosystem, which maintains both files (including the PEP 735
[dependency-groups] tables).

Group each ecosystem under `patterns: ["*"]` so a run produces one Python PR
and one actions PR instead of ~15, pin the schedule to Monday 05:00 UTC, and
set `versioning-strategy: increase-if-necessary` so the library's `>=` floors
in pyproject.toml survive while the bump lands in uv.lock.

Also drop the hand-maintained uv pin in setup-python-env: no ecosystem tracks
that input, so it only ever went stale. `latest` is what setup-uv resolves by
default anyway.
