### PR TITLE
fix(init): module-level lazy-import table and __dir__

### DIFF
--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -79,49 +79,69 @@ __all__ = [
 ]
 
 
+_LAZY_IMPORTS: dict[str, str] = {
+    "FittedVAR": "impulso.fitted",
+    "IdentifiedVAR": "impulso.identified",
+    "Cholesky": "impulso.identification",
+    "ProxySVAR": "impulso.identification",
+    "SignRestriction": "impulso.identification",
+    "MinnesotaPrior": "impulso.priors",
+    "NIWPrior": "impulso.priors",
+    "ConjugateVAR": "impulso.conjugate",
+    "ConjugateVolatility": "impulso.conjugate_volatility",
+    "PandemicBreak": "impulso.conjugate_volatility",
+    "NUTSSampler": "impulso.samplers",
+    "ForecastResult": "impulso.results",
+    "ConditionalForecastResult": "impulso.results",
+    "CounterfactualResult": "impulso.results",
+    "ScenarioResult": "impulso.results",
+    "DynamicMultiplierResult": "impulso.results",
+    "ShockPath": "impulso.scenario",
+    "VariablePath": "impulso.scenario",
+    "IRFResult": "impulso.results",
+    "FEVDResult": "impulso.results",
+    "HistoricalDecompositionResult": "impulso.results",
+    "HDIResult": "impulso.results",
+    "LagOrderResult": "impulso.results",
+    "SVData": "impulso.sv.data",
+    "StochasticVolatility": "impulso.sv.spec",
+    "FittedSV": "impulso.sv.fitted",
+    "SVDefaultPrior": "impulso.sv.priors",
+    "VolatilityResult": "impulso.results",
+    "SVForecastResult": "impulso.results",
+    "Constant": "impulso.volatility",
+    "VolatilityProcess": "impulso.protocols",
+    "compute_ma_phi": "impulso._ma",
+    "lag_matrices": "impulso._linalg",
+}
+"""Map of lazily-exported name to the module that defines it.
+
+Built once at import time so that `__getattr__` does not rebuild it on every
+lazy attribute access.
+"""
+
+
 def __getattr__(name: str):
     """Lazy imports for types not needed at import time."""
-    _lazy_imports = {
-        "FittedVAR": "impulso.fitted",
-        "IdentifiedVAR": "impulso.identified",
-        "Cholesky": "impulso.identification",
-        "ProxySVAR": "impulso.identification",
-        "SignRestriction": "impulso.identification",
-        "MinnesotaPrior": "impulso.priors",
-        "NIWPrior": "impulso.priors",
-        "ConjugateVAR": "impulso.conjugate",
-        "ConjugateVolatility": "impulso.conjugate_volatility",
-        "PandemicBreak": "impulso.conjugate_volatility",
-        "NUTSSampler": "impulso.samplers",
-        "ForecastResult": "impulso.results",
-        "ConditionalForecastResult": "impulso.results",
-        "CounterfactualResult": "impulso.results",
-        "ScenarioResult": "impulso.results",
-        "DynamicMultiplierResult": "impulso.results",
-        "ShockPath": "impulso.scenario",
-        "VariablePath": "impulso.scenario",
-        "IRFResult": "impulso.results",
-        "FEVDResult": "impulso.results",
-        "HistoricalDecompositionResult": "impulso.results",
-        "HDIResult": "impulso.results",
-        "LagOrderResult": "impulso.results",
-        "SVData": "impulso.sv.data",
-        "StochasticVolatility": "impulso.sv.spec",
-        "FittedSV": "impulso.sv.fitted",
-        "SVDefaultPrior": "impulso.sv.priors",
-        "VolatilityResult": "impulso.results",
-        "SVForecastResult": "impulso.results",
-        "Constant": "impulso.volatility",
-        "VolatilityProcess": "impulso.protocols",
-        "compute_ma_phi": "impulso._ma",
-        "lag_matrices": "impulso._linalg",
-    }
-    if name in _lazy_imports:
+    if name in _LAZY_IMPORTS:
         import importlib
 
-        module = importlib.import_module(_lazy_imports[name])
+        module = importlib.import_module(_LAZY_IMPORTS[name])
         return getattr(module, name)
     raise AttributeError(f"module 'impulso' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """List the module's attributes, including the lazily-imported ones.
+
+    Module-level `__getattr__` hides lazy names from the default `dir()`,
+    which degrades REPL completion and IDE discovery. Returning the union of
+    the real globals and `__all__` restores it.
+
+    Returns:
+        Sorted attribute names.
+    """
+    return sorted(set(globals()) | set(__all__))
 
 
 def enable_runtime_checks() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,3 +16,58 @@ def test_lazy_import_unknown_raises():
     """Lazy __getattr__ raises AttributeError for unknown names."""
     with pytest.raises(AttributeError, match="does_not_exist"):
         _ = impulso.does_not_exist
+
+
+def test_lazy_import_unknown_message_shape():
+    """Unknown names report the module and the repr'd attribute name."""
+    with pytest.raises(AttributeError, match=r"module 'impulso' has no attribute 'does_not_exist'"):
+        _ = impulso.does_not_exist
+
+
+@pytest.mark.parametrize("name", impulso.__all__)
+def test_all_names_resolve(name):
+    """Every name advertised in __all__ is resolvable via getattr."""
+    assert getattr(impulso, name) is not None
+
+
+def test_lazy_imports_is_module_level_constant():
+    """The lazy-import table is built once at import time, not per access."""
+    table = impulso._LAZY_IMPORTS
+    assert isinstance(table, dict)
+    # Same object on repeated access -- not rebuilt.
+    assert impulso._LAZY_IMPORTS is table
+
+
+def test_lazy_imports_covers_all_lazy_names():
+    """Names in __all__ are either real globals or present in the lazy table."""
+    eager = set(vars(impulso))
+    missing = [name for name in impulso.__all__ if name not in eager and name not in impulso._LAZY_IMPORTS]
+    assert missing == []
+
+
+def test_lazy_imports_targets_define_their_names():
+    """Each lazy entry points at a module that actually defines the name."""
+    import importlib
+
+    for name, module_path in impulso._LAZY_IMPORTS.items():
+        module = importlib.import_module(module_path)
+        assert hasattr(module, name), f"{module_path} does not define {name}"
+
+
+def test_dir_contains_all_public_names():
+    """dir(impulso) exposes every name in __all__."""
+    listing = dir(impulso)
+    assert set(impulso.__all__) <= set(listing)
+
+
+def test_dir_is_sorted_and_unique():
+    """dir(impulso) returns a sorted, duplicate-free listing."""
+    listing = dir(impulso)
+    assert listing == sorted(listing)
+    assert len(listing) == len(set(listing))
+
+
+def test_dir_includes_real_globals():
+    """dir(impulso) still includes the eagerly-imported globals."""
+    listing = set(dir(impulso))
+    assert {"VAR", "VARData", "select_lag_order", "enable_runtime_checks"} <= listing


### PR DESCRIPTION
## Summary

Two small public-API ergonomics fixes in `src/impulso/__init__.py`:

- **#27**: the 33-entry lazy-import mapping was rebuilt inside `__getattr__` on every lazy attribute access. It is now a module-level constant `_LAZY_IMPORTS`, built once at import time. Names, target modules, and the `AttributeError` message are unchanged.
- **#25**: module-level `__getattr__` hides lazy names from `dir(impulso)`, degrading REPL/IDE completion. A module-level `__dir__` now returns the sorted union of the real globals and `__all__`.

Supersedes stale PR #28 (closed).

Closes #27
Closes #25

## Tests

Extended `tests/test_init.py` (+55 lines): parametrised resolution of all 37 `__all__` names, error-message shape, `_LAZY_IMPORTS` is module-level and covers all lazy names, each lazy target module actually defines its name, and `dir()` is a sorted superset of `__all__` that retains eager globals.

`ruff` / `ty` / fast suite: all green (571 passed, 29 deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV