### PR TITLE
feat(sv): align SVForecastResult index to calendar dates

### DIFF
--- a/src/impulso/_time.py
+++ b/src/impulso/_time.py
@@ -1,0 +1,49 @@
+"""Calendar helpers for building forecast axes from observed indices."""
+
+import pandas as pd
+
+
+def infer_index_freq(index: pd.Index | None) -> pd.offsets.BaseOffset | None:
+    """Detect the sampling frequency of an observed index.
+
+    The index's own `freq` attribute wins; when it is unset, `pd.infer_freq`
+    is consulted. Returns `None` for non-datetime indices, irregular dates,
+    or samples too short to infer from (fewer than three observations).
+
+    Args:
+        index: Observed index, typically `VARData.index` / `SVData.index`.
+
+    Returns:
+        A pandas offset, or `None` when no frequency is detectable.
+    """
+    if not isinstance(index, pd.DatetimeIndex) or len(index) == 0:
+        return None
+    if index.freq is not None:
+        return index.freq
+    try:
+        inferred = pd.infer_freq(index)
+    except (TypeError, ValueError):
+        # <3 observations, or a non-datetime-like index sneaking through.
+        return None
+    return pd.tseries.frequencies.to_offset(inferred) if inferred is not None else None
+
+
+def forecast_index(index: pd.Index | None, steps: int) -> pd.Index:
+    """Build the out-of-sample axis continuing `index` for `steps` periods.
+
+    When a frequency is detectable on `index`, the axis is a `DatetimeIndex`
+    named `time` starting one offset after the last observation. Otherwise it
+    falls back to a step-numbered `RangeIndex` (`0..steps-1`, named `step`),
+    which is the axis undated inputs have always produced.
+
+    Args:
+        index: Observed index, or `None` for a step-numbered axis.
+        steps: Number of forecast steps.
+
+    Returns:
+        A `DatetimeIndex` continuing the calendar, or a `RangeIndex` of steps.
+    """
+    freq = infer_index_freq(index)
+    if freq is None or index is None:
+        return pd.RangeIndex(steps, name="step")
+    return pd.date_range(start=index[-1] + freq, periods=steps, freq=freq, name="time")

--- a/src/impulso/plotting/_sv_forecast.py
+++ b/src/impulso/plotting/_sv_forecast.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
-import numpy as np
+import pandas as pd
 from matplotlib.figure import Figure
 
 if TYPE_CHECKING:
@@ -31,7 +31,8 @@ def plot_sv_forecast(
 
     fig, ax = plt.subplots(figsize=(10, 4))
     col = result.series_name
-    steps = np.arange(1, result.steps + 1)
+    steps = med.index
+    is_dated = isinstance(steps, pd.DatetimeIndex)
     ax.fill_between(
         steps,
         hdi_outer.lower[col].values,
@@ -50,10 +51,12 @@ def plot_sv_forecast(
     )
     ax.plot(steps, med[col].values, color="C0", linewidth=1.5, label="Median")
     ax.axhline(0, color="grey", linewidth=0.5, linestyle="--")
-    ax.set_xlabel("Step ahead")
+    ax.set_xlabel("Date" if is_dated else "Step ahead")
     ax.set_ylabel(col)
     ax.set_title(f"Density forecast — {col}")
     ax.legend(fontsize=8)
     ax.grid(alpha=0.3)
+    if is_dated:
+        fig.autofmt_xdate()
     fig.tight_layout()
     return fig

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib.figure import Figure
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from impulso._base import ImpulsoBaseModel
 from impulso.scenario import ShockPath, VariablePath
@@ -668,22 +668,39 @@ class SVForecastResult(VARResultBase):
         idata: InferenceData with 'forecast' in posterior_predictive.
         series_name: Name of the forecast series.
         steps: Number of forecast steps.
+        index: Forecast axis, normally supplied by `FittedSV.forecast` — a
+            `DatetimeIndex` continuing the observed calendar when the data's
+            frequency is detectable. `None` (the default) falls back to a
+            step-numbered `RangeIndex`.
     """
 
     series_name: str
     steps: int
+    index: pd.Index | None = Field(default=None, repr=False)
+
+    @model_validator(mode="after")
+    def _check_index_length(self) -> "SVForecastResult":
+        """Reject an index that does not match the number of forecast steps."""
+        if self.index is not None and len(self.index) != self.steps:
+            raise ValueError(f"index length {len(self.index)} != steps {self.steps}")
+        return self
+
+    def _axis(self) -> pd.Index:
+        """Forecast axis, falling back to a step-numbered RangeIndex."""
+        from impulso._time import forecast_index
+
+        return self.index if self.index is not None else forecast_index(None, self.steps)
 
     def median(self) -> pd.DataFrame:
         """Posterior median of the density forecast.
 
         Returns:
-            DataFrame of median forecasts indexed by step.
+            DataFrame of median forecasts indexed by the forecast axis —
+            calendar dates when available, otherwise step number.
         """
         forecast = self.idata.posterior_predictive["forecast"]
         med = forecast.median(dim=("chain", "draw")).values
-        df = pd.DataFrame({self.series_name: med})
-        df.index.name = "step"
-        return df
+        return pd.DataFrame({self.series_name: med}, index=self._axis())
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
         """Highest-density interval for the density forecast.
@@ -692,18 +709,20 @@ class SVForecastResult(VARResultBase):
             prob: Probability mass for the HDI. Default 0.89.
 
         Returns:
-            HDIResult with lower/upper DataFrames for each forecast step.
+            HDIResult with lower/upper DataFrames sharing the index of
+            `median()`.
         """
         hdi_data = az.hdi(self.idata.posterior_predictive, hdi_prob=prob)["forecast"]
-        lower = pd.DataFrame({self.series_name: hdi_data.sel(hdi="lower").values})
-        upper = pd.DataFrame({self.series_name: hdi_data.sel(hdi="higher").values})
+        axis = self._axis()
+        lower = pd.DataFrame({self.series_name: hdi_data.sel(hdi="lower").values}, index=axis)
+        upper = pd.DataFrame({self.series_name: hdi_data.sel(hdi="higher").values}, index=axis)
         return HDIResult(lower=lower, upper=upper, prob=prob)
 
     def to_dataframe(self) -> pd.DataFrame:
         """Density forecast posterior median as a DataFrame.
 
         Returns:
-            DataFrame of median forecasts indexed by step.
+            DataFrame of median forecasts indexed by the forecast axis.
         """
         return self.median()
 

--- a/src/impulso/sv/fitted.py
+++ b/src/impulso/sv/fitted.py
@@ -61,11 +61,16 @@ class FittedSV(ImpulsoBaseModel):
                 (default) for fresh non-deterministic draws. Pass an int or
                 `Generator` for reproducible forecasts.
 
+        The result is indexed by calendar dates continuing `data.index`
+        whenever that index has a detectable frequency; otherwise it falls
+        back to a step-numbered index.
+
         Returns:
             SVForecastResult wrapping posterior predictive draws.
         """
         import xarray as xr
 
+        from impulso._time import forecast_index
         from impulso.results import SVForecastResult
 
         rng = np.random.default_rng(random_seed)
@@ -87,4 +92,5 @@ class FittedSV(ImpulsoBaseModel):
             idata=idata,
             series_name=self.data.name,
             steps=steps,
+            index=forecast_index(self.data.index, steps),
         )

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -172,20 +172,32 @@ def test_plot_volatility_returns_figure(synthetic_sv_idata):
     assert isinstance(fig, Figure)
 
 
-def test_plot_sv_forecast_returns_figure():
-    import arviz as az
-    import numpy as np
-    import xarray as xr
-    from matplotlib.figure import Figure
-
+def _make_sv_forecast_result(steps=12, index=None):
     from impulso.results import SVForecastResult
 
     rng = np.random.default_rng(0)
-    steps = 12
     forecast = rng.standard_normal((2, 50, steps))
     idata = az.InferenceData(
         posterior_predictive=xr.Dataset({"forecast": xr.DataArray(forecast, dims=["chain", "draw", "step"])})
     )
-    result = SVForecastResult(idata=idata, series_name="sim", steps=steps)
+    return SVForecastResult(idata=idata, series_name="sim", steps=steps, index=index)
+
+
+def test_plot_sv_forecast_returns_figure():
+    result = _make_sv_forecast_result()
     fig = result.plot()
     assert isinstance(fig, Figure)
+    ax = fig.axes[0]
+    assert ax.get_xlabel() == "Step ahead"
+    np.testing.assert_array_equal(ax.get_lines()[0].get_xdata(), np.arange(12))
+
+
+def test_plot_sv_forecast_uses_calendar_axis():
+    import matplotlib.dates as mdates
+    import pandas as pd
+
+    idx = pd.date_range("2008-05-01", periods=12, freq="MS")
+    fig = _make_sv_forecast_result(index=idx).plot()
+    ax = fig.axes[0]
+    assert ax.get_xlabel() == "Date"
+    np.testing.assert_allclose(ax.get_lines()[0].get_xdata(orig=False), mdates.date2num(idx))

--- a/tests/test_sv_fitted.py
+++ b/tests/test_sv_fitted.py
@@ -46,8 +46,13 @@ def test_fittedsv_forecast_shape_and_type(fitted_sv):
     assert forecast.shape == (2, 50, 12)
 
 
-def _build_ar1_fitted_sv():
-    """Build a FittedSV with synthetic AR(1) posterior, no MCMC."""
+def _build_ar1_fitted_sv(index: pd.DatetimeIndex | None = None):
+    """Build a FittedSV with synthetic AR(1) posterior, no MCMC.
+
+    Args:
+        index: Optional DatetimeIndex of length 50. Defaults to a monthly
+            range; pass an irregular index to exercise the undated path.
+    """
     import arviz as az
     import xarray as xr
 
@@ -69,7 +74,8 @@ def _build_ar1_fitted_sv():
     idata = az.InferenceData(posterior=posterior)
 
     y = rng.standard_normal(T)
-    index = pd.date_range("2000-01-01", periods=T, freq="MS")
+    if index is None:
+        index = pd.date_range("2000-01-01", periods=T, freq="MS")
     data = SVData(y=y, name="sim", index=index)
 
     return FittedSV.model_construct(idata=idata, data=data, dynamics=AR1())
@@ -92,6 +98,50 @@ def test_fittedsv_forecast_ar1_shape_and_type():
     hdi = result.hdi()
     assert hdi.lower.shape[0] == 6
     assert hdi.upper.shape[0] == 6
+
+
+def test_fittedsv_forecast_index_continues_calendar(fitted_sv):
+    """A dated, regular sample yields a calendar forecast axis."""
+    result = fitted_sv.forecast(steps=12)
+
+    # fitted_sv spans 100 monthly starts from 2000-01-01, i.e. up to 2008-04-01.
+    expected = pd.date_range("2008-05-01", periods=12, freq="MS")
+    assert isinstance(result.index, pd.DatetimeIndex)
+    assert list(result.index) == list(expected)
+    assert result.index.freqstr == "MS"
+
+
+def test_fittedsv_forecast_index_carried_by_frames(fitted_sv):
+    """median/to_dataframe/hdi all carry the calendar axis."""
+    result = fitted_sv.forecast(steps=6)
+    expected = pd.date_range("2008-05-01", periods=6, freq="MS")
+
+    for df in (result.median(), result.to_dataframe(), result.hdi().lower, result.hdi().upper):
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert list(df.index) == list(expected)
+        assert df.index.name == "time"
+
+
+def test_fittedsv_forecast_index_infers_freq_when_attribute_missing():
+    """A regular index whose `.freq` was dropped is still recognised."""
+    index = pd.DatetimeIndex(list(pd.date_range("2000-01-01", periods=50, freq="MS")))
+    assert index.freq is None
+
+    result = _build_ar1_fitted_sv(index=index).forecast(steps=3, random_seed=0)
+    assert list(result.index) == list(pd.date_range("2004-03-01", periods=3, freq="MS"))
+
+
+def test_fittedsv_forecast_falls_back_to_step_index():
+    """An irregular calendar has no detectable frequency — step axis."""
+    irregular = pd.date_range("2000-01-01", periods=60, freq="MS").delete([5, 11, 17, 23, 29, 35, 41, 47, 53, 59])
+    assert pd.infer_freq(irregular) is None
+
+    result = _build_ar1_fitted_sv(index=irregular).forecast(steps=4, random_seed=0)
+    assert isinstance(result.index, pd.RangeIndex)
+    assert list(result.index) == [0, 1, 2, 3]
+    med = result.median()
+    assert med.index.name == "step"
+    assert list(med.index) == [0, 1, 2, 3]
 
 
 def test_fittedsv_forecast_rng_seeds_are_respected():

--- a/tests/test_sv_results.py
+++ b/tests/test_sv_results.py
@@ -1,8 +1,14 @@
 """Tests for SV result types."""
 
+import arviz as az
+import numpy as np
 import pandas as pd
+import pytest
+import xarray as xr
+from pydantic import ValidationError
 
-from impulso.results import VolatilityResult
+from impulso._time import forecast_index, infer_index_freq
+from impulso.results import SVForecastResult, VolatilityResult
 
 
 def test_volatility_result_median_shape(synthetic_sv_idata):
@@ -43,3 +49,74 @@ def test_volatility_result_to_dataframe_has_index(synthetic_sv_idata):
     result = VolatilityResult(idata=synthetic_sv_idata, series_name="sim", index=idx)
     df = result.to_dataframe()
     assert list(df.index) == list(idx)
+
+
+# --------------- SVForecastResult forecast axis ---------------
+
+
+def _sv_forecast_idata(steps: int = 12) -> az.InferenceData:
+    """Synthetic posterior-predictive draws for a univariate SV forecast."""
+    rng = np.random.default_rng(0)
+    draws = rng.standard_normal((2, 50, steps))
+    return az.InferenceData(
+        posterior_predictive=xr.Dataset({"forecast": xr.DataArray(draws, dims=["chain", "draw", "step"])})
+    )
+
+
+def test_sv_forecast_result_defaults_to_step_index():
+    """No index supplied — the historical RangeIndex/step behaviour holds."""
+    result = SVForecastResult(idata=_sv_forecast_idata(5), series_name="sim", steps=5)
+    for df in (result.median(), result.to_dataframe(), result.hdi().lower, result.hdi().upper):
+        assert isinstance(df.index, pd.RangeIndex)
+        assert list(df.index) == [0, 1, 2, 3, 4]
+        assert df.index.name == "step"
+
+
+def test_sv_forecast_result_carries_datetime_index():
+    idx = pd.date_range("2008-05-01", periods=5, freq="MS")
+    result = SVForecastResult(idata=_sv_forecast_idata(5), series_name="sim", steps=5, index=idx)
+    for df in (result.median(), result.to_dataframe(), result.hdi(prob=0.5).lower, result.hdi(prob=0.5).upper):
+        assert list(df.index) == list(idx)
+    assert result.median().columns.tolist() == ["sim"]
+
+
+def test_sv_forecast_result_rejects_index_length_mismatch():
+    idx = pd.date_range("2008-05-01", periods=4, freq="MS")
+    with pytest.raises(ValidationError, match="index length 4 != steps 5"):
+        SVForecastResult(idata=_sv_forecast_idata(5), series_name="sim", steps=5, index=idx)
+
+
+# --------------- forecast-axis helper ---------------
+
+
+def test_forecast_index_continues_calendar():
+    idx = pd.date_range("2000-01-01", periods=24, freq="MS")
+    out = forecast_index(idx, 3)
+    assert list(out) == list(pd.date_range("2002-01-01", periods=3, freq="MS"))
+    assert out.name == "time"
+
+
+def test_forecast_index_handles_quarterly_and_daily():
+    quarterly = forecast_index(pd.date_range("2000-01-01", periods=8, freq="QS"), 2)
+    assert list(quarterly) == list(pd.date_range("2002-01-01", periods=2, freq="QS"))
+
+    daily = forecast_index(pd.date_range("2000-01-01", periods=8, freq="D"), 2)
+    assert list(daily) == [pd.Timestamp("2000-01-09"), pd.Timestamp("2000-01-10")]
+
+
+@pytest.mark.parametrize(
+    "idx",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(pd.RangeIndex(10), id="non-datetime"),
+        pytest.param(pd.DatetimeIndex([]), id="empty"),
+        pytest.param(pd.DatetimeIndex(["2000-01-01", "2000-03-01"]), id="too-short-to-infer"),
+        pytest.param(pd.DatetimeIndex(["2000-01-01", "2000-02-05", "2000-04-17"]), id="irregular"),
+    ],
+)
+def test_forecast_index_falls_back_to_steps(idx):
+    out = forecast_index(idx, 3)
+    assert isinstance(out, pd.RangeIndex)
+    assert list(out) == [0, 1, 2]
+    assert out.name == "step"
+    assert infer_index_freq(idx) is None


### PR DESCRIPTION
## Summary

`SVForecastResult` previously indexed everything by bare step number even though `SVData` always carries a `DatetimeIndex`. Now:

- New shared helper `src/impulso/_time.py`: `infer_index_freq` (index's own `freq` wins, else `pd.infer_freq`; `None` for irregular/short samples) and `forecast_index` (calendar `DatetimeIndex` starting one offset after the last observation, `RangeIndex` step fallback). Placed at package level so `FittedVAR.forecast`/`ForecastResult` can adopt the identical axis later — the VAR side has the same gap and no precedent existed to mirror.
- `FittedSV.forecast` threads `forecast_index(self.data.index, steps)` into the result.
- `SVForecastResult` gains an optional `index` field (validated against `steps`), used by `median()`, `to_dataframe()`, and now also `hdi()` — HDI frames were previously unindexed and are now aligned with `median()`.
- `plot_sv_forecast` plots on the result's axis, labelling `Date` vs `Step ahead` and rotating tick labels only when dated. In the undated fallback the plotted x-values now match `median()`'s index (`0..steps-1`), removing a pre-existing off-by-one between plot and frame.

Design note: the field carries the full index (mirroring `VolatilityResult.index`) rather than a `last_date`+`freq` pair. History+forecast concatenation in the plot was left out deliberately — the result doesn't hold the observed series, and the issue leaves the choice open.

Closes #48

## Tests

+12 tests across `test_sv_fitted.py`, `test_sv_results.py`, `test_plotting.py`: calendar continuation at the right freq, freq inference when `.freq` unset, irregular-index fallback, length-mismatch validation, frames carrying the axis, plot x-data/xlabel for both axis kinds. All fast (synthetic idata, no MCMC).

`ruff` / `ty` / fast suite: all green (542 passed, 29 deselected). Touched modules at 100% coverage (`results.py` 93%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV