### PR TITLE
feat(identification): long-run (Blanchard-Quah) structural restrictions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,8 +13,15 @@ The reduced-form VAR fits dynamics without economic interpretation; the structur
 _Avoid_: "raw" / "interpretable" — they obscure the technical meaning.
 
 **Identification scheme**:
-A rule for recovering structural shocks from reduced-form covariance, implemented as adapters of the `IdentificationScheme` Protocol (`Cholesky`, `SignRestriction`). The scheme is a pure function: it consumes a Cholesky factor `L` and produces a structural shock matrix `B = identify(L)`. It does not own time iteration.
+A rule for recovering structural shocks from reduced-form covariance, implemented as adapters of the `IdentificationScheme` Protocol (`Cholesky`, `SignRestriction`, `LongRunRestriction`, `ProxySVAR`). The scheme is a pure function: it consumes a Cholesky factor `L` and produces a structural shock matrix `B = identify(L)`. It does not own time iteration.
 _Avoid_: "identification strategy" (used colloquially; the Protocol is named "scheme").
+
+**Long-run multiplier (C(1))**:
+The sum of the moving-average coefficients of a stable reduced-form VAR, `C(1) = Σ_h Φ_h = (I − Σ_j A_j)^{-1}` — the total effect of a one-off reduced-form innovation on the *level* of each variable. Exists only when the companion spectral radius is below one; `I − Σ_j A_j` near-singular means it is numerically undefined, which is a distinct failure from divergence.
+
+**Cumulative MA impact matrix (Θ(1))**:
+The structural counterpart, `Θ(1) = C(1) P`: the total effect of each structural shock on each variable's level. Where `Cholesky` and `SignRestriction` constrain the impact matrix `Θ(0) = P`, `LongRunRestriction` constrains `Θ(1)` to be lower-triangular in a stated variable ordering, with positive diagonal (shock `j` raises variable `j`'s long-run level).
+_Avoid_: "Blanchard-Quah identification" as an API name — the scheme is named for what it restricts, not for its first users (the prose citation is fine). "Permanent shock" for anything but the first column: only the shock restricted nowhere is unambiguously permanent.
 
 **Volatility process**:
 The seam that owns how the structural-shock covariance Σ_t is constructed (in PyMC), evolved over time, and queried. Concrete adapters of the `VolatilityProcess` Protocol: `Constant` (homoscedastic Σ; the default) and `StochasticVolatility` (time-varying). The volatility process owns its downstream computation — forecast covariance paths, time-`t` Cholesky query, per-variable volatility paths — so the pipeline never branches on adapter type.
@@ -108,6 +115,7 @@ _Avoid_: "stochastic volatility" — the break is deterministic given its hyperp
 - A **VAR** carries one **prior**, one **volatility process**, and one **observation error distribution**.
 - A **FittedVAR** plus an **identification scheme** produces an **IdentifiedVAR**.
 - An **identification scheme** consumes an `L_t` (queried from the volatility process) and produces a structural shock matrix `B`.
+- An **identification scheme** may additionally consume the posterior lag coefficients: `LongRunRestriction` needs them for the **long-run multiplier**, as `SignRestriction(restriction_horizon > 0)` and `ProxySVAR` already do. `L_t` alone is the minimum, not the maximum, of what a scheme may ask for.
 - An **IdentifiedVAR** computes **IRFs**, FEVDs, and historical decompositions by asking the volatility process for `L_t` at the requested `at`, then applying the identification scheme.
 - A **FittedVAR** fitted with exogenous regressors computes **dynamic multipliers** on its own; no identification scheme is involved, because the driver is already exogenous.
 - A **stochastic volatility** can plug into a **VAR** as its volatility process *or* be fitted standalone on a univariate series.

--- a/docs/explanation/identification.md
+++ b/docs/explanation/identification.md
@@ -44,3 +44,31 @@ scheme = SignRestriction(
 ```
 
 Sign restrictions are weaker than Cholesky (they don't uniquely identify the model), but they require fewer assumptions.
+
+## Long-run restrictions
+
+Cholesky and sign restrictions both constrain the *impact* matrix $\Theta(0) = P$ — what happens on the day of the shock. Long-run restrictions constrain the *cumulative* matrix $\Theta(1)$ instead: the total effect of each shock on the level of each variable, summed over all horizons. Adding up the moving-average coefficients of a stable VAR gives the long-run multiplier $C(1) = \sum_h \Phi_h = (I - \sum_j A_j)^{-1}$, and the cumulative structural impact is $\Theta(1) = C(1) P$.
+
+The restriction is that $\Theta(1)$ is lower-triangular in the order you supply: a shock has no long-run effect on any variable ordered before it. Two variables, one restriction — the {cite:t}`blanchardQuah1989` case:
+
+```python
+from impulso.identification import LongRunRestriction
+
+scheme = LongRunRestriction(
+    ordering=["output_growth", "unemployment"],
+    shock_names=["supply", "demand"],
+)
+```
+
+Here the single zero says the demand shock has no permanent effect on the level of output. The supply shock is unrestricted, and both shocks may do whatever they like to unemployment.
+
+Nothing is searched for. Since $\Theta(1)\Theta(1)' = C(1)\Sigma C(1)'$, the lower-triangular positive-diagonal $\Theta(1)$ is that matrix's Cholesky factor, and $P$ follows. So the scheme is a *rotation of the Cholesky factor* — the same object sign restrictions sample over — picked out in closed form. The positive diagonal is the sign convention: shock $j$ raises variable $j$'s long-run level. The diagonal of $P$ itself may be negative, since the normalisation applies to the cumulative matrix rather than to impact.
+
+:::{admonition} Your variables must be differenced
+:class: warning
+$C(1)$ is the long-run multiplier on the levels of the variables *as modelled*. "No permanent effect on output" is a statement about the level of output, so output must enter the VAR as a growth rate — otherwise the restriction says something else entirely. Impulso cannot check this for you.
+:::
+
+Triangularity is $n(n-1)/2$ restrictions, exactly the number needed for point identification. With two variables that is the one restriction you wanted. With three it asserts three zeros at once, which is a much stronger joint claim than it looks. Arbitrary (non-recursive) long-run zero patterns are not supported.
+
+Two things can go wrong, and Impulso reports them separately. If $I - \sum_j A_j$ is close to singular, $C(1)$ is numerically undefined and those draws are blanked (or, with `on_undefined="raise"`, refused). If a draw is explosive — companion spectral radius above one — the arithmetic is fine but $\sum_h \Phi_h$ diverges, so "long-run effect" has no meaning for it; those draws are always reported and never blanked, because posteriors near a unit root routinely contain them.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -9,5 +9,6 @@ data-preparation
 custom-priors
 lag-selection
 sign-restrictions
+long-run-restrictions
 heavy-tailed-errors
 ```

--- a/docs/how-to/long-run-restrictions.md
+++ b/docs/how-to/long-run-restrictions.md
@@ -1,0 +1,105 @@
+# Using Long-Run Restrictions
+
+Long-run restrictions identify structural shocks by what they do *eventually*, not on impact: a shock is defined by having no permanent effect on the level of some variable. This is the Blanchard-Quah scheme.
+
+## Define the restriction
+
+Give the variables in order, most restricted first, and name the shocks:
+
+```python
+from impulso.identification import LongRunRestriction
+
+scheme = LongRunRestriction(
+    ordering=["output_growth", "unemployment"],
+    shock_names=["supply", "demand"],
+)
+```
+
+That single zero says the demand shock has no permanent effect on the level of output. Shock `j` has no long-run effect on any variable ordered before it, so the ordering is the restriction — with two variables there is exactly one.
+
+If naming the zeros directly is clearer than reasoning about an ordering, use the alternative constructor. It recovers the ordering from the pattern, and refuses patterns that no ordering can produce:
+
+```python
+scheme = LongRunRestriction.from_zero_restrictions(
+    restrictions={"output_growth": ["demand"]},
+    var_names=["output_growth", "unemployment"],
+    shock_names=["supply", "demand"],
+)
+```
+
+:::{admonition} Your variables must be differenced
+:class: warning
+The restriction is on the long-run level of the variables *as they enter
+the model*. "Demand has no permanent effect on output" therefore requires
+output to enter as a growth rate — the level then accumulates, and a
+zero cumulative effect on the growth rate is a zero permanent effect on
+the level. If you pass output in levels, the restriction says the demand
+shock has no permanent effect on the *growth rate*, which is a much
+weaker and rarely intended claim. Impulso cannot detect the difference.
+:::
+
+## Apply it
+
+```python
+identified = fitted.set_identification_strategy(scheme)
+irf = identified.impulse_response(horizon=40)
+```
+
+The scheme needs the posterior lag coefficients to build the long-run multiplier; `set_identification_strategy` passes them through automatically.
+
+Rows of the structural shock matrix stay in the data's variable order, whatever `ordering` says. Only the shock columns follow `shock_names`.
+
+## Read the diagnostics
+
+Identification succeeds or fails per posterior draw, so the diagnostics are posterior quantities. Summary statistics ride along on the shock matrix:
+
+```python
+P = identified.shock_matrix()
+P.attrs["long_run_singular_draws"]      # draws where C(1) is undefined
+P.attrs["long_run_explosive_draws"]     # draws with spectral radius > 1
+P.attrs["long_run_condition_q95"]       # conditioning of I - sum_j A_j
+P.attrs["long_run_spectral_radius_max"]
+```
+
+For the full per-draw picture:
+
+```python
+diagnostics = scheme.long_run_diagnostics(fitted.idata.posterior)
+diagnostics["condition"]         # shape (chains, draws)
+diagnostics["spectral_radius"]   # shape (chains, draws)
+```
+
+A spectral radius above one means that draw's moving-average sum diverges, so the long run does not exist for it. Impulso warns and reports those draws but keeps them: posteriors on persistent data routinely put mass above one, and dropping them would quietly condition the posterior on stability.
+
+## When draws are undefined
+
+The long-run multiplier is `C(1) = (I - sum_j A_j)^-1`. When that matrix is close to singular, the inverse is numerically meaningless. Those draws are blanked:
+
+```python
+scheme = LongRunRestriction(
+    ordering=["output_growth", "unemployment"],
+    shock_names=["supply", "demand"],
+    on_undefined="nan",     # default; "raise" errors instead
+    max_condition=1e8,      # condition number above which C(1) is refused
+)
+```
+
+`NaN` draws propagate: impulse responses and forecast error variance decompositions (FEVD) report `NaN` for them rather than a misleading zero, and highest-density intervals over a mixed set of draws may come back `NaN` too. The scenario methods (`counterfactual`, `structural_scenario`) reject them outright. If any of that is in your plans, run with `on_undefined="raise"` so the problem surfaces at identification time instead of three steps later.
+
+## A climate example
+
+The scheme is not specific to macroeconomics. Take global-mean surface temperature and an El Niño-Southern Oscillation (ENSO) index, with temperature differenced:
+
+```python
+scheme = LongRunRestriction(
+    ordering=["temperature_change", "enso_index"],
+    shock_names=["forced", "internal"],
+)
+identified = fitted.set_identification_strategy(scheme)
+```
+
+The restriction: internal variability has no permanent effect on the level of global-mean temperature, while forced variability may. That is one assumption, stated plainly, and it is doing all the identifying work — so be clear about what it commits you to:
+
+- Temperature must enter as a change, not a level, or the restriction means something else.
+- With two variables this is exactly one restriction. Adding a third variable would assert three zeros at once, which is a far stronger joint claim.
+- The zero is exact and permanent. If internal variability has a small but genuinely permanent effect, the scheme will attribute it to the forced shock.

--- a/docs/reference/identification.md
+++ b/docs/reference/identification.md
@@ -9,4 +9,6 @@
 
    Cholesky
    SignRestriction
+   LongRunRestriction
+   ProxySVAR
 ```

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -146,3 +146,13 @@
   number  = {1},
   pages   = {68--79},
 }
+
+@article{blanchardQuah1989,
+  author  = {Blanchard, Olivier Jean and Quah, Danny},
+  title   = {The Dynamic Effects of Aggregate Demand and Supply Disturbances},
+  journal = {The American Economic Review},
+  year    = {1989},
+  volume  = {79},
+  number  = {4},
+  pages   = {655--673},
+}

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from impulso.conjugate_volatility import ConjugateVolatility, PandemicBreak
     from impulso.evidence import EvidenceComparison, ModelEvidence, compare_evidence
     from impulso.fitted import FittedVAR
-    from impulso.identification import Cholesky, ProxySVAR, SignRestriction
+    from impulso.identification import Cholesky, LongRunRestriction, ProxySVAR, SignRestriction
     from impulso.identified import IdentifiedVAR
     from impulso.observation import Gaussian, StudentT
     from impulso.priors import MinnesotaPrior, NIWPrior
@@ -63,6 +63,7 @@ __all__ = [
     "IRFResult",
     "IdentifiedVAR",
     "LagOrderResult",
+    "LongRunRestriction",
     "MinnesotaPrior",
     "ModelEvidence",
     "NIWPrior",
@@ -93,6 +94,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "FittedVAR": "impulso.fitted",
     "IdentifiedVAR": "impulso.identified",
     "Cholesky": "impulso.identification",
+    "LongRunRestriction": "impulso.identification",
     "ProxySVAR": "impulso.identification",
     "SignRestriction": "impulso.identification",
     "MinnesotaPrior": "impulso.priors",

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -92,16 +92,13 @@ class _PosteriorCache:
     variable name, a horizon). Do not put arrays there — elementwise
     comparison would not yield a bool.
 
-    Intended adoption (issue #203). The other identity-keyed memos in this
-    module collapse to the same three lines once their branches merge:
+    Adopted by `ProxySVAR._impact_cache` and `LongRunRestriction._lr_cache`
+    (issue #203). The one remaining identity-keyed memo in this module
+    collapses to the same three lines once its branch merges:
 
         MaxShare._spectral_cache:
             self._spectral_cache.get(posterior, (n_lags, target))
             self._spectral_cache.set(posterior, (n_lags, target), value)
-
-        LongRunRestriction._lr_cache:
-            self._lr_cache.get(posterior, (n_lags,))
-            self._lr_cache.set(posterior, (n_lags,), value)
 
     Declare the attribute on the (frozen) scheme with
     `PrivateAttr(default_factory=_PosteriorCache)` so each instance gets
@@ -517,9 +514,10 @@ class LongRunRestriction(ImpulsoModel):
     # volatility, where the pipeline calls identify() once per period with
     # the same posterior, the eigendecomposition runs once instead of T
     # times (and the warnings fire once, not T times). Keyed by object
-    # identity: valid while the caller holds the same posterior object,
-    # which is exactly the per-t loop's lifetime.
-    _lr_cache: tuple | None = PrivateAttr(default=None)
+    # identity, with a weak reference as the validity token: valid while
+    # the caller holds the same posterior object, which is exactly the
+    # per-t loop's lifetime. See `_PosteriorCache`.
+    _lr_cache: _PosteriorCache = PrivateAttr(default_factory=_PosteriorCache)
 
     @model_validator(mode="after")
     def _validate_names(self) -> "LongRunRestriction":
@@ -694,16 +692,17 @@ class LongRunRestriction(ImpulsoModel):
     def _screen(self, posterior: "xr.Dataset", n_lags: int, n_vars: int) -> tuple[np.ndarray, np.ndarray]:
         """Build `M = I - sum_j A_j` and flag the draws where `C(1)` is undefined.
 
-        Memoised on `(id(posterior), n_lags)` — see `_lr_cache`.
+        Memoised on the posterior's identity plus `n_lags` — see
+        `_lr_cache` and `_PosteriorCache`.
 
         Returns:
             Tuple `(M, bad)`: the long-run matrix, shape
             `(chains, draws, n_vars, n_vars)`, and a boolean mask of draws
             whose condition number exceeds `max_condition`.
         """
-        cache_key = (id(posterior), n_lags)
-        if self._lr_cache is not None and self._lr_cache[0] == cache_key:
-            return self._lr_cache[1]
+        cached = self._lr_cache.get(posterior, (n_lags,))
+        if cached is not _CACHE_MISS:
+            return cached
 
         A = lag_matrices(posterior["B"].values, n_lags)
         M = np.eye(n_vars) - np.sum(A, axis=0)
@@ -726,7 +725,7 @@ class LongRunRestriction(ImpulsoModel):
             "long_run_spectral_radius_max": float(rho.max()),
         }
         self._report(bad, explosive)
-        self._lr_cache = (cache_key, (M, bad))
+        self._lr_cache.set(posterior, (n_lags,), (M, bad))
         return M, bad
 
     def _report(self, bad: np.ndarray, explosive: np.ndarray) -> None:

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1,12 +1,12 @@
 """Identification schemes for structural VAR analysis."""
 
 import weakref
-from typing import TYPE_CHECKING, Any, ClassVar, Final
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal
 
 import numpy as np
 import pandas as pd
 import xarray as xr
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, model_validator
 
 from impulso._base import ImpulsoBaseModel, ImpulsoModel
 from impulso._linalg import lag_matrices
@@ -14,6 +14,37 @@ from impulso._ma import compute_ma_phi
 
 if TYPE_CHECKING:
     from impulso.data import VARData
+
+# Arbitrary (non-recursive) long-run zero patterns need the Arias-Rubio-
+# Ramirez-Waggoner machinery; `LongRunRestriction` points users here.
+_NONRECURSIVE_ISSUE = "https://github.com/thomaspinder/Impulso/issues/144"
+
+
+def _companion_spectral_radius(A: list[np.ndarray]) -> np.ndarray:
+    """Largest absolute eigenvalue of the VAR companion matrix, per draw.
+
+    The companion form stacks the lag matrices in its top block-row and
+    carries an identity subdiagonal. Its spectral radius is below one
+    exactly when the VAR is stable, i.e. when the moving-average sum
+    `sum_h Phi_h` converges.
+
+    Args:
+        A: Lag coefficient matrices `A_1, ..., A_p` in lag order, each of
+            shape `(..., n, n)` with shared leading batch axes.
+
+    Returns:
+        Spectral radii with the shared leading batch shape, e.g.
+        `(chains, draws)`.
+    """
+    n = A[0].shape[-1]
+    n_lags = len(A)
+    leading = A[0].shape[:-2]
+    companion = np.zeros((*leading, n * n_lags, n * n_lags))
+    companion[..., :n, :] = np.concatenate(A, axis=-1)
+    if n_lags > 1:
+        sub = np.arange(n * (n_lags - 1))
+        companion[..., n + sub, sub] = 1.0
+    return np.abs(np.linalg.eigvals(companion)).max(axis=-1)
 
 
 _CACHE_MISS: Final = object()
@@ -395,6 +426,378 @@ class SignRestriction(ImpulsoModel):
                 if sign == "-" and val > 0:
                     return False
         return True
+
+
+class LongRunRestriction(ImpulsoModel):
+    """Long-run (cumulative) zero restrictions, Blanchard-Quah style.
+
+    Cholesky and sign restrictions constrain the *impact* matrix
+    `Theta(0) = P`. This scheme constrains the *cumulative* matrix
+    `Theta(1)`: the total effect of each structural shock on the level of
+    each variable, summed over all horizons. For a stable reduced-form VAR
+    with moving-average coefficients `Phi_h`, the long-run multiplier is
+
+        C(1) = sum_h Phi_h = (I - sum_j A_j)^-1 = M^-1,   M = I - sum_j A_j,
+
+    and the cumulative structural impact is `Theta(1) = C(1) P`. The
+    restriction imposed here is that `Theta(1)` is lower-triangular in the
+    coordinates given by `ordering`: shock `j` has no long-run effect on
+    the variables ordered before it. In the Blanchard-Quah (1989) two-
+    variable case — `ordering=["output_growth", "unemployment"]`,
+    `shock_names=["supply", "demand"]` — the single zero says the demand
+    shock has no permanent effect on the level of output.
+
+    Construction is closed-form. `Theta(1) Theta(1)' = C(1) Sigma C(1)'`,
+    so the lower-triangular positive-diagonal `Theta(1)` is the Cholesky
+    factor of that matrix and `P = M Theta(1)`. Internally the equivalent
+    QR route is used: with `L L' = Sigma`, factor `(M^-1 L)' = Q R` and set
+    `P = L Q` (sign-fixed so `diag(R) > 0`). Because `Q` is orthogonal,
+    `P P' = Sigma` holds to machine precision, and the conditioning of
+    `C(1) Sigma C(1)'` is never squared. It also shows what the scheme is:
+    a rotation of the Cholesky factor, chosen in closed form rather than
+    searched for.
+
+    Sign convention: the diagonal of `Theta(1)` is positive, so shock `j`
+    raises variable `j`'s long-run level. The diagonal of `P` itself may
+    be negative — the normalisation is on the cumulative matrix, not on
+    impact.
+
+    Restriction count: triangularity is `n(n-1)/2` restrictions, exactly
+    the number needed for point identification. For `n = 2` that is the
+    single restriction users usually want. For larger `n` it asserts every
+    zero above the diagonal, which is a strong joint claim. Arbitrary
+    (non-recursive) long-run zero patterns are out of scope, as are
+    partial long-run identification and mixed short-run/long-run schemes
+    (Gali 1999).
+
+    Two failure modes are reported separately:
+
+    - `M` near-singular (`C(1)` numerically undefined). Controlled by
+      `on_undefined` and `max_condition`.
+    - Explosive draws (companion spectral radius above one). `M` may be
+      perfectly well conditioned while `sum_h Phi_h` diverges, so the
+      arithmetic succeeds but the *interpretation* does not. Those draws
+      are always returned finite and always warned about.
+
+    Attributes:
+        ordering: Variable names ordered most long-run-restricted first,
+            mirroring `Cholesky.ordering`. The returned matrix keeps its
+            rows in the data's own variable order; `ordering` only defines
+            the coordinates in which `Theta(1)` is triangular.
+        shock_names: Labels for the shock columns, in the same order as
+            `ordering`. `None` (default) reuses `ordering` as the labels.
+            Explicit naming is strongly preferred — the whole point of the
+            scheme is that the columns mean something.
+        on_undefined: `"nan"` (default) blanks draws whose `M` is
+            numerically singular and warns; `"raise"` errors instead.
+            NaN draws propagate into IRF/FEVD and are rejected outright by
+            the scenario methods, so `"raise"` catches the problem early.
+        max_condition: Condition-number threshold above which `M` counts
+            as numerically singular. Default `1e8`.
+
+    Note:
+        `C(1)` is the long-run multiplier on the levels of the *modelled*
+        variables. "No permanent effect on output" therefore requires
+        output to enter the VAR as a growth rate; the library cannot check
+        this for you.
+    """
+
+    ordering: list[str]
+    shock_names: list[str] | None = None
+    on_undefined: Literal["nan", "raise"] = "nan"
+    max_condition: float = Field(default=1e8, gt=0.0)
+
+    # Single-call scratchpad, mirroring ProxySVAR._last_diagnostics:
+    # _screen() writes the long-run diagnostics; the pipeline reads them
+    # back and attaches them to the shock-matrix attrs.
+    _last_diagnostics: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    # Memoised screen. `M`, its conditioning and the spectral radii depend
+    # only on (posterior, n_lags) — not on L — so under time-varying
+    # volatility, where the pipeline calls identify() once per period with
+    # the same posterior, the eigendecomposition runs once instead of T
+    # times (and the warnings fire once, not T times). Keyed by object
+    # identity: valid while the caller holds the same posterior object,
+    # which is exactly the per-t loop's lifetime.
+    _lr_cache: tuple | None = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def _validate_names(self) -> "LongRunRestriction":
+        """Reject empty/duplicated orderings and unusable shock labels."""
+        if not self.ordering:
+            raise ValueError("ordering must name at least one variable")
+        if len(set(self.ordering)) != len(self.ordering):
+            raise ValueError(f"ordering contains duplicate variable names: {self.ordering}")
+        if self.shock_names is None:
+            return self
+        if len(self.shock_names) != len(self.ordering):
+            raise ValueError(
+                f"shock_names and ordering must have the same length; got "
+                f"{len(self.shock_names)} shock names for {len(self.ordering)} variables."
+            )
+        if len(set(self.shock_names)) != len(self.shock_names):
+            raise ValueError(f"shock_names contains duplicate names: {self.shock_names}")
+        reserved = [s for s in self.shock_names if s.startswith("unidentified_")]
+        if reserved:
+            raise ValueError(
+                f"Shock names may not start with the reserved prefix 'unidentified_' (got {reserved}). "
+                "Downstream guards read that prefix to mask rotation-arbitrary columns, so such a "
+                "name would silently hide an identified shock from FEVD and historical decomposition."
+            )
+        return self
+
+    @classmethod
+    def from_zero_restrictions(
+        cls,
+        restrictions: dict[str, list[str]],
+        var_names: list[str],
+        shock_names: list[str],
+        **kwargs,
+    ) -> "LongRunRestriction":
+        """Build the scheme from named long-run zeros instead of an ordering.
+
+        Each entry maps a variable to the shocks that must have *no*
+        long-run effect on it. The pattern must be triangular under some
+        ordering of the variables — that is what a recursive long-run
+        scheme means — and this constructor recovers that ordering.
+
+        Args:
+            restrictions: Variable name -> list of shock names with zero
+                long-run effect on it. Variables with no zeros may be
+                omitted.
+            var_names: All endogenous variable names.
+            shock_names: All shock names, ordered most long-run-restricted
+                first (the shock that is zero-restricted nowhere comes
+                first, and so on).
+            **kwargs: Forwarded to the constructor (`on_undefined`,
+                `max_condition`).
+
+        Returns:
+            A `LongRunRestriction` whose `ordering` reproduces the named
+            pattern.
+
+        Raises:
+            ValueError: If a name is unknown, or the pattern is not
+                triangular under any ordering.
+        """
+        n = len(var_names)
+        if len(shock_names) != n:
+            raise ValueError(f"shock_names must name {n} shocks, one per variable; got {len(shock_names)}.")
+        unknown_vars = [v for v in restrictions if v not in var_names]
+        if unknown_vars:
+            raise ValueError(f"restrictions name variables absent from var_names: {unknown_vars}")
+        named = {s for shocks in restrictions.values() for s in shocks}
+        unknown_shocks = sorted(named - set(shock_names))
+        if unknown_shocks:
+            raise ValueError(f"restrictions name shocks absent from shock_names: {unknown_shocks}")
+
+        counts = {v: len(set(restrictions.get(v, []))) for v in var_names}
+        if sorted(counts.values()) != list(range(n)):
+            raise ValueError(
+                f"A recursive long-run structure needs one variable restricted by each of "
+                f"{list(range(n))} shocks; got restriction counts {counts}. Arbitrary "
+                f"(non-recursive) long-run zero patterns are not supported — see {_NONRECURSIVE_ISSUE}."
+            )
+        ordering = sorted(var_names, key=lambda v: -counts[v])
+        for i, variable in enumerate(ordering):
+            expected = set(shock_names[i + 1 :])
+            got = set(restrictions.get(variable, []))
+            if got != expected:
+                raise ValueError(
+                    f"Variable {variable!r} is restricted by {sorted(got)}, but its restriction "
+                    f"count places it at position {i} of the ordering, where a recursive structure "
+                    f"requires exactly {sorted(expected)}. Only recursive (triangular) long-run "
+                    f"patterns are supported — see {_NONRECURSIVE_ISSUE}."
+                )
+        return cls(ordering=ordering, shock_names=list(shock_names), **kwargs)
+
+    def identify(
+        self,
+        L: np.ndarray,
+        var_names: list[str],
+        posterior: "xr.Dataset | None" = None,
+        data: "VARData | None" = None,
+        n_lags: int | None = None,
+    ) -> np.ndarray:
+        """Apply long-run-restriction identification.
+
+        Args:
+            L: Lower-triangular Cholesky factor, shape (chains, draws, n_vars, n_vars).
+            var_names: Variable names in the data's natural order.
+            posterior: Full posterior; required, because the long-run
+                multiplier is built from the lag coefficients `B`.
+            data: Unused. Accepted for Protocol uniformity.
+            n_lags: Lag order. Inferred from `B`'s trailing axis if omitted.
+
+        Returns:
+            Structural shock matrix, shape (chains, draws, n_vars, n_vars).
+            Rows follow `var_names` (the data's order); columns follow
+            `shock_coords`. Draws whose long-run multiplier is numerically
+            undefined are NaN when `on_undefined="nan"`.
+
+        Raises:
+            ValueError: If `posterior` is missing or carries no `B`, if
+                `ordering` does not match `var_names`, or if
+                `on_undefined="raise"` and some draw is undefined.
+        """
+        del data  # unused
+        if posterior is None or "B" not in posterior:
+            raise ValueError(
+                "LongRunRestriction.identify requires the full posterior with 'B' (the VAR lag "
+                "coefficients): the long-run multiplier C(1) = (I - sum_j A_j)^-1 is built from "
+                "them. Pass posterior=fitted.idata.posterior to identify() — "
+                "FittedVAR.set_identification_strategy(...) supplies it automatically."
+            )
+        n_vars = L.shape[-1]
+        if n_lags is None:
+            n_lags = posterior["B"].shape[-1] // n_vars
+
+        perm = self._permutation(var_names)
+        inv = np.argsort(perm)
+        M, bad = self._screen(posterior, n_lags, n_vars)
+
+        # Work in `ordering` coordinates: permute M on both axes, and L on
+        # its rows only (L_ord L_ord' is then the permuted Sigma).
+        M_ord = M[..., perm, :][..., :, perm]
+        L_ord = L[..., perm, :]
+        # Batched solve raises for the whole batch if any slice is
+        # singular, so sanitise first and blank the offenders afterwards.
+        M_safe = np.where(bad[..., np.newaxis, np.newaxis], np.eye(n_vars), M_ord)
+
+        K = np.linalg.solve(M_safe, L_ord)  # C(1) L, in ordering coords
+        Q, R = np.linalg.qr(np.swapaxes(K, -1, -2))
+        # numpy does not guarantee diag(R) > 0; fixing the signs pins the
+        # sign convention (positive diagonal of Theta(1)) and makes
+        # identify() deterministic.
+        signs = np.sign(np.diagonal(R, axis1=-2, axis2=-1))
+        signs = np.where(signs == 0.0, 1.0, signs)
+        P = (L_ord @ (Q * signs[..., np.newaxis, :]))[..., inv, :]
+
+        if bad.any():
+            P = np.where(bad[..., np.newaxis, np.newaxis], np.nan, P)
+        return P
+
+    def _permutation(self, var_names: list[str]) -> np.ndarray:
+        """Positions of `ordering` within `var_names`."""
+        missing = [v for v in self.ordering if v not in var_names]
+        if missing:
+            raise ValueError(f"ordering names variables absent from the data: {missing}. Data has {list(var_names)}.")
+        if len(self.ordering) != len(var_names):
+            raise ValueError(
+                f"ordering must cover every variable: got {len(self.ordering)} names "
+                f"for {len(var_names)} variables ({list(var_names)})."
+            )
+        return np.array([var_names.index(v) for v in self.ordering])
+
+    def _screen(self, posterior: "xr.Dataset", n_lags: int, n_vars: int) -> tuple[np.ndarray, np.ndarray]:
+        """Build `M = I - sum_j A_j` and flag the draws where `C(1)` is undefined.
+
+        Memoised on `(id(posterior), n_lags)` — see `_lr_cache`.
+
+        Returns:
+            Tuple `(M, bad)`: the long-run matrix, shape
+            `(chains, draws, n_vars, n_vars)`, and a boolean mask of draws
+            whose condition number exceeds `max_condition`.
+        """
+        cache_key = (id(posterior), n_lags)
+        if self._lr_cache is not None and self._lr_cache[0] == cache_key:
+            return self._lr_cache[1]
+
+        A = lag_matrices(posterior["B"].values, n_lags)
+        M = np.eye(n_vars) - np.sum(A, axis=0)
+        # cond() returns inf for a singular matrix rather than raising,
+        # which is what makes the sanitise-then-blank strategy possible.
+        condition = np.linalg.cond(M)
+        bad = ~np.isfinite(condition) | (condition > self.max_condition)
+        rho = _companion_spectral_radius(A)
+        explosive = rho > 1.0
+
+        self._last_diagnostics = {
+            "long_run_singular_draws": float(bad.sum()),
+            "long_run_singular_fraction": float(bad.mean()),
+            "long_run_condition_median": float(np.median(condition)),
+            "long_run_condition_q95": float(np.quantile(condition, 0.95)),
+            "long_run_condition_max": float(condition.max()),
+            "long_run_explosive_draws": float(explosive.sum()),
+            "long_run_explosive_fraction": float(explosive.mean()),
+            "long_run_spectral_radius_median": float(np.median(rho)),
+            "long_run_spectral_radius_max": float(rho.max()),
+        }
+        self._report(bad, explosive)
+        self._lr_cache = (cache_key, (M, bad))
+        return M, bad
+
+    def _report(self, bad: np.ndarray, explosive: np.ndarray) -> None:
+        """Warn (or raise) about undefined and explosive draws.
+
+        The two conditions are distinct. A singular `M` is an arithmetic
+        failure — `C(1)` does not exist. An explosive draw is an
+        interpretation failure — the arithmetic is fine but the cumulative
+        sum diverges, so "long-run effect" means nothing. Bayesian
+        posteriors near a unit root routinely contain explosive draws, so
+        those are reported, never blanked.
+        """
+        import warnings
+
+        total = int(bad.size)
+        n_bad = int(bad.sum())
+        if n_bad:
+            if self.on_undefined == "raise":
+                raise ValueError(
+                    f"The long-run multiplier C(1) = (I - sum_j A_j)^-1 is numerically undefined "
+                    f"for {n_bad}/{total} posterior draws (condition number above "
+                    f"max_condition={self.max_condition:g}). Pass on_undefined='nan' to blank "
+                    "those draws instead, or raise max_condition if the loss of precision is "
+                    "acceptable."
+                )
+            warnings.warn(
+                f"The long-run multiplier C(1) = (I - sum_j A_j)^-1 is numerically undefined for "
+                f"{n_bad}/{total} posterior draws (condition number above "
+                f"max_condition={self.max_condition:g}); those draws are returned as NaN. NaN "
+                "draws propagate into IRF and FEVD, and the scenario methods reject them.",
+                UserWarning,
+                stacklevel=4,
+            )
+        n_explosive = int(explosive.sum())
+        if n_explosive:
+            warnings.warn(
+                f"{n_explosive}/{total} posterior draws are explosive (companion spectral radius "
+                "above 1), so the cumulative moving-average sum does not converge and the long-run "
+                "restriction has no interpretation for them. They are still identified "
+                "arithmetically and returned finite — check long_run_diagnostics() before reading "
+                "the results.",
+                UserWarning,
+                stacklevel=4,
+            )
+
+    def long_run_diagnostics(self, posterior: "xr.Dataset", n_lags: int | None = None) -> dict[str, np.ndarray]:
+        """Per-draw conditioning and stability of the long-run multiplier.
+
+        Args:
+            posterior: Posterior Dataset carrying `B` (`fitted.idata.posterior`).
+            n_lags: Lag order. Inferred from `B`'s trailing axis if omitted.
+
+        Returns:
+            Dict with `"condition"` — the condition number of
+            `M = I - sum_j A_j`, shape `(chains, draws)` — and
+            `"spectral_radius"`, the companion spectral radius, same shape.
+            A large condition number means `C(1)` is barely defined; a
+            spectral radius above one means the long-run sum diverges.
+        """
+        n_vars = posterior["B"].shape[-2]
+        if n_lags is None:
+            n_lags = posterior["B"].shape[-1] // n_vars
+        A = lag_matrices(posterior["B"].values, n_lags)
+        M = np.eye(n_vars) - np.sum(A, axis=0)
+        return {
+            "condition": np.linalg.cond(M),
+            "spectral_radius": _companion_spectral_radius(A),
+        }
+
+    def shock_coords(self, n_vars: int) -> list[str]:
+        """Explicit shock names if given, otherwise the ordering."""
+        del n_vars  # ordering already has the right length
+        return list(self.shock_names or self.ordering)
 
 
 class ProxySVAR(ImpulsoBaseModel):

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -528,16 +528,18 @@ class LongRunRestriction(ImpulsoModel):
             raise ValueError("ordering must name at least one variable")
         if len(set(self.ordering)) != len(self.ordering):
             raise ValueError(f"ordering contains duplicate variable names: {self.ordering}")
-        if self.shock_names is None:
-            return self
-        if len(self.shock_names) != len(self.ordering):
-            raise ValueError(
-                f"shock_names and ordering must have the same length; got "
-                f"{len(self.shock_names)} shock names for {len(self.ordering)} variables."
-            )
-        if len(set(self.shock_names)) != len(self.shock_names):
-            raise ValueError(f"shock_names contains duplicate names: {self.shock_names}")
-        reserved = [s for s in self.shock_names if s.startswith("unidentified_")]
+        if self.shock_names is not None:
+            if len(self.shock_names) != len(self.ordering):
+                raise ValueError(
+                    f"shock_names and ordering must have the same length; got "
+                    f"{len(self.shock_names)} shock names for {len(self.ordering)} variables."
+                )
+            if len(set(self.shock_names)) != len(self.shock_names):
+                raise ValueError(f"shock_names contains duplicate names: {self.shock_names}")
+        # Check the EFFECTIVE labels: with shock_names=None, shock_coords falls
+        # back to the ordering, so a variable named unidentified_* would leak
+        # the reserved prefix into the shock labels through that path too.
+        reserved = [s for s in (self.shock_names or self.ordering) if s.startswith("unidentified_")]
         if reserved:
             raise ValueError(
                 f"Shock names may not start with the reserved prefix 'unidentified_' (got {reserved}). "

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -307,6 +307,21 @@ class IdentifiedVAR(ImpulsoBaseModel):
             )
         return fevd_arr
 
+    @staticmethod
+    def _shares(mse_cum: np.ndarray, total: np.ndarray) -> np.ndarray:
+        """Normalise cumulative MSE contributions into variance shares.
+
+        The zero-total guard exists for the degenerate horizon-0 case; it
+        must not swallow *undefined* draws. `NaN > 0` is `False`, so a
+        plain `np.where(total > 0, ...)` would report a NaN draw as a
+        clean 0.0 share — indistinguishable from "this shock explains
+        nothing". Schemes can legitimately return NaN draws
+        (`LongRunRestriction` blanks draws whose long-run multiplier is
+        numerically undefined), so NaN is re-imposed after the guard.
+        """
+        shares = np.where(total > 0, mse_cum / total, 0.0)
+        return np.where(np.isnan(total), np.nan, shares)
+
     def fevd(self, horizon: int = 20, at: AtParam = None) -> FEVDResult:
         """Compute forecast error variance decomposition.
 
@@ -339,7 +354,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
             Theta = Phi_arr[:, :, np.newaxis, :, :, :] @ P.values[:, :, :, np.newaxis, :, :]
             mse_cum = np.cumsum(Theta**2, axis=3)
             total = mse_cum.sum(axis=-1, keepdims=True)
-            fevd_arr = np.where(total > 0, mse_cum / total, 0.0)
+            fevd_arr = self._shares(mse_cum, total)
             fevd_arr = self._fevd_guard(fevd_arr)
             fevd_da = xr.DataArray(
                 fevd_arr,
@@ -356,7 +371,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
             Theta = Phi_arr @ P.values[:, :, np.newaxis, :, :]
             mse_cum = np.cumsum(Theta**2, axis=2)
             total = mse_cum.sum(axis=-1, keepdims=True)
-            fevd_arr = np.where(total > 0, mse_cum / total, 0.0)
+            fevd_arr = self._shares(mse_cum, total)
             fevd_arr = self._fevd_guard(fevd_arr)
             fevd_da = xr.DataArray(
                 fevd_arr,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,67 @@ def synthetic_idata_2v_t(synthetic_idata_2v):
     return az.InferenceData(posterior=posterior)
 
 
+@pytest.fixture
+def permanent_transitory_2v():
+    """Exact-arithmetic 2-var VAR(1) with a known long-run structure.
+
+    Built backwards from the answer so the long-run identification has a
+    closed form to be checked against:
+
+        A_1 = [[0.5, 0.1], [0.2, 0.4]]   (eigenvalues 0.6, 0.3 — stable)
+        M   = I - A_1                    (det 0.28)
+        C1  = M^-1                       (long-run multiplier)
+        G   = [[1.0, 0.0], [0.5, 0.8]]   (imposed cumulative impact, G[0, 1] = 0)
+        P   = M @ G = [[0.45, -0.08], [0.10, 0.48]]
+        Sigma = P @ P.T
+
+    `P` is deliberately not lower-triangular, so it is distinguishable
+    from the Cholesky factor of Sigma.
+
+    Returns:
+        Dict with keys `A1`, `M`, `C1`, `G`, `P_true`, `Sigma`, `L`
+        (Cholesky factor of Sigma) and `idata` — an InferenceData with 2
+        chains x 50 draws whose draws all equal the truth, laid out like
+        `synthetic_idata_2v`.
+    """
+    n_chains, n_draws, n_vars = 2, 50, 2
+
+    A1 = np.array([[0.5, 0.1], [0.2, 0.4]])
+    M = np.eye(n_vars) - A1
+    C1 = np.linalg.inv(M)
+    G = np.array([[1.0, 0.0], [0.5, 0.8]])
+    P_true = M @ G
+    Sigma = P_true @ P_true.T
+    L = np.linalg.cholesky(Sigma)
+
+    shape = (n_chains, n_draws, n_vars, n_vars)
+    B = np.broadcast_to(A1, shape).copy()
+    intercept = np.zeros((n_chains, n_draws, n_vars))
+    sigma_draws = np.broadcast_to(Sigma, shape).copy()
+    L_draws = np.broadcast_to(L, shape).copy()
+
+    posterior = xr.Dataset({
+        "B": xr.DataArray(B, dims=["chain", "draw", "var", "coeff"]),
+        "intercept": xr.DataArray(intercept, dims=["chain", "draw", "var"]),
+        "Sigma": xr.DataArray(
+            sigma_draws,
+            dims=["chain", "draw", "var1", "var2"],
+            coords={"var1": ["y1", "y2"], "var2": ["y1", "y2"]},
+        ),
+        "L": xr.DataArray(L_draws, dims=["chain", "draw", "var1", "var2"]),
+    })
+    return {
+        "A1": A1,
+        "M": M,
+        "C1": C1,
+        "G": G,
+        "P_true": P_true,
+        "Sigma": Sigma,
+        "L": L_draws,
+        "idata": az.InferenceData(posterior=posterior),
+    }
+
+
 # --------------- SV fixtures ---------------
 
 

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -810,3 +810,66 @@ class TestLongRunRestrictionRecovery:
         )
         P_median = np.median(identified.shock_matrix().values, axis=(0, 1))
         np.testing.assert_allclose(P_median, P_true, atol=0.05)
+
+
+class TestLongRunRestrictionMultipleLags:
+    """The long-run multiplier sums *every* lag block, and the companion grows with p."""
+
+    @staticmethod
+    def _var2_posterior() -> tuple:
+        import xarray as xr
+
+        A1 = np.array([[0.4, 0.1], [0.1, 0.3]])
+        A2 = np.array([[0.2, 0.0], [0.05, 0.1]])
+        M = np.eye(2) - A1 - A2
+        G = np.array([[1.0, 0.0], [0.5, 0.8]])
+        P_true = M @ G
+        L = np.linalg.cholesky(P_true @ P_true.T)
+
+        B = np.broadcast_to(np.concatenate([A1, A2], axis=1), (1, 4, 2, 4)).copy()
+        posterior = xr.Dataset({"B": xr.DataArray(B, dims=["chain", "draw", "var", "coeff"])})
+        return posterior, np.broadcast_to(L, (1, 4, 2, 2)).copy(), P_true, G
+
+    def test_identify_with_two_lags(self):
+        posterior, L, P_true, _ = self._var2_posterior()
+        scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+        P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=2)
+        np.testing.assert_allclose(P, np.broadcast_to(P_true, P.shape), atol=1e-12)
+
+    def test_n_lags_is_inferred_from_b(self):
+        """B's trailing axis is n_vars * n_lags, so p need not be passed."""
+        posterior, L, P_true, _ = self._var2_posterior()
+        scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+        P = scheme.identify(L, ["y1", "y2"], posterior=posterior)
+        np.testing.assert_allclose(P, np.broadcast_to(P_true, P.shape), atol=1e-12)
+
+    def test_cumulative_ma_sum_matches_the_imposed_long_run(self):
+        """Brute-force sum of 400 MA coefficients must reproduce G — pins the lag handling."""
+        from impulso._ma import compute_ma_phi
+
+        posterior, L, _, G = self._var2_posterior()
+        scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+        P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=2)
+
+        A = [posterior["B"].values[0, 0][:, :2], posterior["B"].values[0, 0][:, 2:]]
+        cumulative = compute_ma_phi(A, 400).sum(axis=0)
+        np.testing.assert_allclose(cumulative @ P[0, 0], G, atol=1e-10)
+
+    def test_companion_spectral_radius_uses_every_lag_block(self):
+        posterior, _, _, _ = self._var2_posterior()
+        scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+        rho = scheme.long_run_diagnostics(posterior)["spectral_radius"]
+
+        A1 = np.array([[0.4, 0.1], [0.1, 0.3]])
+        A2 = np.array([[0.2, 0.0], [0.05, 0.1]])
+        companion = np.zeros((4, 4))
+        companion[:2] = np.concatenate([A1, A2], axis=1)
+        companion[2, 0] = companion[3, 1] = 1.0
+        np.testing.assert_allclose(rho, np.abs(np.linalg.eigvals(companion)).max(), rtol=1e-12)
+
+    def test_partial_ordering_is_rejected(self):
+        """`ordering` must cover every variable — a short one is silently wrong otherwise."""
+        posterior, L, _, _ = self._var2_posterior()
+        scheme = LongRunRestriction(ordering=["y1"], shock_names=["permanent"])
+        with pytest.raises(ValueError, match="cover every variable"):
+            scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=2)

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -720,6 +720,21 @@ class TestLongRunRestriction:
             warnings.simplefilter("error")
             scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
 
+    def test_screen_cache_misses_once_the_posterior_is_collected(self, permanent_transitory_2v):
+        """A collected posterior's address can be recycled, so a dead referent
+        must read as a miss rather than serving another posterior's screen (#203)."""
+        fx = permanent_transitory_2v
+        scheme = self._scheme()
+        posterior = self._posterior_with(fx, lambda c, d: None)
+        scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        ref = weakref.ref(posterior)
+
+        del posterior
+        gc.collect()
+        assert ref() is None
+
+        assert scheme._lr_cache.get(self._posterior_with(fx, lambda c, d: None), (1,)) is _CACHE_MISS
+
     # --- 17-19. from_zero_restrictions -------------------------------------
 
     def test_from_zero_restrictions_recovers_the_ordering(self, permanent_transitory_2v):

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -714,3 +714,99 @@ class TestLongRunRestriction:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+
+    # --- 17-19. from_zero_restrictions -------------------------------------
+
+    def test_from_zero_restrictions_recovers_the_ordering(self, permanent_transitory_2v):
+        fx = permanent_transitory_2v
+        scheme = LongRunRestriction.from_zero_restrictions(
+            restrictions={"y1": ["transitory"]},
+            var_names=["y1", "y2"],
+            shock_names=["permanent", "transitory"],
+        )
+        assert scheme.ordering == ["y1", "y2"]
+        assert scheme.shock_names == ["permanent", "transitory"]
+        np.testing.assert_array_equal(self._identify(scheme, fx), self._identify(self._scheme(), fx))
+
+    def test_from_zero_restrictions_forwards_kwargs(self):
+        scheme = LongRunRestriction.from_zero_restrictions(
+            restrictions={"y1": ["transitory"]},
+            var_names=["y1", "y2"],
+            shock_names=["permanent", "transitory"],
+            on_undefined="raise",
+            max_condition=1e6,
+        )
+        assert scheme.on_undefined == "raise"
+        assert scheme.max_condition == 1e6
+
+    def test_from_zero_restrictions_rejects_non_recursive_patterns(self):
+        """Counts (1, 1, 0) are not a permutation of (0, 1, 2) — no ordering makes this triangular."""
+        with pytest.raises(ValueError, match="recursive"):
+            LongRunRestriction.from_zero_restrictions(
+                restrictions={"a": ["s2"], "b": ["s3"]},
+                var_names=["a", "b", "c"],
+                shock_names=["s1", "s2", "s3"],
+            )
+
+    def test_from_zero_restrictions_names_the_offending_variable(self):
+        """Counts are a valid permutation, but the restricted shocks are the wrong ones."""
+        with pytest.raises(ValueError, match="'b'"):
+            LongRunRestriction.from_zero_restrictions(
+                restrictions={"a": ["s2", "s3"], "b": ["s2"]},
+                var_names=["a", "b", "c"],
+                shock_names=["s1", "s2", "s3"],
+            )
+
+    def test_from_zero_restrictions_rejects_unknown_names(self):
+        with pytest.raises(ValueError, match="var_names"):
+            LongRunRestriction.from_zero_restrictions(
+                restrictions={"nope": ["transitory"]},
+                var_names=["y1", "y2"],
+                shock_names=["permanent", "transitory"],
+            )
+        with pytest.raises(ValueError, match="shock_names"):
+            LongRunRestriction.from_zero_restrictions(
+                restrictions={"y1": ["nope"]},
+                var_names=["y1", "y2"],
+                shock_names=["permanent", "transitory"],
+            )
+
+    def test_from_zero_restrictions_requires_one_shock_per_variable(self):
+        with pytest.raises(ValueError, match="one per variable"):
+            LongRunRestriction.from_zero_restrictions(
+                restrictions={"y1": ["transitory"]},
+                var_names=["y1", "y2"],
+                shock_names=["permanent"],
+            )
+
+
+class TestLongRunRestrictionRecovery:
+    """End-to-end: does the scheme recover a known long-run structure from data?"""
+
+    def test_recovers_p_true_from_simulated_data(self):
+        import pandas as pd
+
+        from impulso.conjugate import ConjugateVAR
+        from impulso.data import VARData
+        from impulso.priors import NIWPrior
+
+        A1 = np.array([[0.5, 0.1], [0.2, 0.4]])
+        P_true = (np.eye(2) - A1) @ np.array([[1.0, 0.0], [0.5, 0.8]])
+
+        rng = np.random.default_rng(0)
+        T = 2000
+        y = np.zeros((T, 2))
+        for t in range(1, T):
+            y[t] = A1 @ y[t - 1] + P_true @ rng.standard_normal(2)
+        data = VARData(
+            endog=y,
+            endog_names=["y1", "y2"],
+            index=pd.date_range("1900-01-01", periods=T, freq="QS"),
+        )
+
+        fitted = ConjugateVAR(lags=1, prior=NIWPrior(), draws=200, seed=0).fit(data)
+        identified = fitted.set_identification_strategy(
+            LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+        )
+        P_median = np.median(identified.shock_matrix().values, axis=(0, 1))
+        np.testing.assert_allclose(P_median, P_true, atol=0.05)

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -1,6 +1,7 @@
 """Tests for identification schemes."""
 
 import gc
+import warnings
 import weakref
 
 import numpy as np
@@ -8,7 +9,7 @@ import pytest
 import xarray as xr
 from pydantic import ValidationError
 
-from impulso.identification import _CACHE_MISS, Cholesky, SignRestriction, _PosteriorCache
+from impulso.identification import _CACHE_MISS, Cholesky, LongRunRestriction, SignRestriction, _PosteriorCache
 from impulso.protocols import IdentificationScheme
 
 
@@ -474,3 +475,242 @@ class TestPosteriorCache:
         cache.set(owner, (1,), "value")
         cache.clear()
         assert cache.get(owner, (1,)) is _CACHE_MISS
+
+
+class TestLongRunRestriction:
+    """Blanchard-Quah style long-run (cumulative) zero restrictions."""
+
+    @staticmethod
+    def _scheme(**kwargs) -> LongRunRestriction:
+        kwargs.setdefault("ordering", ["y1", "y2"])
+        kwargs.setdefault("shock_names", ["permanent", "transitory"])
+        return LongRunRestriction(**kwargs)
+
+    @staticmethod
+    def _identify(scheme: LongRunRestriction, fx: dict, var_names=("y1", "y2")) -> np.ndarray:
+        return scheme.identify(fx["L"], list(var_names), posterior=fx["idata"].posterior, n_lags=1)
+
+    # --- 1. exact recovery -------------------------------------------------
+
+    def test_identify_recovers_the_true_impact_matrix(self, permanent_transitory_2v):
+        """P is built backwards from a known G, so identify must return it exactly."""
+        P = self._identify(self._scheme(), permanent_transitory_2v)
+        assert P.shape == (2, 50, 2, 2)
+        np.testing.assert_allclose(P, np.broadcast_to(permanent_transitory_2v["P_true"], P.shape), atol=1e-12)
+
+    # --- 2. the restriction actually binds ---------------------------------
+
+    def test_cumulative_impact_is_lower_triangular_with_positive_diagonal(self, permanent_transitory_2v):
+        fx = permanent_transitory_2v
+        P = self._identify(self._scheme(), fx)
+        theta1 = fx["C1"] @ P
+        assert np.abs(np.triu(theta1, 1)).max() < 1e-10
+        assert (np.diagonal(theta1, axis1=-2, axis2=-1) > 0).all()
+        np.testing.assert_allclose(theta1, np.broadcast_to(fx["G"], theta1.shape), atol=1e-12)
+
+    # --- 3. covariance is reproduced exactly -------------------------------
+
+    def test_p_reproduces_sigma(self, permanent_transitory_2v):
+        fx = permanent_transitory_2v
+        P = self._identify(self._scheme(), fx)
+        np.testing.assert_allclose(P @ np.swapaxes(P, -1, -2), np.broadcast_to(fx["Sigma"], P.shape), atol=1e-12)
+
+    # --- 4. reversed ordering keeps rows in data order ---------------------
+
+    def test_reversed_ordering_returns_rows_in_data_order(self, permanent_transitory_2v):
+        """Rows of the returned P follow the data, not `ordering` — so P @ P.T is Sigma."""
+        fx = permanent_transitory_2v
+        scheme = self._scheme(ordering=["y2", "y1"], shock_names=["permanent", "transitory"])
+        P = self._identify(scheme, fx)
+        np.testing.assert_allclose(P @ np.swapaxes(P, -1, -2), np.broadcast_to(fx["Sigma"], P.shape), atol=1e-12)
+        # Triangularity holds in the *ordering* row coordinates.
+        perm = [1, 0]
+        theta1 = (fx["C1"] @ P)[..., perm, :]
+        assert np.abs(np.triu(theta1, 1)).max() < 1e-10
+        assert (np.diagonal(theta1, axis1=-2, axis2=-1) > 0).all()
+
+    # --- 5. agrees with the textbook construction --------------------------
+
+    def test_agrees_with_textbook_cholesky_route(self, permanent_transitory_2v):
+        """QR route must match M @ chol(C1 Sigma C1')."""
+        fx = permanent_transitory_2v
+        P = self._identify(self._scheme(), fx)
+        omega = fx["C1"] @ fx["Sigma"] @ fx["C1"].T
+        P_textbook = fx["M"] @ np.linalg.cholesky(omega)
+        np.testing.assert_allclose(P[0, 0], P_textbook, atol=1e-10)
+
+    # --- 6. it is not Cholesky ---------------------------------------------
+
+    def test_differs_from_cholesky(self, permanent_transitory_2v):
+        fx = permanent_transitory_2v
+        P = self._identify(self._scheme(), fx)
+        chol = np.linalg.cholesky(fx["Sigma"])
+        assert np.abs(P[0, 0] - chol).max() > 1e-3
+
+    # --- 7. determinism ----------------------------------------------------
+
+    def test_identify_is_deterministic(self, permanent_transitory_2v):
+        scheme = self._scheme()
+        first = self._identify(scheme, permanent_transitory_2v)
+        second = self._identify(scheme, permanent_transitory_2v)
+        assert np.array_equal(first, second)
+
+    # --- 8. shock labels ---------------------------------------------------
+
+    def test_shock_coords_uses_shock_names_when_given(self):
+        scheme = self._scheme()
+        assert scheme.shock_coords(n_vars=2) == ["permanent", "transitory"]
+
+    def test_shock_coords_falls_back_to_ordering(self):
+        scheme = LongRunRestriction(ordering=["y1", "y2"])
+        assert scheme.shock_coords(n_vars=2) == ["y1", "y2"]
+
+    # --- 9. protocol + immutability ----------------------------------------
+
+    def test_satisfies_protocol(self):
+        assert isinstance(self._scheme(), IdentificationScheme)
+
+    def test_frozen(self):
+        scheme = self._scheme()
+        with pytest.raises(ValidationError):
+            scheme.ordering = ["y2", "y1"]
+
+    # --- 10. posterior is mandatory ----------------------------------------
+
+    def test_identify_without_posterior_raises(self, permanent_transitory_2v):
+        with pytest.raises(ValueError, match="LongRunRestriction"):
+            self._scheme().identify(permanent_transitory_2v["L"], ["y1", "y2"], posterior=None)
+
+    def test_identify_without_b_raises(self, permanent_transitory_2v):
+        import xarray as xr
+
+        posterior = xr.Dataset({"intercept": permanent_transitory_2v["idata"].posterior["intercept"]})
+        with pytest.raises(ValueError, match="LongRunRestriction"):
+            self._scheme().identify(permanent_transitory_2v["L"], ["y1", "y2"], posterior=posterior)
+
+    # --- 11. unknown ordering entry ----------------------------------------
+
+    def test_unknown_ordering_variable_raises(self, permanent_transitory_2v):
+        scheme = self._scheme(ordering=["y1", "nope"])
+        with pytest.raises(ValueError, match="nope"):
+            self._identify(scheme, permanent_transitory_2v)
+
+    # --- 12. construction-time validation ----------------------------------
+
+    def test_duplicate_ordering_rejected(self):
+        with pytest.raises(ValidationError, match="duplicate"):
+            LongRunRestriction(ordering=["y1", "y1"])
+
+    def test_empty_ordering_rejected(self):
+        with pytest.raises(ValidationError):
+            LongRunRestriction(ordering=[])
+
+    def test_shock_names_length_mismatch_rejected(self):
+        with pytest.raises(ValidationError, match="same length"):
+            LongRunRestriction(ordering=["y1", "y2"], shock_names=["only_one"])
+
+    def test_duplicate_shock_names_rejected(self):
+        with pytest.raises(ValidationError, match="duplicate"):
+            LongRunRestriction(ordering=["y1", "y2"], shock_names=["s", "s"])
+
+    def test_reserved_shock_name_prefix_rejected(self):
+        with pytest.raises(ValidationError, match="unidentified_"):
+            LongRunRestriction(ordering=["y1", "y2"], shock_names=["unidentified_1", "transitory"])
+
+    # --- 13. numerically singular draws ------------------------------------
+
+    @staticmethod
+    def _posterior_with(fx: dict, A_by_draw) -> "object":
+        """Copy the fixture posterior with `A_by_draw(c, d)` substituted for B."""
+        posterior = fx["idata"].posterior.copy(deep=True)
+        B = posterior["B"].values.copy()
+        for c in range(B.shape[0]):
+            for d in range(B.shape[1]):
+                replacement = A_by_draw(c, d)
+                if replacement is not None:
+                    B[c, d] = replacement
+        posterior["B"] = (("chain", "draw", "var", "coeff"), B)
+        return posterior
+
+    def test_singular_draws_are_nan_and_counted(self, permanent_transitory_2v):
+        """M = I - A_1 = 0 for the doctored draws: those alone come back NaN."""
+        fx = permanent_transitory_2v
+        posterior = self._posterior_with(fx, lambda c, d: np.eye(2) if (c == 0 and d < 5) else None)
+        scheme = self._scheme()
+        with pytest.warns(UserWarning, match="long-run multiplier"):
+            P = scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        assert np.isnan(P[0, :5]).all()
+        assert not np.isnan(P[0, 5:]).any()
+        assert not np.isnan(P[1]).any()
+        np.testing.assert_allclose(P[0, 5:], np.broadcast_to(fx["P_true"], P[0, 5:].shape), atol=1e-12)
+        assert scheme._last_diagnostics["long_run_singular_draws"] == 5.0
+        assert scheme._last_diagnostics["long_run_singular_fraction"] == pytest.approx(0.05)
+
+    def test_singular_draws_raise_when_asked(self, permanent_transitory_2v):
+        fx = permanent_transitory_2v
+        posterior = self._posterior_with(fx, lambda c, d: np.eye(2) if (c == 0 and d < 5) else None)
+        scheme = self._scheme(on_undefined="raise")
+        with pytest.raises(ValueError, match="5"):
+            scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+
+    # --- 14. the max_condition threshold is consulted ----------------------
+
+    def test_near_singular_draws_respect_max_condition(self, permanent_transitory_2v):
+        """A_1 = diag(1 - 1e-9, 0) gives cond(M) ~ 1e9 — caught at 1e8, allowed at 1e20."""
+        fx = permanent_transitory_2v
+        doctored = np.diag([1.0 - 1e-9, 0.0])
+        posterior = self._posterior_with(fx, lambda c, d: doctored if (c == 0 and d < 3) else None)
+
+        strict = self._scheme()
+        with pytest.warns(UserWarning, match="long-run multiplier"):
+            P_strict = strict.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        assert np.isnan(P_strict[0, :3]).all()
+        assert strict._last_diagnostics["long_run_singular_draws"] == 3.0
+
+        lenient = self._scheme(max_condition=1e20)
+        P_lenient = lenient.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        assert not np.isnan(P_lenient).any()
+        assert lenient._last_diagnostics["long_run_singular_draws"] == 0.0
+
+    # --- 15. explosive is not singular -------------------------------------
+
+    def test_explosive_draws_warn_but_stay_finite(self, permanent_transitory_2v):
+        """A_1 = 1.5 I: M = -0.5 I is perfectly conditioned, but the MA sum diverges."""
+        fx = permanent_transitory_2v
+        posterior = self._posterior_with(fx, lambda c, d: 1.5 * np.eye(2) if (c == 1 and d < 4) else None)
+        scheme = self._scheme()
+        with pytest.warns(UserWarning, match="explosive"):
+            P = scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        assert np.isfinite(P).all()
+        assert scheme._last_diagnostics["long_run_explosive_draws"] == 4.0
+        assert scheme._last_diagnostics["long_run_singular_draws"] == 0.0
+        assert scheme._last_diagnostics["long_run_spectral_radius_max"] == pytest.approx(1.5)
+
+    # --- 16. the diagnostics query -----------------------------------------
+
+    def test_long_run_diagnostics(self, permanent_transitory_2v):
+        fx = permanent_transitory_2v
+        diagnostics = self._scheme().long_run_diagnostics(fx["idata"].posterior, n_lags=1)
+        assert diagnostics["condition"].shape == (2, 50)
+        assert diagnostics["spectral_radius"].shape == (2, 50)
+        np.testing.assert_allclose(diagnostics["spectral_radius"], 0.6, atol=1e-10)
+        np.testing.assert_allclose(diagnostics["condition"], np.linalg.cond(fx["M"]), rtol=1e-10)
+
+    def test_long_run_diagnostics_infers_n_lags(self, permanent_transitory_2v):
+        diagnostics = self._scheme().long_run_diagnostics(permanent_transitory_2v["idata"].posterior)
+        assert diagnostics["condition"].shape == (2, 50)
+
+    # --- screen memoisation ------------------------------------------------
+
+    def test_screen_is_memoised_per_posterior(self, permanent_transitory_2v):
+        """The per-t (SV) path calls identify repeatedly; the screen must not re-warn."""
+        fx = permanent_transitory_2v
+        posterior = self._posterior_with(fx, lambda c, d: np.eye(2) if (c == 0 and d < 5) else None)
+        scheme = self._scheme()
+        with pytest.warns(UserWarning, match="long-run multiplier"):
+            scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -617,6 +617,11 @@ class TestLongRunRestriction:
         with pytest.raises(ValidationError, match="unidentified_"):
             LongRunRestriction(ordering=["y1", "y2"], shock_names=["unidentified_1", "transitory"])
 
+    def test_reserved_prefix_rejected_through_ordering_fallback(self):
+        """With shock_names=None the ordering becomes the shock labels, so the guard must fire there too."""
+        with pytest.raises(ValidationError, match="unidentified_"):
+            LongRunRestriction(ordering=["unidentified_x", "y2"])
+
     # --- 13. numerically singular draws ------------------------------------
 
     @staticmethod

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -1,5 +1,7 @@
 """Tests for IdentifiedVAR."""
 
+import warnings
+
 import arviz as az
 import numpy as np
 import pytest
@@ -575,3 +577,118 @@ class TestFEVDIsInvariantToTheErrorLaw:
         from impulso.observation import Gaussian
 
         assert isinstance(identified_cholesky.error_dist, Gaussian)
+
+
+@pytest.fixture
+def identified_long_run(permanent_transitory_2v, var_data_2v):
+    """IdentifiedVAR over the exact-arithmetic long-run fixture."""
+    from impulso.identification import LongRunRestriction
+    from impulso.volatility import Constant
+
+    fitted = FittedVAR(
+        idata=permanent_transitory_2v["idata"],
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+    return fitted.set_identification_strategy(scheme)
+
+
+def _identified_with_singular_draws(permanent_transitory_2v, var_data_2v, n_bad: int = 5):
+    """Same pipeline, but the first `n_bad` draws of chain 0 have M = 0."""
+    from impulso.identification import LongRunRestriction
+    from impulso.volatility import Constant
+
+    idata = permanent_transitory_2v["idata"].copy()
+    B = idata.posterior["B"].values.copy()
+    B[0, :n_bad] = np.eye(2)
+    idata.posterior["B"] = (("chain", "draw", "var", "coeff"), B)
+
+    fitted = FittedVAR(
+        idata=idata,
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+    return fitted.set_identification_strategy(scheme)
+
+
+class TestLongRunRestrictionPipeline:
+    """LongRunRestriction through the FittedVAR -> IdentifiedVAR pipeline."""
+
+    # --- 20. shock matrix labelling and diagnostics ------------------------
+
+    def test_shock_matrix_labels_and_attrs(self, identified_long_run, permanent_transitory_2v):
+        P = identified_long_run.shock_matrix()
+        assert P.dims == ("chain", "draw", "response", "shock")
+        assert list(P.coords["response"].values) == ["y1", "y2"]
+        assert list(P.coords["shock"].values) == ["permanent", "transitory"]
+        np.testing.assert_allclose(P.values, np.broadcast_to(permanent_transitory_2v["P_true"], P.shape), atol=1e-12)
+        assert P.attrs["long_run_singular_draws"] == 0.0
+        assert P.attrs["long_run_explosive_draws"] == 0.0
+        assert "sign_restriction_acceptance_rate" not in P.attrs
+
+    # --- 21. the headline: cumulative IRF converges to Theta(1) ------------
+
+    def test_cumulative_irf_converges_to_the_imposed_long_run_matrix(
+        self, identified_long_run, permanent_transitory_2v
+    ):
+        """Sum of IRFs over horizons is C(1) P — computed here by brute force."""
+        irf = identified_long_run.impulse_response(horizon=200)
+        cumulative = np.cumsum(irf.idata.posterior_predictive["irf"].values, axis=2)
+        long_run = cumulative[:, :, -1, :, :]
+
+        G = permanent_transitory_2v["G"]
+        np.testing.assert_allclose(long_run, np.broadcast_to(G, long_run.shape), atol=1e-8)
+        # The restriction: the transitory shock has no permanent effect on y1.
+        assert np.abs(long_run[..., 0, 1]).max() < 1e-10
+        np.testing.assert_allclose(long_run[..., 0, 0], 1.0, atol=1e-8)
+
+    # --- 22. FEVD is well-behaved ------------------------------------------
+
+    def test_fevd_shares_sum_to_one_without_warning(self, identified_long_run):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            fevd = identified_long_run.fevd(horizon=10)
+        shares = fevd.idata.posterior_predictive["fevd"].values
+        np.testing.assert_allclose(shares.sum(axis=-1), 1.0, atol=1e-10)
+
+    # --- 23. undefined draws stay undefined through FEVD -------------------
+
+    def test_fevd_propagates_nan_draws(self, permanent_transitory_2v, var_data_2v):
+        identified = _identified_with_singular_draws(permanent_transitory_2v, var_data_2v)
+        with pytest.warns(UserWarning, match="long-run multiplier"):
+            fevd = identified.fevd(horizon=5)
+        shares = fevd.idata.posterior_predictive["fevd"].values
+
+        assert np.isnan(shares[0, :5]).all()
+        assert not np.isnan(shares[0, 5:]).any()
+        good = np.concatenate([shares[0, 5:], shares[1]], axis=0)
+        np.testing.assert_allclose(good.sum(axis=-1), 1.0, atol=1e-10)
+
+    # --- 24. historical decomposition stays additive ------------------------
+
+    def test_historical_decomposition_is_additive(self, identified_long_run, var_data_2v):
+        hd = identified_long_run.historical_decomposition()
+        contributions = hd.idata.posterior_predictive["hd"].values
+        baseline = hd.idata.posterior_predictive["baseline"].values
+
+        assert list(hd.idata.posterior_predictive["hd"].coords["shock"].values) == ["permanent", "transitory"]
+        reconstructed = contributions.sum(axis=-1) + baseline
+        expected = var_data_2v.endog[1:]
+        np.testing.assert_allclose(reconstructed, np.broadcast_to(expected, reconstructed.shape), atol=1e-8)
+
+    # --- 25. undefined draws do not crash the decomposition ----------------
+
+    def test_historical_decomposition_survives_nan_draws(self, permanent_transitory_2v, var_data_2v):
+        identified = _identified_with_singular_draws(permanent_transitory_2v, var_data_2v)
+        with pytest.warns(UserWarning, match="long-run multiplier"):
+            hd = identified.historical_decomposition()
+        contributions = hd.idata.posterior_predictive["hd"].values
+
+        assert np.isnan(contributions[0, :5]).all()
+        assert not np.isnan(contributions[0, 5:]).any()

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -184,3 +184,16 @@ class TestErrorDistributionPublicAPI:
         import impulso
 
         assert {"Gaussian", "StudentT", "ErrorDistribution"} <= set(impulso.__all__)
+
+
+class TestIdentificationPublicAPI:
+    def test_long_run_restriction_importable_from_impulso(self):
+        from impulso import LongRunRestriction
+        from impulso.identification import LongRunRestriction as Direct
+
+        assert LongRunRestriction is Direct
+
+    def test_long_run_restriction_in_all(self):
+        import impulso
+
+        assert "LongRunRestriction" in impulso.__all__


### PR DESCRIPTION
## Summary

New **`LongRunRestriction`** identification scheme: named zero restrictions on the cumulative MA impact matrix `Θ(1) = C(1)P` — the Blanchard-Quah construction — flowing through the standard `IdentifiedVAR` pipeline (IRF/FEVD/HD).

- **Construction**: implemented via the numerically superior QR route (`K = C(1)L`, `K' = Q̃R̃` sign-fixed, `P = LQ̃`) rather than the textbook `M·chol(C(1)ΣC(1)')` — `PP' = Σ` holds *exactly* (P is an orthogonal rotation of the Cholesky factor) and the long-run covariance's condition number is never squared. Both routes are asserted to agree in tests. Sign convention: positive diagonal of `Θ(1)`.
- **Scope**: recursive/triangular patterns (exactly solvable). `from_zero_restrictions({"y1": ["transitory"]}, ...)` accepts a named zero pattern, validates it is triangular under some ordering, and rejects non-recursive patterns with a clear pointer to the combined zero-and-sign machinery planned in #144.
- **Singular ≠ explosive, handled separately** per the issue's requirement: draws where `cond(I − ΣAⱼ)` exceeds `max_condition` are NaN'd (or raise, via `on_undefined="raise"`) with counts in the diagnostics; explosive draws (spectral radius > 1) are *kept* — the arithmetic is fine, the long-run interpretation isn't — and warned about. Diagnostics ride `shock_matrix().attrs` and a public `long_run_diagnostics()`.
- **In-scope pipeline fix**: `IdentifiedVAR.fevd`'s zero-total guard silently converted NaN draws into exactly-0.0 variance shares; NaN draws now stay NaN (behaviour-preserving for finite inputs — full suite count unchanged).
- Docs: explanation section (Θ(0)-vs-Θ(1) framing, the blunt differencing requirement, the n(n−1)/2 restriction count), a how-to with a climate example (forced vs internal-variability shocks), reference entries (including the previously missing `ProxySVAR` listing), CONTEXT.md terms, Blanchard-Quah bib entry.

**Convention note for reviewers**: `identify()` returns rows in *data* order, which is what `IdentifiedVAR` labels against. `Cholesky` currently returns rows in *ordering* order under a non-identity ordering — a pre-existing mislabelling bug discovered during planning, deliberately not fixed here and filed separately.

Closes #143

## Review

Planned with the algebra verified numerically before design; independently reviewed with the QR construction re-derived symbolically and brute-forced over 200 random systems with random permutations (200/200 exact). Two plan errors were caught and corrected during implementation (a scale-invariant condition-number test that could never fire, and a mis-stated permutation identity — the reviewer confirmed the corrected forms). One P2 (reserved-prefix guard bypassed via the `shock_names=None` fallback) fixed in a follow-up commit.

## Tests

+40 tests: exact-arithmetic permanent/transitory fixture (`P_true` deliberately non-triangular so the test discriminates BQ from Cholesky; recovery at `atol=1e-12`), cumulative IRF at horizon 200 converging to the imposed long-run matrix via an independent route, VAR(2) companion coverage with a brute-force 400-term MA sum, singular/near-singular/explosive draw handling, FEVD NaN propagation, HD additivity, `from_zero_restrictions` acceptance/rejection, and an end-to-end `ConjugateVAR` recovery on simulated data. `identification.py` at 99% coverage.

`ruff` / `ty` / fast suite: all green (573 passed; the only local failures are the known broken-marimo-husk nutpie import in the venv, environmental and pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV