### PR TITLE
fix(spec): safe default sampler with cores=1 in VAR.fit

### DIFF
--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -62,6 +62,13 @@ class VAR(ImpulsoBaseModel):
             return _VOLATILITY_REGISTRY[self.volatility]()
         return self.volatility
 
+    @staticmethod
+    def _default_sampler() -> Sampler:
+        """Default sampler for VAR: cores=1 (macOS PyMC segfault), target_accept=0.8."""
+        from impulso.samplers import NUTSSampler
+
+        return NUTSSampler(cores=1, chains=4)
+
     def fit(
         self,
         data: VARData,
@@ -71,7 +78,9 @@ class VAR(ImpulsoBaseModel):
 
         Args:
             data: VARData instance.
-            sampler: Sampler protocol instance. Defaults to NUTSSampler().
+            sampler: Sampler protocol instance. Defaults to `_default_sampler()`
+                (`cores=1`, `chains=4`, `target_accept=0.8`). Pass an explicit
+                `NUTSSampler(cores=n)` to opt into parallel chains.
 
         Returns:
             FittedVAR with posterior draws.
@@ -80,10 +89,9 @@ class VAR(ImpulsoBaseModel):
 
         from impulso._lag_selection import select_lag_order
         from impulso.fitted import FittedVAR
-        from impulso.samplers import NUTSSampler
 
         if sampler is None:
-            sampler = NUTSSampler()
+            sampler = self._default_sampler()
 
         # Resolve lags
         if isinstance(self.lags, str):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -45,6 +45,16 @@ class TestVARSpec:
         with pytest.raises(ValidationError):
             VAR(lags=0, prior="minnesota")
 
+    def test_default_sampler_is_safe(self):
+        """The sampler `VAR.fit` falls back to must pin cores=1 to dodge the segfault."""
+        from impulso.samplers import NUTSSampler
+
+        sampler = VAR._default_sampler()
+        assert isinstance(sampler, NUTSSampler)
+        assert sampler.cores == 1
+        assert sampler.chains == 4
+        assert sampler.target_accept == 0.8
+
 
 class TestVolatilityParameter:
     def test_default_volatility_is_constant_string(self):


### PR DESCRIPTION
## Summary

`VAR.fit()` fell back to a bare `NUTSSampler()` when no sampler was passed, which uses parallel multiprocessing defaults that segfault in this environment (documented in CLAUDE.md). It now routes through `VAR._default_sampler()` returning `NUTSSampler(cores=1, chains=4)` (`target_accept` stays at the 0.8 field default), mirroring the existing `StochasticVolatility._default_sampler()` pattern in `sv/spec.py` — same shape, naming, and lazy-import placement.

Audit note: `ConjugateVAR.fit` takes no sampler (direct-draw conjugate engine) and no other production code constructs a bare `NUTSSampler()` default.

Supersedes stale PR #44 (closed).

Closes #43

## Tests

`tests/test_spec.py::TestVARSpec::test_default_sampler_is_safe` — fast, no MCMC; asserts the default's `cores`/`chains`/`target_accept`.

`ruff` / `ty` / fast suite: all green (528 passed, 29 deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV