### PR TITLE
feat(conjugate): expose model evidence and Bayes-factor comparison

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,10 @@ _Avoid_: conflating with `MinnesotaPrior` — different priors for different est
 The overall standard deviation of the Minnesota prior — the scalar controlling how hard all coefficients shrink toward the random-walk prior mean. `MinnesotaPrior.tightness` is this λ, held fixed; `ConjugateVAR` instead selects λ by maximising / sampling the marginal likelihood (hierarchical, à la Giannone et al. 2015).
 _Avoid_: bare "shrinkage" (ambiguous with cross-variable shrinkage).
 
+**Model evidence (`ModelEvidence`)**:
+The conjugate VAR's closed-form log marginal likelihood of the observed response block, `log p(y_{p+1:T} | y_{1:p}, hyperparameters, model)`, attached to `FittedVAR.evidence` by `ConjugateVAR.fit` (`None` on the NUTS path, which has no closed form). Because the value includes the volatility-rescaling Jacobian it is a density over the *observed* data, so a break model and a homoscedastic model on the same observations are directly comparable. It is conditional on the presample and on the hyperparameters it was evaluated at, so with `NIWPrior(select=True)` a ratio of two evidences is an empirical-Bayes Bayes factor. `compare_evidence(**fits)` checks comparability (same variable set, effective sample, window and response digest) and returns an `EvidenceComparison` of Bayes factors and posterior model probabilities.
+_Avoid_: "log ML" in the API surface (spell out marginal likelihood); "model probability" for a raw Bayes factor — the probability requires prior model weights.
+
 **Deterministic volatility break (`ConjugateVolatility`)**:
 A volatility process whose per-period scale `s_t` follows a deterministic, hyperparameter-driven path with a known break date — not a stochastic process. Used only by `ConjugateVAR`: the scale enters as data rescaling `ỹ_t = y_t / s_t` with a Jacobian in the marginal likelihood, and its hyperparameters are estimated jointly with λ. `PandemicBreak` (three outbreak scales + geometric decay from March 2020) is the concrete case reproducing Lenza & Primiceri (2020).
 _Avoid_: "stochastic volatility" — the break is deterministic given its hyperparameters.

--- a/docs/reference/evidence.md
+++ b/docs/reference/evidence.md
@@ -1,0 +1,24 @@
+# Model Evidence
+
+The conjugate VAR's closed-form log marginal likelihood, attached to
+`FittedVAR.evidence` by `ConjugateVAR.fit`, and the Bayes-factor
+comparison built on top of it.
+
+```{eval-rst}
+.. currentmodule:: impulso.evidence
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   ModelEvidence
+   EvidenceComparison
+
+.. currentmodule:: impulso
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   compare_evidence
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -17,6 +17,7 @@ identified
 identification
 scenario
 results
+evidence
 primitives
 protocols
 plotting

--- a/docs/tutorials/conjugate-var.py
+++ b/docs/tutorials/conjugate-var.py
@@ -64,7 +64,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from impulso import Cholesky, ConjugateVAR, MinnesotaPrior, NIWPrior, VAR, VARData
+from impulso import Cholesky, ConjugateVAR, MinnesotaPrior, NIWPrior, VAR, VARData, compare_evidence
 from impulso.samplers import NUTSSampler
 
 # %% [markdown]
@@ -258,6 +258,53 @@ if not ci:
     print(f"median-IRF shape correlation across all 16 shock/response pairs: {np.nanmean(correlations):.2f}")
 
 # %% [markdown]
+# ## Which lag order does the data prefer?
+#
+# The closed form gives us more than speed. Every conjugate fit reports its **marginal
+# likelihood** — the density of the observed data under the model, with the coefficients and
+# covariance integrated out — on `fitted.evidence`. Ratios of those numbers are Bayes
+# factors, so the twelve-lag choice we made by convention can be put to the data instead.
+#
+# One alignment matters. A VAR($p$) conditions on its first $p$ rows and models the rest, so
+# a VAR(1) and a VAR(12) on the same DataFrame are densities over *different* observations
+# and their ratio means nothing. We therefore feed each candidate a series pre-trimmed to
+# the longest lag order, `anomalies.iloc[LAGS - p:]`, so all three model exactly the same
+# response window and differ only in how far back they look. `compare_evidence` refuses the
+# comparison — loudly — if that alignment is missing.
+
+# %%
+comparison_draws = 50 if ci else 250
+candidates = {}
+for p in (1, 6, LAGS):
+    aligned = VARData.from_df(anomalies.iloc[LAGS - p :], endog=list(anomalies.columns))
+    candidates[f"p{p}"] = ConjugateVAR(
+        lags=p,
+        prior=NIWPrior(select=True, decay=2.0, cross_shrinkage=1.0),
+        draws=comparison_draws,
+        tune=comparison_draws,
+        seed=0,
+    ).fit(aligned)
+
+# %%
+evidence = compare_evidence(**candidates)
+print(f"preferred lag order: {evidence.best}")
+evidence.to_dataframe().round(3)
+
+# %% [markdown]
+# The `log_bayes_factor` column reads against the first model passed (`p1` here); the log10
+# column is the unit Kass and Raftery tabulate, and `posterior_probability` converts the
+# evidences to model weights under a flat prior over the three candidates. On these
+# de-seasonalised anomalies the short model wins by tens of log points: once the calendar is
+# removed, a month of Berlin weather carries little information about the next year of it,
+# and the extra lags buy less than they cost. We keep twelve lags for the rest of the
+# notebook so the estimator comparison stays on the system introduced above — but this is
+# the number to quote when someone asks why.
+#
+# Two caveats travel with these values. Each is conditional on the presample the shared
+# window leaves in front of it, and each is evaluated at the $\lambda$ its own fit selected,
+# which makes the ratio an *empirical-Bayes* Bayes factor rather than a fully marginal one.
+# Both are stated on `ModelEvidence`.
+#
 # ## When to reach for which
 #
 # Both estimators share the entire post-fitting pipeline — identification, IRFs, FEVDs,

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from impulso._ma import compute_ma_phi
     from impulso.conjugate import ConjugateVAR
     from impulso.conjugate_volatility import ConjugateVolatility, PandemicBreak
+    from impulso.evidence import EvidenceComparison, ModelEvidence, compare_evidence
     from impulso.fitted import FittedVAR
     from impulso.identification import Cholesky, ProxySVAR, SignRestriction
     from impulso.identified import IdentifiedVAR
@@ -49,6 +50,7 @@ __all__ = [
     "Constant",
     "CounterfactualResult",
     "DynamicMultiplierResult",
+    "EvidenceComparison",
     "FEVDResult",
     "FittedSV",
     "FittedVAR",
@@ -59,6 +61,7 @@ __all__ = [
     "IdentifiedVAR",
     "LagOrderResult",
     "MinnesotaPrior",
+    "ModelEvidence",
     "NIWPrior",
     "NUTSSampler",
     "PandemicBreak",
@@ -74,6 +77,7 @@ __all__ = [
     "VariablePath",
     "VolatilityProcess",
     "VolatilityResult",
+    "compare_evidence",
     "compute_ma_phi",
     "enable_runtime_checks",
     "lag_matrices",
@@ -92,6 +96,9 @@ _LAZY_IMPORTS: dict[str, str] = {
     "ConjugateVAR": "impulso.conjugate",
     "ConjugateVolatility": "impulso.conjugate_volatility",
     "PandemicBreak": "impulso.conjugate_volatility",
+    "ModelEvidence": "impulso.evidence",
+    "EvidenceComparison": "impulso.evidence",
+    "compare_evidence": "impulso.evidence",
     "NUTSSampler": "impulso.samplers",
     "ForecastResult": "impulso.results",
     "ConditionalForecastResult": "impulso.results",

--- a/src/impulso/_conjugate_sampler.py
+++ b/src/impulso/_conjugate_sampler.py
@@ -233,6 +233,10 @@ def select_and_sample(  # noqa: C901
         * ``L``: lower-triangular Cholesky draws of ``Sigma`` (``Sigma = L @ L.T``).
         * ``acceptance_rate``: Metropolis acceptance rate over the retained ``draws``.
         * ``mode``: ``{name: float}`` the transformed-posterior mode of each hyperparameter.
+        * ``log_marginal_likelihood``: the log marginal likelihood at the mode (on the
+          fixed-prior fast path, at the fixed hyperparameters). It excludes the hyperprior
+          and the transform Jacobian, so it is a data density — not the maximised posterior
+          height — and it is conditional on the hyperparameters it was evaluated at.
     """
     rng = np.random.default_rng(seed)
     y = np.asarray(y, dtype=float)
@@ -248,6 +252,8 @@ def select_and_sample(  # noqa: C901
     if d == 0:
         dummies_y, dummies_x = prior.build_dummies(y, n_lags, sigma, tightness=prior.tightness)
         drawn = draw_niw(niw_posterior(response, regressors, dummies_y, dummies_x), draws, rng)
+        # No volatility hyperparameters are free here, so the fitted model is the
+        # unrescaled one: evaluate its evidence with log_scales=None to match.
         return {
             "hyperparameters": {},
             "B_full": drawn["B_full"],
@@ -255,6 +261,9 @@ def select_and_sample(  # noqa: C901
             "L": drawn["L"],
             "acceptance_rate": 1.0,
             "mode": {},
+            "log_marginal_likelihood": float(
+                log_marginal_likelihood(response, regressors, dummies_y, dummies_x, log_scales=None)
+            ),
         }
 
     los = np.array([s.lo for s in specs])
@@ -279,16 +288,21 @@ def select_and_sample(  # noqa: C901
                 vol_theta[spec.name] = float(x[i])
         return x, lam, vol_theta, log_pj
 
-    def log_target(u: np.ndarray) -> float:
+    def log_ml_and_prior(u: np.ndarray) -> tuple[float, float]:
+        """Return the log marginal likelihood at ``u`` and its log prior + Jacobian, separately."""
         _, lam, vol_theta, log_pj = unpack(u)
         if not np.isfinite(log_pj):
-            return -np.inf
+            return -np.inf, -np.inf
         if lam_free:
             dummies_y, dummies_x = prior.build_dummies(y, n_lags, sigma, tightness=lam)
         else:
             dummies_y, dummies_x = fixed_dummies
         log_scales = None if volatility is None else volatility.log_scales(vol_theta, n_obs)
         lml = log_marginal_likelihood(response, regressors, dummies_y, dummies_x, log_scales=log_scales)
+        return lml, log_pj
+
+    def log_target(u: np.ndarray) -> float:
+        lml, log_pj = log_ml_and_prior(u)
         value = lml + log_pj
         return value if np.isfinite(value) else -np.inf
 
@@ -352,6 +366,7 @@ def select_and_sample(  # noqa: C901
 
     _, _, _, _ = unpack(u_mode)  # ensure mode is in-support
     mode = {spec.name: _to_constrained(u_mode[i], los[i], his[i]) for i, spec in enumerate(specs)}
+    log_ml_mode, _ = log_ml_and_prior(u_mode)
 
     return {
         "hyperparameters": hyper,
@@ -360,4 +375,5 @@ def select_and_sample(  # noqa: C901
         "L": chol_draws,
         "acceptance_rate": accepted_draws / draws,
         "mode": mode,
+        "log_marginal_likelihood": float(log_ml_mode),
     }

--- a/src/impulso/conjugate.py
+++ b/src/impulso/conjugate.py
@@ -24,6 +24,7 @@ from impulso._conjugate import split_intercept
 from impulso._conjugate_sampler import select_and_sample
 from impulso.conjugate_volatility import ConjugateVolatility
 from impulso.data import VARData
+from impulso.evidence import ModelEvidence, _response_digest
 from impulso.fitted import FittedVAR
 from impulso.priors import NIWPrior
 from impulso.volatility import Constant
@@ -93,6 +94,9 @@ class ConjugateVAR(ImpulsoBaseModel):
             fixed-prior fast path no Metropolis chain runs (draws come
             straight from the closed-form posterior), so the attr is absent
             rather than stamped with a meaningless 1.0.
+            `FittedVAR.evidence` carries the closed-form log marginal
+            likelihood at the selected hyperparameters together with the
+            metadata `impulso.compare_evidence` needs to form Bayes factors.
 
         Raises:
             ValueError: If `data` carries exogenous regressors — the
@@ -132,7 +136,8 @@ class ConjugateVAR(ImpulsoBaseModel):
         posterior = xr.Dataset(posterior_vars)
         # Volatility adapters anchor forecast scale paths at the true sample
         # end (see ConjugateVolatility.forecast_cholesky_path).
-        posterior.attrs["in_sample_length"] = data.endog.shape[0] - self.lags
+        n_obs = data.endog.shape[0] - self.lags
+        posterior.attrs["in_sample_length"] = n_obs
         # Hyperparameter-sampler quality signal for convergence reporting. Only
         # meaningful when the Metropolis chain actually ran: with no free
         # hyperparameters `select_and_sample` takes the closed-form fast path and
@@ -142,10 +147,26 @@ class ConjugateVAR(ImpulsoBaseModel):
         idata = az.InferenceData(posterior=posterior)
         volatility = self.volatility if self.volatility is not None else Constant()
 
+        evidence = ModelEvidence(
+            log_marginal_likelihood=result["log_marginal_likelihood"],
+            n_obs=n_obs,
+            n_vars=len(data.endog_names),
+            var_names=list(data.endog_names),
+            n_lags=self.lags,
+            volatility=(
+                None if self.volatility is None else getattr(self.volatility, "name", type(self.volatility).__name__)
+            ),
+            hyperparameters=dict(result["mode"]),
+            sample_start=data.index[self.lags],
+            sample_end=data.index[-1],
+            sample_digest=_response_digest(data.endog, data.endog_names, self.lags),
+        )
+
         return FittedVAR.model_construct(
             idata=idata,
             n_lags=self.lags,
             data=data,
             var_names=data.endog_names,
             volatility=volatility,
+            evidence=evidence,
         )

--- a/src/impulso/evidence.py
+++ b/src/impulso/evidence.py
@@ -1,0 +1,357 @@
+"""Model evidence for the conjugate VAR, and Bayes-factor comparison across fits.
+
+The conjugate (Normal-Inverse-Wishart) VAR has a closed-form marginal likelihood, so
+`ConjugateVAR.fit` can report the log evidence of the model it just estimated at no extra
+cost. `ModelEvidence` is the value plus the metadata needed to decide whether two such
+values are comparable; `compare_evidence` does the comparing and returns an
+`EvidenceComparison` carrying Bayes factors and posterior model probabilities.
+
+All arithmetic happens in log space. Bayes factors are exponentiated only at the last
+step, with an explicit clamp, so an overwhelming log difference reports `inf` or `0.0`
+rather than raising or emitting an overflow warning. The log and log10 columns are always
+published alongside the ratio, and are the numbers to quote (Kass and Raftery 1995).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+from pydantic import Field, field_validator, model_validator
+
+from impulso._base import ImpulsoBaseModel
+
+if TYPE_CHECKING:
+    from impulso.fitted import FittedVAR
+
+# math.exp overflows above log(finfo(float).max) ~= 709.78; clamp just below.
+_MAX_LOG_BAYES_FACTOR: float = 709.0
+
+
+def _response_digest(endog: np.ndarray, var_names: Sequence[str], n_lags: int) -> str:
+    """Byte-exact digest of the response block a VAR(`n_lags`) actually fits.
+
+    The first `n_lags` rows are the presample the model conditions on, so they are
+    excluded; columns are reordered by sorted variable name so that two fits which order
+    the same variables differently still hash alike.
+
+    Args:
+        endog: Endogenous data of shape `(T_full, n_vars)`, before lag trimming.
+        var_names: Column names of `endog`, in column order.
+        n_lags: Lag order `p`; the first `p` rows are dropped.
+
+    Returns:
+        Hex SHA-256 digest of the trimmed, column-sorted response block.
+    """
+    order = sorted(range(len(var_names)), key=lambda i: var_names[i])
+    block = np.ascontiguousarray(np.asarray(endog, dtype=np.float64)[n_lags:, order])
+    return hashlib.sha256(block.tobytes()).hexdigest()
+
+
+class ModelEvidence(ImpulsoBaseModel):
+    """Closed-form log marginal likelihood of a conjugate VAR, with comparability metadata.
+
+    The value is the log density of the observed response block given the presample and
+    the hyperparameters,
+
+    `log p(y_{p+1:T} | y_{1:p}, hyperparameters, model)`,
+
+    with three properties worth stating explicitly:
+
+    * It is a density over the **observed** data. When a deterministic volatility break
+      rescales the sample, the change-of-variables Jacobian is included, so a break model
+      and a homoscedastic model fitted to the same observations are directly comparable.
+    * It is **conditional on the hyperparameters** in `hyperparameters`. With
+      `NIWPrior(select=True)` those were chosen by maximising evidence times hyperprior,
+      so a ratio of two such values is an empirical-Bayes (conditional) Bayes factor, not
+      a fully marginal one. When `hyperparameters` is empty — a fixed prior with no
+      volatility break — nothing was selected and the value is the full marginal
+      likelihood of the model.
+    * It **conditions on the presample**, so models with different lag orders condition
+      on different initial rows. Fixing the response window and conditioning on initial
+      conditions is the standard practice (Giannone, Lenza and Primiceri 2015), but the
+      resulting Bayes factor is conditional on those initial conditions.
+
+    Attributes:
+        log_marginal_likelihood: The log evidence. Must be finite.
+        n_obs: Response rows after lag trimming, `T_full - n_lags`.
+        n_vars: Number of endogenous variables.
+        var_names: Endogenous variable names, in column order.
+        n_lags: Lag order `p`.
+        volatility: Name of the deterministic volatility break, or None if homoscedastic.
+        hyperparameters: Hyperparameters the evidence was evaluated at (empty when the
+            prior is fixed and there is no volatility break).
+        sample_start: Timestamp of the first response row.
+        sample_end: Timestamp of the last response row.
+        sample_digest: Digest of the response block (see `_response_digest`).
+    """
+
+    log_marginal_likelihood: float
+    n_obs: int = Field(ge=1)
+    n_vars: int = Field(ge=1)
+    var_names: list[str]
+    n_lags: int = Field(ge=1)
+    volatility: str | None = None
+    hyperparameters: dict[str, float] = Field(default_factory=dict)
+    sample_start: pd.Timestamp = Field(repr=False)
+    sample_end: pd.Timestamp = Field(repr=False)
+    sample_digest: str = Field(repr=False)
+
+    @field_validator("log_marginal_likelihood")
+    @classmethod
+    def _require_finite(cls, value: float) -> float:
+        """Reject a non-finite evidence loudly at fit time rather than at comparison time."""
+        if not math.isfinite(value):
+            raise ValueError(
+                f"the conjugate marginal likelihood evaluated to {value}; the hyperparameter "
+                "mode fell outside the model's support (a degenerate design or an unstable "
+                "volatility path)"
+            )
+        return value
+
+
+def _safe_exp(delta: float) -> float:
+    """Exponentiate a log difference, saturating at `inf` / `0.0` instead of overflowing."""
+    if delta > _MAX_LOG_BAYES_FACTOR:
+        return math.inf
+    if delta < -_MAX_LOG_BAYES_FACTOR:
+        return 0.0
+    return math.exp(delta)
+
+
+class EvidenceComparison(ImpulsoBaseModel):
+    """Bayes factors and posterior model probabilities across named model evidences.
+
+    Built by `compare_evidence`. The `reference` model is the denominator of every Bayes
+    factor unless a different one is named per call.
+
+    Attributes:
+        evidences: Named `ModelEvidence` objects, in the order they were compared.
+        reference: Key of the default denominator model.
+    """
+
+    evidences: dict[str, ModelEvidence]
+    reference: str
+
+    @model_validator(mode="after")
+    def _validate_reference(self) -> EvidenceComparison:
+        """Require at least two models and a reference that names one of them."""
+        if len(self.evidences) < 2:
+            raise ValueError(f"an evidence comparison needs at least two models, got {len(self.evidences)}")
+        if self.reference not in self.evidences:
+            raise ValueError(
+                f"reference {self.reference!r} is not one of the compared models ({', '.join(sorted(self.evidences))})"
+            )
+        return self
+
+    @property
+    def best(self) -> str:
+        """Name of the model with the highest log marginal likelihood."""
+        return max(self.evidences, key=lambda name: self.evidences[name].log_marginal_likelihood)
+
+    def _lookup(self, name: str) -> ModelEvidence:
+        """Fetch one evidence by name, naming the alternatives when it is missing."""
+        if name not in self.evidences:
+            raise KeyError(f"{name!r} is not one of the compared models ({', '.join(sorted(self.evidences))})")
+        return self.evidences[name]
+
+    def log_bayes_factor(self, model: str, against: str | None = None) -> float:
+        """Log Bayes factor of `model` against another model.
+
+        Args:
+            model: Name of the numerator model.
+            against: Name of the denominator model. Defaults to `reference`.
+
+        Returns:
+            `log ML(model) - log ML(against)`. Positive favours `model`.
+
+        Raises:
+            KeyError: If either name is not part of the comparison.
+        """
+        denominator = self.reference if against is None else against
+        return self._lookup(model).log_marginal_likelihood - self._lookup(denominator).log_marginal_likelihood
+
+    def log10_bayes_factor(self, model: str, against: str | None = None) -> float:
+        """Base-10 log Bayes factor — the unit Kass and Raftery (1995) tabulate.
+
+        Args:
+            model: Name of the numerator model.
+            against: Name of the denominator model. Defaults to `reference`.
+
+        Returns:
+            `log10 BF(model, against)`.
+        """
+        return self.log_bayes_factor(model, against) / math.log(10.0)
+
+    def bayes_factor(self, model: str, against: str | None = None) -> float:
+        """Bayes factor of `model` against another model.
+
+        Saturates rather than overflowing: a log difference beyond about 709 returns
+        `inf` (or `0.0` below `-709`). Quote `log_bayes_factor` or
+        `log10_bayes_factor` when the ratio is that large.
+
+        Args:
+            model: Name of the numerator model.
+            against: Name of the denominator model. Defaults to `reference`.
+
+        Returns:
+            `BF(model, against)`.
+        """
+        return _safe_exp(self.log_bayes_factor(model, against))
+
+    def posterior_probabilities(self) -> dict[str, float]:
+        """Posterior model probabilities under equal prior model weights.
+
+        Computed by a max-shifted softmax over the log marginal likelihoods, so the
+        result is stable however far apart the models are.
+
+        Returns:
+            Model name to posterior probability; the values sum to one.
+        """
+        names = list(self.evidences)
+        lml = np.array([self.evidences[name].log_marginal_likelihood for name in names], dtype=float)
+        weights = np.exp(lml - lml.max())
+        probs = weights / weights.sum()
+        return dict(zip(names, (float(p) for p in probs), strict=True))
+
+    def to_dataframe(self, reference: str | None = None) -> pd.DataFrame:
+        """Tabulate the comparison, one row per model in comparison order.
+
+        Args:
+            reference: Denominator for the Bayes-factor columns. Defaults to `reference`.
+
+        Returns:
+            DataFrame indexed by model name (`index.name` is `"model"`) with columns
+            `log_marginal_likelihood`, `log_bayes_factor`, `log10_bayes_factor`,
+            `bayes_factor`, `posterior_probability`, `n_obs`, `n_vars`, `n_lags` and
+            `volatility`. The reference row has a log Bayes factor of exactly 0.0.
+            `volatility` is object dtype so a homoscedastic model reads as `None`
+            rather than as a missing value.
+        """
+        denominator = self.reference if reference is None else reference
+        self._lookup(denominator)
+        probs = self.posterior_probabilities()
+        rows = {
+            name: {
+                "log_marginal_likelihood": ev.log_marginal_likelihood,
+                "log_bayes_factor": self.log_bayes_factor(name, denominator),
+                "log10_bayes_factor": self.log10_bayes_factor(name, denominator),
+                "bayes_factor": self.bayes_factor(name, denominator),
+                "posterior_probability": probs[name],
+                "n_obs": ev.n_obs,
+                "n_vars": ev.n_vars,
+                "n_lags": ev.n_lags,
+            }
+            for name, ev in self.evidences.items()
+        }
+        frame = pd.DataFrame.from_dict(rows, orient="index")
+        # Object dtype, not the inferred string dtype: pandas would otherwise coerce the
+        # None of a homoscedastic model into a missing value.
+        frame["volatility"] = pd.Series({name: ev.volatility for name, ev in self.evidences.items()}, dtype=object)
+        frame.index.name = "model"
+        return frame
+
+
+def _as_evidence(name: str, obj: Any) -> ModelEvidence:
+    """Coerce a fitted VAR or a bare `ModelEvidence` into a `ModelEvidence`."""
+    if isinstance(obj, ModelEvidence):
+        return obj
+    evidence = getattr(obj, "evidence", None)
+    if isinstance(evidence, ModelEvidence):
+        return evidence
+    if evidence is None and hasattr(obj, "idata"):
+        raise ValueError(
+            f"{name!r} carries no model evidence. Only ConjugateVAR fits have a closed-form "
+            "marginal likelihood; the PyMC/NUTS estimator (impulso.VAR) does not. Refit with "
+            "impulso.ConjugateVAR to compare evidence."
+        )
+    raise TypeError(f"{name!r} is a {type(obj).__name__}; compare_evidence takes fitted VARs or ModelEvidence objects.")
+
+
+def _check_compatible(name: str, evidence: ModelEvidence, ref_name: str, reference: ModelEvidence) -> None:
+    """Reject an evidence that cannot be placed in a Bayes factor against `reference`."""
+    if sorted(evidence.var_names) != sorted(reference.var_names):
+        raise ValueError(
+            f"{name!r} was fitted on variables {sorted(evidence.var_names)} but {ref_name!r} on "
+            f"{sorted(reference.var_names)}. Model evidence is only comparable across the same "
+            "variables — the marginal likelihood's dimension constants depend on the number of "
+            "variables. (Variable order does not matter; the variable set does.)"
+        )
+    if evidence.n_obs != reference.n_obs:
+        raise ValueError(
+            f"{name!r} was fitted on {evidence.n_obs} observations but {ref_name!r} on "
+            f"{reference.n_obs}. A marginal likelihood is a density over the observations it "
+            "conditions on, so a Bayes factor across different effective samples is undefined. "
+            "A VAR(p) trims p initial rows, so lag orders must be aligned before comparison — "
+            "fit the lower-order model on data already trimmed by the largest lag order."
+        )
+    if evidence.sample_start != reference.sample_start or evidence.sample_end != reference.sample_end:
+        raise ValueError(
+            f"{name!r} and {ref_name!r} both use {evidence.n_obs} observations but over different "
+            f"windows ({evidence.sample_start.date()}..{evidence.sample_end.date()} vs "
+            f"{reference.sample_start.date()}..{reference.sample_end.date()})."
+        )
+    if evidence.sample_digest != reference.sample_digest:
+        raise ValueError(
+            f"{name!r} and {ref_name!r} cover the same window and variables but not the same "
+            "observations (sample digest mismatch). Evidence is not comparable across "
+            "transformations of the data — levels vs logs vs differences, rescaling, or a data "
+            "revision. Refit both models on identical data."
+        )
+
+
+def compare_evidence(**fits: FittedVAR | ModelEvidence) -> EvidenceComparison:
+    """Compare conjugate-VAR fits by marginal likelihood.
+
+    Each keyword names a model, so the labels flow through to the Bayes-factor table:
+
+    ```python
+    comparison = impulso.compare_evidence(baseline=fit_p1, with_break=fit_p2)
+    comparison.to_dataframe()
+    ```
+
+    The first fit passed becomes the reference (the denominator of every Bayes factor);
+    override it per call with `bayes_factor(name, against=...)` or
+    `to_dataframe(reference=...)`.
+
+    Every fit must be comparable to the first: the same variable set (order is
+    irrelevant), the same number of response observations, the same sample window and
+    byte-identical response data. What is *allowed* to differ is exactly what is being
+    compared — lag order, volatility break, prior settings and selected hyperparameters.
+    Note that a VAR(p) drops p initial rows, so comparing lag orders means aligning the
+    response windows by hand (fit the shorter-lag model on data already trimmed by the
+    largest lag order).
+
+    Three caveats carry over from `ModelEvidence`: the evidence conditions on the
+    presample, it conditions on the selected hyperparameters (making the ratio an
+    empirical-Bayes Bayes factor when `NIWPrior(select=True)` was used), and it includes
+    the volatility-rescaling Jacobian so break and no-break models are comparable.
+
+    Args:
+        **fits: Two or more `FittedVAR` objects from `ConjugateVAR.fit` (or bare
+            `ModelEvidence` objects), keyed by the label to report them under.
+
+    Returns:
+        An `EvidenceComparison` over the named evidences.
+
+    Raises:
+        ValueError: If fewer than two fits are given, if a fit carries no evidence
+            (the PyMC/NUTS path), or if two fits are not comparable.
+        TypeError: If an argument is neither a fitted VAR nor a `ModelEvidence`.
+    """
+    if len(fits) < 2:
+        raise ValueError(
+            f"compare_evidence needs at least two named fits, got {len(fits)}. Call it with "
+            "keyword arguments, e.g. compare_evidence(baseline=fit_a, with_break=fit_b)."
+        )
+    evidences = {name: _as_evidence(name, obj) for name, obj in fits.items()}
+    ref_name = next(iter(evidences))
+    reference = evidences[ref_name]
+    for name, evidence in evidences.items():
+        if name != ref_name:
+            _check_compatible(name, evidence, ref_name, reference)
+    return EvidenceComparison(evidences=evidences, reference=ref_name)

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -10,6 +10,7 @@ from impulso._base import ImpulsoBaseModel
 from impulso._linalg import lag_matrices, sigma_from_cholesky
 from impulso._ma import compute_ma_phi
 from impulso.data import VARData
+from impulso.evidence import ModelEvidence
 from impulso.protocols import IdentificationScheme, VolatilityProcess
 
 if TYPE_CHECKING:
@@ -39,6 +40,11 @@ class FittedVAR(ImpulsoBaseModel):
             the model cannot be re-conditioned on new data. Typed as Any so
             that importing `impulso.fitted` does not pull in PyMC (see the
             lazy-import convention).
+        evidence: The closed-form log marginal likelihood of the fitted model
+            plus the metadata needed to compare it, or None when the estimator
+            has no closed-form evidence (the PyMC/NUTS `VAR` path). Populated
+            by `ConjugateVAR.fit`; pass fits carrying it to
+            `impulso.compare_evidence` for Bayes factors.
     """
 
     idata: az.InferenceData = Field(repr=False)
@@ -47,6 +53,7 @@ class FittedVAR(ImpulsoBaseModel):
     var_names: list[str]
     volatility: VolatilityProcess
     pymc_model: Any = Field(default=None, repr=False)
+    evidence: ModelEvidence | None = Field(default=None, repr=False)
 
     @property
     def has_exog(self) -> bool:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,458 @@
+"""Tests for conjugate model evidence and Bayes-factor comparison.
+
+Three things are pinned:
+
+1. The value `ConjugateVAR.fit` attaches to `FittedVAR.evidence` is the conjugate log
+   marginal likelihood *at the selected hyperparameters*, verified against independent
+   sequential-predictive-t and matrix-t evaluations (and, for a volatility break, against
+   the rescaled reference plus an explicitly added Jacobian).
+2. The metadata that decides comparability — effective sample, window, response digest.
+3. The comparison arithmetic: Bayes factors, posterior model probabilities, saturation
+   instead of overflow, and every rejection path.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+from scipy.special import multigammaln  # ty: ignore[unresolved-import]
+from scipy.stats import multivariate_t as mvt
+
+from impulso import ConjugateVAR, NIWPrior, PandemicBreak, VARData, compare_evidence
+from impulso._conjugate import ar1_residual_sd
+from impulso.evidence import EvidenceComparison, ModelEvidence, _response_digest
+from impulso.fitted import FittedVAR
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _series(seed: int, n: int, t_full: int) -> np.ndarray:
+    """Small persistent synthetic series of shape (t_full, n)."""
+    rng = np.random.default_rng(seed)
+    return np.cumsum(rng.standard_normal((t_full, n)), axis=0) + 5.0
+
+
+def _var_data(seed: int = 3, n: int = 2, t_full: int = 24) -> VARData:
+    """VARData over a monthly index, small enough for fast fits."""
+    y = _series(seed, n, t_full)
+    index = pd.date_range("2018-01-01", periods=t_full, freq="MS")
+    names = [f"y{i + 1}" for i in range(n)]
+    return VARData(endog=y, endog_names=names, index=index)
+
+
+def _design(y: np.ndarray, n_lags: int) -> tuple[np.ndarray, np.ndarray]:
+    """(Y, X) with a leading constant column, matching the engine's lag order."""
+    t_full, _ = y.shape
+    t_obs = t_full - n_lags
+    cols = [np.ones((t_obs, 1))]
+    for ell in range(1, n_lags + 1):
+        cols.append(y[n_lags - ell : t_full - ell])
+    return y[n_lags:], np.hstack(cols)
+
+
+def _sequential_logml(Y, X, Yd, Xd) -> float:
+    """Independent log ML as a product of one-step conjugate predictive multivariate-t
+    densities (recursive Bayesian updating; well-conditioned, no batch determinants)."""
+    n = Y.shape[1]
+    omega = np.linalg.inv(Xd.T @ Xd)
+    b = omega @ Xd.T @ Yd
+    r0 = Yd - Xd @ b
+    psi = r0.T @ r0
+    nu = float(n + 2)
+    total = 0.0
+    for t in range(Y.shape[0]):
+        x, y = X[t], Y[t]
+        pred_mean = b.T @ x
+        s = 1.0 + x @ omega @ x
+        df = nu - n + 1.0
+        total += mvt.logpdf(y, loc=pred_mean, shape=(s / df) * psi, df=df)
+        omega_x = omega @ x
+        omega = omega - np.outer(omega_x, omega_x) / s
+        resid = y - pred_mean
+        b = b + np.outer(omega_x, resid) / s
+        psi = psi + np.outer(resid, resid) / s
+        nu += 1.0
+    return float(total)
+
+
+def _matrix_t_logml(Y, X, Yd, Xd) -> float:
+    """Independent log ML via the matrix-t density (T x T determinant form)."""
+    n, t_obs = Y.shape[1], Y.shape[0]
+    d0, d_t = n + 2, n + 2 + t_obs
+    omega0 = np.linalg.inv(Xd.T @ Xd)
+    b0 = omega0 @ Xd.T @ Yd
+    psi0 = (Yd - Xd @ b0).T @ (Yd - Xd @ b0)
+    a_mat = np.eye(t_obs) + X @ omega0 @ X.T
+    err = Y - X @ b0
+    quad = psi0 + err.T @ np.linalg.solve(a_mat, err)
+    ld = lambda m: np.linalg.slogdet(m)[1]
+    return float(
+        -0.5 * n * t_obs * np.log(np.pi)
+        + multigammaln(d_t / 2, n)
+        - multigammaln(d0 / 2, n)
+        - 0.5 * n * ld(a_mat)
+        + 0.5 * d0 * ld(psi0)
+        - 0.5 * d_t * ld(quad)
+    )
+
+
+def _reference_logml(
+    data: VARData,
+    n_lags: int,
+    prior: NIWPrior,
+    tightness: float,
+    log_scales: np.ndarray | None = None,
+) -> float:
+    """Rebuild the conjugate log ML independently: rescale, then sequential predictive-t.
+
+    The change-of-variables Jacobian ``-n * sum(log_scales)`` is added here explicitly,
+    so a passing test pins that the library adds it exactly once.
+    """
+    y = data.endog
+    response, regressors = _design(y, n_lags)
+    dummies_y, dummies_x = prior.build_dummies(y, n_lags, ar1_residual_sd(y), tightness=tightness)
+    jacobian = 0.0
+    if log_scales is not None:
+        weights = np.exp(-np.asarray(log_scales, dtype=float).ravel())[:, None]
+        response = response * weights
+        regressors = regressors * weights
+        jacobian = -y.shape[1] * float(np.asarray(log_scales).sum())
+    return _sequential_logml(response, regressors, dummies_y, dummies_x) + jacobian
+
+
+def _evidence(name_suffix: str = "", **overrides) -> ModelEvidence:
+    """A hand-built ModelEvidence; every field overridable for the mismatch tests."""
+    fields = {
+        "log_marginal_likelihood": -100.0,
+        "n_obs": 20,
+        "n_vars": 2,
+        "var_names": ["y1", "y2"],
+        "n_lags": 1,
+        "volatility": None,
+        "hyperparameters": {},
+        "sample_start": pd.Timestamp("2018-02-01"),
+        "sample_end": pd.Timestamp("2019-09-01"),
+        "sample_digest": f"digest{name_suffix}",
+    }
+    fields.update(overrides)
+    return ModelEvidence(**fields)
+
+
+# ------------------------------------------------------------- A: the fitted-side value
+
+
+class TestEvidenceValue:
+    """The number on `FittedVAR.evidence` is the conjugate log ML the model implies."""
+
+    def test_fixed_prior_matches_sequential_reference(self):
+        data = _var_data()
+        prior = NIWPrior(tightness=0.25)
+        fitted = ConjugateVAR(lags=1, prior=prior, draws=4, tune=0, seed=0).fit(data)
+
+        expected = _reference_logml(data, 1, prior, prior.tightness)
+        assert fitted.evidence is not None
+        assert fitted.evidence.log_marginal_likelihood == pytest.approx(expected, abs=1e-8)
+
+    def test_fixed_prior_matches_matrix_t_reference(self):
+        data = _var_data(seed=5)
+        prior = NIWPrior(tightness=0.3, sum_of_coefficients=1.0)
+        fitted = ConjugateVAR(lags=2, prior=prior, draws=4, tune=0, seed=1).fit(data)
+
+        response, regressors = _design(data.endog, 2)
+        dummies = prior.build_dummies(data.endog, 2, ar1_residual_sd(data.endog), tightness=prior.tightness)
+        expected = _matrix_t_logml(response, regressors, *dummies)
+        assert fitted.evidence.log_marginal_likelihood == pytest.approx(expected, rel=1e-8)
+
+    def test_selected_prior_evidence_is_evaluated_at_the_selected_lambda(self):
+        data = _var_data(seed=7)
+        prior = NIWPrior(select=True)
+        fitted = ConjugateVAR(lags=1, prior=prior, draws=4, tune=0, seed=2).fit(data)
+
+        lam = fitted.evidence.hyperparameters["lambda_"]
+        expected = _reference_logml(data, 1, prior, lam)
+        assert fitted.evidence.log_marginal_likelihood == pytest.approx(expected, abs=1e-8)
+
+        # A wrong lambda gives a materially different value, so the test above has teeth.
+        off = _reference_logml(data, 1, prior, lam + 0.1)
+        assert abs(off - expected) > 1e-4
+
+    def test_volatility_break_evidence_includes_the_jacobian(self):
+        data = _var_data(seed=11, t_full=26)
+        prior = NIWPrior(tightness=0.2)
+        break_at = 8
+        volatility = PandemicBreak(start=break_at)
+        fitted = ConjugateVAR(lags=1, prior=prior, volatility=volatility, draws=4, tune=0, seed=3).fit(data)
+
+        theta = fitted.evidence.hyperparameters
+        log_scales = volatility.log_scales(theta, data.endog.shape[0] - 1)
+        expected = _reference_logml(data, 1, prior, prior.tightness, log_scales=log_scales)
+        assert fitted.evidence.log_marginal_likelihood == pytest.approx(expected, abs=1e-8)
+        # The Jacobian is a real, nonzero contribution on this path.
+        assert abs(float(np.sum(log_scales))) > 0.0
+
+    def test_evidence_is_seed_independent(self):
+        data = _var_data(seed=13)
+        prior = NIWPrior(select=True)
+        a = ConjugateVAR(lags=1, prior=prior, draws=4, tune=0, seed=0).fit(data)
+        b = ConjugateVAR(lags=1, prior=prior, draws=4, tune=0, seed=7).fit(data)
+
+        assert a.evidence.log_marginal_likelihood == b.evidence.log_marginal_likelihood
+        assert a.evidence.hyperparameters == b.evidence.hyperparameters
+
+    def test_hand_built_fitted_var_has_no_evidence(self, synthetic_idata_2v, var_data_2v):
+        from impulso.volatility import Constant
+
+        fitted = FittedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+        assert fitted.evidence is None
+
+
+# ------------------------------------------------------------------------ B: metadata
+
+
+class TestEvidenceMetadata:
+    """The comparability metadata describes the sample the model actually saw."""
+
+    def test_metadata_for_a_fixed_homoscedastic_fit(self):
+        data = _var_data(t_full=24)
+        fitted = ConjugateVAR(lags=2, prior=NIWPrior(), draws=4, tune=0, seed=0).fit(data)
+        ev = fitted.evidence
+
+        assert ev.n_obs == 24 - 2
+        assert ev.n_vars == 2
+        assert ev.var_names == ["y1", "y2"]
+        assert ev.n_lags == 2
+        assert ev.volatility is None
+        assert ev.hyperparameters == {}
+        assert ev.sample_start == data.index[2]
+        assert ev.sample_end == data.index[-1]
+
+    def test_metadata_for_a_selected_break_fit(self):
+        data = _var_data(seed=17, t_full=26)
+        fitted = ConjugateVAR(
+            lags=1,
+            prior=NIWPrior(select=True),
+            volatility=PandemicBreak(start=8),
+            draws=4,
+            tune=0,
+            seed=0,
+        ).fit(data)
+        ev = fitted.evidence
+
+        assert ev.volatility == "pandemic_break"
+        assert set(ev.hyperparameters) == {"lambda_", "s_march", "s_april", "s_may", "rho"}
+
+    def test_digest_is_stable_and_sensitive(self):
+        data = _var_data()
+        names = data.endog_names
+        base = _response_digest(data.endog, names, 1)
+
+        assert _response_digest(data.endog.copy(), names, 1) == base
+        assert _response_digest(data.endog * 1.001, names, 1) != base
+
+    def test_digest_is_invariant_to_column_permutation(self):
+        data = _var_data(n=3)
+        names = data.endog_names
+        order = [2, 0, 1]
+        permuted = data.endog[:, order]
+        permuted_names = [names[i] for i in order]
+
+        assert _response_digest(permuted, permuted_names, 1) == _response_digest(data.endog, names, 1)
+
+    def test_aligned_lag_orders_share_sample_metadata(self):
+        data = _var_data(t_full=24)
+        trimmed = VARData(endog=data.endog[1:], endog_names=data.endog_names, index=data.index[1:])
+
+        fit_p2 = ConjugateVAR(lags=2, prior=NIWPrior(), draws=4, tune=0, seed=0).fit(data)
+        fit_p1 = ConjugateVAR(lags=1, prior=NIWPrior(), draws=4, tune=0, seed=0).fit(trimmed)
+
+        assert fit_p1.evidence.n_obs == fit_p2.evidence.n_obs
+        assert fit_p1.evidence.sample_start == fit_p2.evidence.sample_start
+        assert fit_p1.evidence.sample_end == fit_p2.evidence.sample_end
+        assert fit_p1.evidence.sample_digest == fit_p2.evidence.sample_digest
+
+
+# ---------------------------------------------------------------------- C: comparison
+
+
+class TestComparison:
+    """Bayes-factor arithmetic on hand-built evidences — no fitting involved."""
+
+    def test_bayes_factor_from_a_known_log_difference(self):
+        a = _evidence(log_marginal_likelihood=-100.0)
+        b = _evidence(log_marginal_likelihood=-100.0 + np.log(10.0))
+        comparison = compare_evidence(base=a, alt=b)
+
+        assert comparison.bayes_factor("alt") == pytest.approx(10.0, rel=1e-12)
+        assert comparison.log10_bayes_factor("alt") == pytest.approx(1.0, rel=1e-12)
+        assert comparison.log_bayes_factor("alt") == pytest.approx(np.log(10.0), rel=1e-12)
+
+    def test_reference_defaults_to_the_first_fit_and_inverts(self):
+        a = _evidence(log_marginal_likelihood=-100.0)
+        b = _evidence(log_marginal_likelihood=-97.0)
+        comparison = compare_evidence(base=a, alt=b)
+
+        assert comparison.reference == "base"
+        assert comparison.log_bayes_factor("base") == 0.0
+        assert comparison.bayes_factor("alt", against="base") == pytest.approx(
+            1.0 / comparison.bayes_factor("base", against="alt"), rel=1e-12
+        )
+        assert comparison.best == "alt"
+
+    def test_to_dataframe_shape_order_and_reference_row(self):
+        a = _evidence(log_marginal_likelihood=-100.0)
+        b = _evidence(log_marginal_likelihood=-97.0, n_lags=2)
+        frame = compare_evidence(base=a, alt=b).to_dataframe()
+
+        assert frame.index.name == "model"
+        assert list(frame.index) == ["base", "alt"]
+        assert list(frame.columns) == [
+            "log_marginal_likelihood",
+            "log_bayes_factor",
+            "log10_bayes_factor",
+            "bayes_factor",
+            "posterior_probability",
+            "n_obs",
+            "n_vars",
+            "n_lags",
+            "volatility",
+        ]
+        assert frame.loc["base", "log_bayes_factor"] == 0.0
+        assert frame.loc["base", "bayes_factor"] == 1.0
+        assert frame["posterior_probability"].sum() == pytest.approx(1.0, rel=1e-12)
+        assert list(frame["n_lags"]) == [1, 2]
+
+    def test_to_dataframe_accepts_an_explicit_reference(self):
+        a = _evidence(log_marginal_likelihood=-100.0)
+        b = _evidence(log_marginal_likelihood=-97.0)
+        frame = compare_evidence(base=a, alt=b).to_dataframe(reference="alt")
+
+        assert frame.loc["alt", "log_bayes_factor"] == 0.0
+        assert frame.loc["base", "log_bayes_factor"] == pytest.approx(-3.0, rel=1e-12)
+
+    def test_extreme_log_differences_saturate_instead_of_overflowing(self):
+        a = _evidence(log_marginal_likelihood=-1e4)
+        b = _evidence(log_marginal_likelihood=1e4)
+        comparison = compare_evidence(base=a, alt=b)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert comparison.bayes_factor("alt") == np.inf
+            assert comparison.bayes_factor("base", against="alt") == 0.0
+            assert comparison.log_bayes_factor("alt") == pytest.approx(2e4, rel=1e-12)
+            assert comparison.log10_bayes_factor("alt") == pytest.approx(2e4 / np.log(10.0), rel=1e-12)
+            probs = comparison.posterior_probabilities()
+        assert probs == {"base": 0.0, "alt": 1.0}
+
+    def test_unknown_model_name_raises_key_error(self):
+        comparison = compare_evidence(base=_evidence(), alt=_evidence())
+        with pytest.raises(KeyError, match="missing"):
+            comparison.log_bayes_factor("missing")
+
+    def test_single_fit_is_rejected(self):
+        with pytest.raises(ValueError, match="at least two"):
+            compare_evidence(only=_evidence())
+
+    def test_mismatched_variables_are_rejected(self):
+        a = _evidence()
+        b = _evidence(var_names=["y1", "y3"])
+        with pytest.raises(ValueError, match="variables"):
+            compare_evidence(base=a, alt=b)
+
+    def test_permuted_variable_names_are_accepted(self):
+        a = _evidence()
+        b = _evidence(var_names=["y2", "y1"])
+        assert compare_evidence(base=a, alt=b).reference == "base"
+
+    def test_mismatched_sample_size_is_rejected(self):
+        a = _evidence()
+        b = _evidence(n_obs=19)
+        with pytest.raises(ValueError, match="observations"):
+            compare_evidence(base=a, alt=b)
+
+    def test_mismatched_window_is_rejected(self):
+        a = _evidence()
+        b = _evidence(sample_start=pd.Timestamp("2018-03-01"), sample_end=pd.Timestamp("2019-10-01"))
+        with pytest.raises(ValueError, match="window"):
+            compare_evidence(base=a, alt=b)
+
+    def test_mismatched_digest_is_rejected(self):
+        a = _evidence()
+        b = _evidence("-other")
+        with pytest.raises(ValueError, match="digest"):
+            compare_evidence(base=a, alt=b)
+
+    def test_fit_without_evidence_is_rejected(self, synthetic_idata_2v, var_data_2v):
+        from impulso.volatility import Constant
+
+        fitted = FittedVAR.model_construct(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+        with pytest.raises(ValueError, match="ConjugateVAR"):
+            compare_evidence(base=_evidence(), nuts=fitted)
+
+    def test_non_fit_argument_is_rejected(self):
+        with pytest.raises(TypeError, match="ModelEvidence"):
+            compare_evidence(base=_evidence(), oops="not a fit")
+
+    def test_non_finite_evidence_is_rejected_at_construction(self):
+        with pytest.raises(ValidationError, match="marginal likelihood evaluated to"):
+            _evidence(log_marginal_likelihood=-np.inf)
+
+    def test_comparison_requires_a_reference_it_holds(self):
+        with pytest.raises(ValidationError, match="not one of the compared models"):
+            EvidenceComparison(evidences={"a": _evidence(), "b": _evidence()}, reference="c")
+
+
+# ------------------------------------------------------------------- D: end-to-end fast
+
+
+class TestEndToEnd:
+    """Real fits, small enough to stay off the slow marker."""
+
+    def test_lag_order_comparison_on_an_aligned_window(self):
+        data = _var_data(seed=21, t_full=28)
+        trimmed = VARData(endog=data.endog[1:], endog_names=data.endog_names, index=data.index[1:])
+
+        fit_p1 = ConjugateVAR(lags=1, prior=NIWPrior(select=True), draws=2, tune=0, seed=0).fit(trimmed)
+        fit_p2 = ConjugateVAR(lags=2, prior=NIWPrior(select=True), draws=2, tune=0, seed=0).fit(data)
+
+        frame = compare_evidence(one_lag=fit_p1, two_lags=fit_p2).to_dataframe()
+        assert list(frame["n_lags"]) == [1, 2]
+        assert frame.loc["one_lag", "log_bayes_factor"] == 0.0
+        assert frame["posterior_probability"].sum() == pytest.approx(1.0, rel=1e-12)
+
+    def test_unaligned_lag_orders_are_rejected_with_the_trimming_hint(self):
+        data = _var_data(seed=21, t_full=28)
+        fit_p1 = ConjugateVAR(lags=1, prior=NIWPrior(), draws=2, tune=0, seed=0).fit(data)
+        fit_p2 = ConjugateVAR(lags=2, prior=NIWPrior(), draws=2, tune=0, seed=0).fit(data)
+
+        with pytest.raises(ValueError, match="trimmed by the largest lag order"):
+            compare_evidence(one_lag=fit_p1, two_lags=fit_p2)
+
+    def test_break_versus_no_break_on_the_same_sample(self):
+        data = _var_data(seed=23, t_full=26)
+        homoscedastic = ConjugateVAR(lags=1, prior=NIWPrior(), draws=2, tune=0, seed=0).fit(data)
+        with_break = ConjugateVAR(
+            lags=1,
+            prior=NIWPrior(),
+            volatility=PandemicBreak(start=8),
+            draws=2,
+            tune=0,
+            seed=0,
+        ).fit(data)
+
+        frame = compare_evidence(homoscedastic=homoscedastic, with_break=with_break).to_dataframe()
+        assert list(frame["volatility"]) == [None, "pandemic_break"]
+        assert np.isfinite(frame["log_bayes_factor"]).all()

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -132,3 +132,30 @@ class TestVolatilityPublicAPI:
 
         assert "Constant" in impulso.__all__
         assert "VolatilityProcess" in impulso.__all__
+
+
+class TestEvidencePublicAPI:
+    def test_model_evidence_importable_from_impulso(self):
+        from impulso import ModelEvidence
+        from impulso.evidence import ModelEvidence as DirectModelEvidence
+
+        assert ModelEvidence is DirectModelEvidence
+
+    def test_evidence_comparison_importable_from_impulso(self):
+        from impulso import EvidenceComparison
+        from impulso.evidence import EvidenceComparison as DirectEvidenceComparison
+
+        assert EvidenceComparison is DirectEvidenceComparison
+
+    def test_compare_evidence_importable_from_impulso(self):
+        from impulso import compare_evidence
+        from impulso.evidence import compare_evidence as direct_compare_evidence
+
+        assert compare_evidence is direct_compare_evidence
+
+    def test_evidence_names_in_all(self):
+        import impulso
+
+        assert "ModelEvidence" in impulso.__all__
+        assert "EvidenceComparison" in impulso.__all__
+        assert "compare_evidence" in impulso.__all__


### PR DESCRIPTION
## Summary

The conjugate engine computed its closed-form log marginal likelihood hundreds of times per fit inside hyperparameter selection and threw every value away. Now:

- **`FittedVAR.evidence: ModelEvidence | None`** — populated by `ConjugateVAR.fit` (mirrors the estimator-specific `pymc_model` field; `None` on the NUTS path, which has no closed form). Carries the log marginal likelihood **at the selected hyperparameter mode** plus the metadata that establishes comparability: effective sample after lag trimming, window, variable names, a SHA-256 digest of the response block (column-order-invariant), volatility discriminator, and the hyperparameter values the number is conditional on.
- **`compare_evidence(**fits)`** in new leaf module `src/impulso/evidence.py` — keyword names are the model labels; validates that every fit's marginal likelihood is a density over the same observations (same variable *set*, same effective sample — with an explicit lag-trimming alignment hint in the error — same window, same digest), then returns a frozen `EvidenceComparison` with log/log10 Bayes factors, clamped `bayes_factor` (`inf`/`0.0` beyond ±709 rather than overflow), max-shifted posterior model probabilities, and `.to_dataframe()`.
- `select_and_sample` gains a behaviour-identical `log_ml_and_prior` split and returns `log_marginal_likelihood` from both paths (fast path evaluates with `log_scales=None`, matching what it actually fits).
- Docs: `docs/reference/evidence.md` + toctree, `CONTEXT.md` glossary entry, and a "Which lag order does the data prefer?" section in the conjugate tutorial (deterministic, no MCMC, smoke-safe — the committed data prefers p=1 by ~28–30 log points).

Key semantics, documented on every surface: the value is a density over the *observed* data (the volatility change-of-variables Jacobian is included once, which is exactly what makes break-vs-no-break fits comparable); with `select=True` the Bayes factor is a conditional (empirical-Bayes) one; differing lag orders condition on different presamples, so aligned response windows are required and hinted at in the error.

Closes #141

## Review

Planned by a dedicated planning agent; implementation reviewed by an independent reviewer that re-derived the predictive-t recursions, Sylvester determinant form, and permutation-invariance claim, and executed the tutorial cells offline. Verdict: approve, no in-scope findings. Out-of-scope items filed as separate issues.

## Tests

34 new tests (30 in `tests/test_evidence.py`, 4 in `tests/test_public_api.py`), all fast. Two *independent* references for the evidence value (sequential predictive multivariate-t via scipy + rank-1 updates; batch matrix-t determinant form) at 1e-8 tolerance; an explicit Jacobian pin that fails on both drop and double-add; overflow tests under warnings-as-errors; compatibility-rejection tests for each rule.

`ruff` / `ty` / fast suite: all green (561 passed, 29 deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV