### PR TITLE
ci: run slow MCMC tests on schedule instead of the PR matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run tests
-        run: uv run python -m pytest tests --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml
+      - name: Run tests (fast; MCMC-marked tests run in slow-tests.yml)
+        run: uv run python -m pytest tests -m "not slow" --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml
 
       - name: Check typing
         run: uv run ty check

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,48 @@
+name: Slow Tests
+
+# The `@pytest.mark.slow` tests each run a real NUTS sampler. Running them on
+# every PR across the 3.11-3.14 matrix dominated the CI budget and leaked
+# sampler noise (divergences, multiprocessing crashes) into PR signal, so
+# `main.yml` now runs `-m "not slow"` and this workflow owns the MCMC suite.
+# One Python version is enough: these tests exercise the sampler, not
+# Python-version-specific behaviour.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Monday 03:00 UTC
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  slow-tests:
+    runs-on: ubuntu-latest
+    # 29 MCMC tests take ~1m45s locally on Apple Silicon. Hosted runners are
+    # several times slower on compiled numerical work, and NUTS wall time is
+    # stochastic, so allow generous headroom — the timeout exists to kill a
+    # hang, not to police a slow-but-healthy run.
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "3.11"
+
+      - name: Run slow (MCMC) tests
+        # No coverage upload: `main.yml` owns the single Codecov report and
+        # does not use flags, so a second upload would clobber it.
+        run: uv run python -m pytest tests -m slow -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ All domain models inherit from one of these. Use `object.__setattr__` only for i
 - **Linter/Formatter**: Ruff — line length 120, target py311, auto-fix enabled
 - **Type checker**: ty (configured for `.venv`, Python 3.11). Ignores `unresolved-attribute`, `not-subscriptable`, and `invalid-argument-type` due to ArviZ/PyMC/pandas dynamic attrs.
 - **Prek**: Ruff checks + standard hooks (trailing whitespace, TOML/YAML/JSON validation)
-- **CI**: GitHub Actions runs quality, tests (3.11–3.14), and a docs build on push/PR. The `build-docs` job smoke-renders on PRs (fast, `IMPULSO_DOCS_CI=1`) and full-renders on push to `main` (real MCMC), restoring the jupyter-cache between runs. No rendered `.md` or figures are committed — notebooks execute at build time. A scheduled/on-release full render runs via `full-render-notebooks.yml`. Tutorials read `IMPULSO_DOCS_CI` (smoke draws) and Sphinx sets `IMPULSO_DOCS_BUILD=1` (disables the sampler progress bar).
+- **CI**: GitHub Actions runs quality, tests (3.11–3.14), and a docs build on push/PR. The PR/push test job runs `-m "not slow"` only; the `@pytest.mark.slow` MCMC suite runs on Python 3.11 via `slow-tests.yml` (weekly schedule, `workflow_dispatch`, and push to `main`). Codecov is uploaded from the fast job only. The `build-docs` job smoke-renders on PRs (fast, `IMPULSO_DOCS_CI=1`) and full-renders on push to `main` (real MCMC), restoring the jupyter-cache between runs. No rendered `.md` or figures are committed — notebooks execute at build time. A scheduled/on-release full render runs via `full-render-notebooks.yml`. Tutorials read `IMPULSO_DOCS_CI` (smoke draws) and Sphinx sets `IMPULSO_DOCS_BUILD=1` (disables the sampler progress bar).
 
 ## Test Fixtures (`conftest.py`)
 


### PR DESCRIPTION
## Summary

Per-PR CI ran the full pytest suite — including 29 `@pytest.mark.slow` real-NUTS tests — across the whole Python 3.11–3.14 matrix (116 MCMC test invocations per PR). Now:

- `main.yml` test step runs `-m "not slow"` (name updated to say where the slow tests went).
- New `slow-tests.yml`: `-m slow` on Python 3.11 only, triggered by weekly schedule (Mon 03:00 UTC, offset from the Sunday full-render slot), `workflow_dispatch`, and push to `main`. Same setup action, checkout version, concurrency and permissions patterns as the existing workflows. `timeout-minutes: 45` (~25× local headroom — the timeout kills hangs, not healthy runs).
- CLAUDE.md CI bullet updated.

**Coverage consequence: none.** Fast-only coverage is **95.06%** against the 90% codecov target (0.5% threshold), so `codecov.yaml` is untouched. The slow workflow deliberately uploads no coverage — `main.yml` owns the single unflagged Codecov report and a second upload would clobber it.

Note: the issue text says 12 slow tests; the suite has since grown to 29 (proxy-SVAR, dynamic-multiplier, volatility, SV spec/recovery test files postdate it).

Closes #45

## Verification

Both workflow files YAML-validated; fast suite re-run green (527 passed, 29 deselected); the full 29-test slow suite passes in ~103s locally on a clean import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV