### PR TITLE
feat(identification): max-share frequency-band identification

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,9 @@ The sum of the moving-average coefficients of a stable reduced-form VAR, `C(1) =
 **Cumulative MA impact matrix (Θ(1))**:
 The structural counterpart, `Θ(1) = C(1) P`: the total effect of each structural shock on each variable's level. Where `Cholesky` and `SignRestriction` constrain the impact matrix `Θ(0) = P`, `LongRunRestriction` constrains `Θ(1)` to be lower-triangular in a stated variable ordering, with positive diagonal (shock `j` raises variable `j`'s long-run level).
 _Avoid_: "Blanchard-Quah identification" as an API name — the scheme is named for what it restricts, not for its first users (the prose citation is fine). "Permanent shock" for anything but the first column: only the shock restricted nowhere is unambiguously permanent.
+**Max-share identification**:
+The scheme (`MaxShare`) that identifies one structural shock as the direction explaining the largest share of a nominated variable's variance over a **frequency band**. The maximiser is the leading eigenvector of the band variance form `M = ∫_B (C_i L)* (C_i L) dω` — a closed-form rotation of the Cholesky factor, not a search. Only one column is identified; the rest are the same rotation-arbitrary `unidentified_*` completion `ProxySVAR` produces.
+_Avoid_: "the business-cycle shock" as if the band named a mechanism — the band organises variance, it does not attribute cause. Radians in the API: bands are always stated in **periods of the sampling interval**, `(low_period, high_period)`, so quarterly business cycles are `band=(6, 32)`.
 
 **Volatility process**:
 The seam that owns how the structural-shock covariance Σ_t is constructed (in PyMC), evolved over time, and queried. Concrete adapters of the `VolatilityProcess` Protocol: `Constant` (homoscedastic Σ; the default) and `StochasticVolatility` (time-varying). The volatility process owns its downstream computation — forecast covariance paths, time-`t` Cholesky query, per-variable volatility paths — so the pipeline never branches on adapter type.
@@ -138,6 +141,7 @@ _Avoid_: "number of cointegrating vectors" in API surface (fine in prose); "coin
 - A **stationarity pretest** consumes `VARData` (endogenous block only), a DataFrame, or a Series, and produces a result object — never a modified dataset and never a specification. It sits *beside* the pipeline, not in it: nothing downstream of `VAR.fit()` reads its output.
 - **Integration order** feeds **cointegration rank**: the Johansen test is only meaningful for series that are individually integrated, and it is conditioned on a lag order (`k_ar_diff = p - 1`) that `select_lag_order` supplies.
 - A **ConjugateVAR** carries an **NIW prior** and optionally a **deterministic volatility break**; a **VAR** carries a **MinnesotaPrior** and a **PyMC volatility process** (`PyMCVolatilityProcess`, the `build_pymc_latent` extension of the `VolatilityProcess` query surface). Each estimator's fields accept only its compatible components, enforced by types + validators rather than a builder.
+- An **identification scheme** may additionally consume the posterior lag coefficients: **max-share identification** needs them to build the transfer function, as `SignRestriction(restriction_horizon > 0)` and `ProxySVAR` already do. `L_t` alone is the minimum, not the maximum, of what a scheme may ask for.
 
 ## Example dialogue
 

--- a/docs/explanation/identification.md
+++ b/docs/explanation/identification.md
@@ -72,3 +72,45 @@ $C(1)$ is the long-run multiplier on the levels of the variables *as modelled*. 
 Triangularity is $n(n-1)/2$ restrictions, exactly the number needed for point identification. With two variables that is the one restriction you wanted. With three it asserts three zeros at once, which is a much stronger joint claim than it looks. Arbitrary (non-recursive) long-run zero patterns are not supported.
 
 Two things can go wrong, and Impulso reports them separately. If $I - \sum_j A_j$ is close to singular, $C(1)$ is numerically undefined and those draws are blanked (or, with `on_undefined="raise"`, refused). If a draw is explosive — companion spectral radius above one — the arithmetic is fine but $\sum_h \Phi_h$ diverges, so "long-run effect" has no meaning for it; those draws are always reported and never blanked, because posteriors near a unit root routinely contain them.
+## Max-share identification
+
+Cholesky and sign restrictions both say something about the *shape* of the impact matrix. Max-share identification says nothing about shape at all. It asks a quantitative question instead: of all the directions a single structural shock could point in, which one explains the most of one variable's variance over a stated range of frequencies?
+
+Write the reduced-form transfer function as $C(\omega) = (I - \sum_j A_j e^{-i\omega j})^{-1}$. A candidate impact column is $p = Lq$, where $LL' = \Sigma$ and $q$ is a real unit vector — the free parameter is the direction $q$, one rotation of the Cholesky factor. The target variable $i$'s variance over a band $B$ attributable to that shock is then a quadratic form,
+
+$$
+q' M q, \qquad M = \int_B \bigl(C_i(\omega) L\bigr)^{*} \bigl(C_i(\omega) L\bigr)\, d\omega,
+$$ (max-share-form)
+
+with $C_i$ the target's row of $C$. The matrix $M$ is Hermitian and positive semi-definite, and for real $q$ only its real part contributes, so the maximiser of {eq}`max-share-form` is the leading eigenvector of the real symmetric matrix $\operatorname{Re}(M)$ and the share it achieves is $\lambda_{\max}/\operatorname{tr}$. Nothing is searched for and nothing is sampled: one eigendecomposition per posterior draw.
+
+```python
+from impulso.identification import MaxShare
+
+scheme = MaxShare(target="gdp", band=(6, 32))
+```
+
+### Bands are periods, not radians
+
+`band` is `(low_period, high_period)` in periods of the sampling interval, so the frequencies covered are $\omega \in [2\pi/\text{high}, 2\pi/\text{low}]$. The conventional business-cycle window is 6 to 32 quarters:
+
+| Data frequency | Business cycle | Low frequency |
+| --- | --- | --- |
+| Quarterly | `(6, 32)` | `(32, inf)` |
+| Monthly | `(18, 96)` | `(96, inf)` |
+| Annual | `(2, 8)` | `(10, inf)` |
+
+An unbounded upper period is allowed: the quadrature uses midpoints, which never land on $\omega = 0$, so `(32, inf)` picks up everything below the business-cycle band without hitting the zero frequency where the transfer function of a near-unit-root process blows up.
+
+### One shock, and only one
+
+Max-share identifies a single column. The rest of the matrix is completed orthogonally so that $PP' = \Sigma$ still holds exactly and everything downstream keeps working, but those columns are rotation-arbitrary and labelled `unidentified_*`: forecast error variance decompositions (FEVDs) mask their shares, and the historical decomposition collapses them into one remainder column. The identified column's sign is fixed so the shock raises the target variable on impact.
+
+The natural failure mode is degeneracy. If the top two eigenvalues of $\operatorname{Re}(M)$ are close, the maximiser is not a ray but a plane, and which direction in that plane comes back is up to the eigensolver rather than the data. Impulso reports $\lambda_2/\lambda_1$ as a diagnostic and warns when the posterior median exceeds 0.9.
+
+:::{admonition} Variance is not causation
+:class: warning
+A shock that explains most of output's business-cycle variance is, on the evidence, a shock that explains most of output's business-cycle variance. Calling it "the demand shock" is an interpretation the maximisation cannot supply — the scheme searches shock space, not the space of economic stories. Max-share is at its most convincing when paired with something else: sign restrictions the winner should satisfy, or an independent series it should correlate with.
+:::
+
+The scheme is due to {cite:t}`faust1998` and {cite:t}`uhlig2004`, and is most familiar today from {cite:t}`angeletosCollardDellas2020`, where the shock maximising the business-cycle variance of unemployment turns out to drive most of the rest of the cycle too.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -12,5 +12,6 @@ stationarity-testing
 climate-pitfalls
 sign-restrictions
 long-run-restrictions
+max-share
 heavy-tailed-errors
 ```

--- a/docs/how-to/max-share.md
+++ b/docs/how-to/max-share.md
@@ -1,0 +1,105 @@
+# Using Max-Share Identification
+
+Max-share identification picks out the single structural shock that explains the largest possible share of one variable's variance over a stated band of frequencies. Instead of asserting a sign or an ordering, you nominate a target variable and a band, and the shock is whatever maximises that share.
+
+## Define the target and the band
+
+```python
+from impulso.identification import MaxShare
+
+scheme = MaxShare(target="unemployment", band=(6, 32))
+```
+
+`band` is `(low_period, high_period)` in **periods of the sampling interval**, shortest first — not radians. With quarterly data, `(6, 32)` is the conventional business-cycle window of six to thirty-two quarters. The monthly analogue is `(18, 96)`. The lower bound may not go below 2, which is the Nyquist frequency; the upper bound may be `inf`.
+
+## Apply it
+
+```python
+identified = fitted.set_identification_strategy(scheme)
+irf = identified.impulse_response(horizon=40)
+```
+
+The scheme needs the posterior lag coefficients to build the transfer function; `set_identification_strategy` passes them through automatically.
+
+Only one shock is identified. The other columns are an orthogonal completion, labelled `unidentified_1`, `unidentified_2`, and so on. Impulse responses report them, since they are a valid decomposition of the residual covariance, but forecast error variance decompositions (FEVDs) mask their shares to `NaN` and the historical decomposition collapses them into a single `unidentified_remainder` column. The identified column is signed so the shock raises the target variable on impact.
+
+Rows of the shock matrix stay in the data's own variable order. There is no ordering parameter, so nothing can be silently permuted.
+
+## Read the diagnostics
+
+Identification succeeds or fails per posterior draw, so the diagnostics are posterior quantities. Summary statistics ride along on the shock matrix:
+
+```python
+P = identified.shock_matrix()
+P.attrs["max_share_share_median"]        # band variance share achieved
+P.attrs["max_share_share_q05"]
+P.attrs["max_share_eigen_ratio_median"]  # lambda_2 / lambda_1
+P.attrs["max_share_explosive_draws"]
+P.attrs["max_share_singular_draws"]
+```
+
+For the full per-draw picture:
+
+```python
+posterior = fitted.idata.posterior
+diagnostics = scheme.max_share_diagnostics(
+    identified.volatility.cholesky_at(posterior, t=None),
+    fitted.var_names,
+    posterior,
+)
+diagnostics["share"]            # shape (chains, draws)
+diagnostics["eigen_ratio"]
+diagnostics["spectral_radius"]
+diagnostics["condition_max"]
+```
+
+The eigenvalue ratio is the one to watch. It compares the second-largest eigenvalue of the band variance form to the largest. Near zero, the maximiser is a well-separated direction. Near one, two directions explain almost the same share, and which of them is returned is down to the eigensolver rather than to the data — Impulso warns when the posterior median exceeds 0.9, and the honest response is to widen the band, change the target, or stop treating the answer as a point estimate.
+
+A spectral radius above one means that draw is explosive, so its spectral density is not that of a stationary process and the share has no interpretation. Those draws are warned about but kept: posteriors on persistent data routinely put mass above one, and dropping them would quietly condition the posterior on stability.
+
+## When draws are undefined
+
+The transfer function is `C(w) = (I - sum_j A_j e^{-i w j})^-1`. If a draw has a root essentially on the unit circle *at a frequency inside your band*, that inverse is numerically meaningless there and the draw is blanked:
+
+```python
+scheme = MaxShare(
+    target="unemployment",
+    band=(6, 32),
+    on_undefined="nan",     # default; "raise" errors instead
+    max_condition=1e8,      # condition number above which C(w) is refused
+)
+```
+
+`NaN` draws propagate: impulse responses and FEVDs report `NaN` for them rather than a misleading zero, and the scenario methods reject them outright. If any of that is in your plans, run with `on_undefined="raise"` so the problem surfaces at identification time instead of three steps later.
+
+## Tuning the quadrature
+
+The band integral is a uniform midpoint rule with `n_frequencies` nodes, 192 by default, which is comfortably converged for typical macro VARs. Raise it for very narrow bands, or when draws sit close to a unit root and the spectral density has a sharp peak inside the band:
+
+```python
+scheme = MaxShare(target="unemployment", band=(28, 32), n_frequencies=512)
+```
+
+The cost is linear in `n_frequencies`, and the sweep is computed once per posterior and reused, so raising it is cheap relative to sampling.
+
+## A climate example
+
+Nothing about the scheme is macroeconomic. With annual data on global-mean surface temperature, ocean heat content and an El Niño-Southern Oscillation (ENSO) index, the same machinery separates variance by timescale:
+
+```python
+forced = MaxShare(target="temperature", band=(10, float("inf")))
+internal = MaxShare(target="temperature", band=(2, 8))
+```
+
+The first asks which single shock explains most of temperature's decadal-and-longer variance; the second asks the same question of its interannual variance. The two bands are different questions about the same posterior, and each returns its own structural column.
+
+:::{admonition} A band is not a mechanism
+:class: warning
+The low-frequency shock is not "the forced response" and the
+interannual one is not "ENSO" — those are labels you supply, and the
+maximisation cannot check them. All the scheme establishes is that a
+particular direction in shock space accounts for most of the variance in
+a particular frequency range. Treat the band as a way of *organising* the
+variance, then argue separately, from physics or from an independent
+series, that the direction it selects is the thing you named.
+:::

--- a/docs/reference/identification.md
+++ b/docs/reference/identification.md
@@ -11,4 +11,5 @@
    SignRestriction
    LongRunRestriction
    ProxySVAR
+   MaxShare
 ```

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -155,6 +155,8 @@
   volume  = {79},
   number  = {4},
   pages   = {655--673},
+}
+
 @article{faust1998,
   author  = {Faust, Jon},
   title   = {The Robustness of Identified {VAR} Conclusions About Money},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -155,4 +155,31 @@
   volume  = {79},
   number  = {4},
   pages   = {655--673},
+@article{faust1998,
+  author  = {Faust, Jon},
+  title   = {The Robustness of Identified {VAR} Conclusions About Money},
+  journal = {Carnegie-Rochester Conference Series on Public Policy},
+  year    = {1998},
+  volume  = {49},
+  pages   = {207--244},
+}
+
+@article{uhlig2004,
+  author  = {Uhlig, Harald},
+  title   = {Do Technology Shocks Lead to a Fall in Total Hours Worked?},
+  journal = {Journal of the European Economic Association},
+  year    = {2004},
+  volume  = {2},
+  number  = {2--3},
+  pages   = {361--371},
+}
+
+@article{angeletosCollardDellas2020,
+  author  = {Angeletos, George-Marios and Collard, Fabrice and Dellas, Harris},
+  title   = {Business-Cycle Anatomy},
+  journal = {The American Economic Review},
+  year    = {2020},
+  volume  = {110},
+  number  = {10},
+  pages   = {3030--3070},
 }

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from impulso.evidence import EvidenceComparison, ModelEvidence, compare_evidence
     from impulso.fitted import FittedVAR
     from impulso.identification import Cholesky, LongRunRestriction, ProxySVAR, SignRestriction
+    from impulso.identification import Cholesky, MaxShare, ProxySVAR, SignRestriction
     from impulso.identified import IdentifiedVAR
     from impulso.observation import Gaussian, StudentT
     from impulso.priors import MinnesotaPrior, NIWPrior
@@ -70,6 +71,7 @@ __all__ = [
     "IntegrationOrderResult",
     "LagOrderResult",
     "LongRunRestriction",
+    "MaxShare",
     "MinnesotaPrior",
     "ModelEvidence",
     "NIWPrior",
@@ -106,6 +108,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "IdentifiedVAR": "impulso.identified",
     "Cholesky": "impulso.identification",
     "LongRunRestriction": "impulso.identification",
+    "MaxShare": "impulso.identification",
     "ProxySVAR": "impulso.identification",
     "SignRestriction": "impulso.identification",
     "MinnesotaPrior": "impulso.priors",

--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
     from impulso.conjugate_volatility import ConjugateVolatility, PandemicBreak
     from impulso.evidence import EvidenceComparison, ModelEvidence, compare_evidence
     from impulso.fitted import FittedVAR
-    from impulso.identification import Cholesky, LongRunRestriction, ProxySVAR, SignRestriction
-    from impulso.identification import Cholesky, MaxShare, ProxySVAR, SignRestriction
+    from impulso.identification import Cholesky, LongRunRestriction, MaxShare, ProxySVAR, SignRestriction
     from impulso.identified import IdentifiedVAR
     from impulso.observation import Gaussian, StudentT
     from impulso.priors import MinnesotaPrior, NIWPrior

--- a/src/impulso/_linalg.py
+++ b/src/impulso/_linalg.py
@@ -61,3 +61,65 @@ def lag_matrices(B: np.ndarray, n_lags: int) -> list[np.ndarray]:
         raise ValueError(f"B trailing axis {n_coeffs} is not divisible by n_lags {n_lags}")
     n_vars = n_coeffs // n_lags
     return [B[..., j * n_vars : (j + 1) * n_vars] for j in range(n_lags)]
+
+
+def companion_spectral_radius(A: list[np.ndarray]) -> np.ndarray:
+    """Largest absolute eigenvalue of the VAR companion matrix, per draw.
+
+    The companion form stacks the lag matrices in its top block-row and
+    carries an identity subdiagonal. Its spectral radius is below one
+    exactly when the VAR is stable, i.e. when the moving-average sum
+    `sum_h Phi_h` converges and the spectral density is finite at every
+    frequency.
+
+    Args:
+        A: Lag coefficient matrices `A_1, ..., A_p` in lag order, each of
+            shape `(..., n, n)` with shared leading batch axes.
+
+    Returns:
+        Spectral radii with the shared leading batch shape, e.g.
+        `(chains, draws)`.
+    """
+    n = A[0].shape[-1]
+    n_lags = len(A)
+    leading = A[0].shape[:-2]
+    companion = np.zeros((*leading, n * n_lags, n * n_lags))
+    companion[..., :n, :] = np.concatenate(A, axis=-1)
+    if n_lags > 1:
+        sub = np.arange(n * (n_lags - 1))
+        companion[..., n + sub, sub] = 1.0
+    return np.abs(np.linalg.eigvals(companion)).max(axis=-1)
+
+
+def householder_from_e1(q1: np.ndarray) -> np.ndarray:
+    """Orthogonal completion of a unit vector, as a Householder reflection.
+
+    Returns the symmetric orthogonal matrix `Q = I - 2 w w' / (w'w)` with
+    `w = q1 - e1`, which maps `e1` to `q1` and therefore has `q1` as its
+    first column. The remaining columns are an arbitrary but deterministic
+    orthonormal completion of `q1`.
+
+    Identification schemes that pin down a single structural column use
+    this to build a full invertible `P = L Q` satisfying `P P' = Sigma`:
+    column 0 is the identified direction and columns 1.. are the
+    rotation-arbitrary remainder (labelled `unidentified_*` downstream).
+
+    Args:
+        q1: Unit vector(s), shape `(..., n)`. Leading axes are batch axes,
+            typically `(chains, draws)`. Not renormalised — callers are
+            expected to pass a normalised direction.
+
+    Returns:
+        Orthogonal matrices of shape `(..., n, n)` whose first column is
+        `q1`. When `q1` is already `e1` (so `w` vanishes) the identity is
+        returned, which satisfies the same contract.
+    """
+    n = q1.shape[-1]
+    e1 = np.zeros(n)
+    e1[0] = 1.0
+    w = q1 - e1
+    w_norm2 = np.einsum("...i,...i->...", w, w)[..., np.newaxis, np.newaxis]
+    outer = w[..., :, np.newaxis] * w[..., np.newaxis, :]
+    eye = np.broadcast_to(np.eye(n), outer.shape)
+    usable = w_norm2 > 1e-14
+    return np.where(usable, eye - 2.0 * outer / np.where(usable, w_norm2, 1.0), eye)

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1204,6 +1204,17 @@ class MaxShare(ImpulsoModel):
             is numerically undefined inside the band are NaN when
             `on_undefined="nan"`.
 
+        Note:
+            Under time-varying volatility the pipeline calls this once per
+            time slice, and `_last_diagnostics` is overwritten each call.
+            The diagnostics attached to `shock_matrix(at="all")` therefore
+            describe the *last* time slice only. The share and eigenvalue
+            ratio are the L-dependent ones and so genuinely differ across
+            slices; the singular, explosive and spectral-radius counts do
+            not, since they are properties of the posterior alone. Use
+            `max_share_diagnostics` with an explicit `L` for a specific
+            period.
+
         Raises:
             ValueError: If `posterior` is missing or carries no `B`, if
                 `target` is not an endogenous variable, or if

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -99,6 +99,9 @@ class _PosteriorCache:
         MaxShare._spectral_cache:
             self._spectral_cache.get(posterior, (n_lags, target))
             self._spectral_cache.set(posterior, (n_lags, target), value)
+    Adopted by `ProxySVAR._impact_cache` and `MaxShare._spectral_cache`
+    (issue #203). The one remaining identity-keyed memo in this module
+    collapses to the same three lines once its branch merges:
 
     Declare the attribute on the (frozen) scheme with
     `PrivateAttr(default_factory=_PosteriorCache)` so each instance gets
@@ -1144,9 +1147,10 @@ class MaxShare(ImpulsoModel):
     # under time-varying volatility, where the pipeline calls identify()
     # once per period with the same posterior, the frequency loop runs
     # once instead of T times (and the warnings fire once, not T times).
-    # Keyed by object identity: valid while the caller holds the same
-    # posterior object, which is exactly the per-t loop's lifetime.
-    _spectral_cache: tuple | None = PrivateAttr(default=None)
+    # Keyed by object identity, with a weak reference as the validity
+    # token: valid while the caller holds the same posterior object, which
+    # is exactly the per-t loop's lifetime. See `_PosteriorCache`.
+    _spectral_cache: _PosteriorCache = PrivateAttr(default_factory=_PosteriorCache)
 
     @model_validator(mode="after")
     def _validate_band(self) -> "MaxShare":
@@ -1292,8 +1296,9 @@ class MaxShare(ImpulsoModel):
         `x_w` is the target's row of the transfer function, obtained from
         the single batched solve `F(w)' x = e_target` (a plain transpose,
         not a conjugate one: `x' = e_target' F^-1`). Because `K` does not
-        involve `L`, the whole loop is memoised on
-        `(id(posterior), n_lags, target_index)` — see `_spectral_cache`.
+        involve `L`, the whole loop is memoised on the posterior's identity
+        plus `(n_lags, target_index)` — see `_spectral_cache` and
+        `_PosteriorCache`.
 
         Returns:
             Tuple `(K, bad, rho, condition)`: the real symmetric
@@ -1302,9 +1307,9 @@ class MaxShare(ImpulsoModel):
             companion spectral radii; and the worst in-band condition
             number, the last three all `(C, D)`.
         """
-        cache_key = (id(posterior), n_lags, target_index)
-        if self._spectral_cache is not None and self._spectral_cache[0] == cache_key:
-            return self._spectral_cache[1]
+        cached = self._spectral_cache.get(posterior, (n_lags, target_index))
+        if cached is not _CACHE_MISS:
+            return cached
 
         A = lag_matrices(posterior["B"].values, n_lags)
         rho = companion_spectral_radius(A)
@@ -1336,7 +1341,7 @@ class MaxShare(ImpulsoModel):
 
         self._report(bad, rho > 1.0)
         result = (K, bad, rho, condition_max)
-        self._spectral_cache = (cache_key, result)
+        self._spectral_cache.set(posterior, (n_lags, target_index), result)
         return result
 
     def _frequencies(self) -> np.ndarray:

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1056,10 +1056,10 @@ class MaxShare(ImpulsoModel):
 
     Identifies the single structural shock that accounts for the largest
     possible fraction of one target variable's variance over a stated band
-    of frequencies — the "main business-cycle shock" of
-    {cite:t}`angeletosCollardDellas2020`, in the frequency-domain form of
-    {cite:t}`faust1998` and {cite:t}`uhlig2004`. Nothing is searched for:
-    the maximiser is an eigenvector, computed in closed form per draw.
+    of frequencies — the "main business-cycle shock" of Angeletos, Collard
+    and Dellas (2020), in the frequency-domain form of Faust (1998) and
+    Uhlig (2004). Nothing is searched for: the maximiser is an
+    eigenvector, computed in closed form per draw.
 
     The reduced-form transfer function is
     `C(w) = (I - sum_j A_j e^{-i w j})^-1`, so for a candidate impact

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -9,7 +9,7 @@ import xarray as xr
 from pydantic import Field, PrivateAttr, model_validator
 
 from impulso._base import ImpulsoBaseModel, ImpulsoModel
-from impulso._linalg import lag_matrices
+from impulso._linalg import companion_spectral_radius, householder_from_e1, lag_matrices
 from impulso._ma import compute_ma_phi
 
 if TYPE_CHECKING:
@@ -1033,6 +1033,455 @@ class ProxySVAR(ImpulsoBaseModel):
         tss = np.einsum("cdt,cdt->cd", u_policy_c, u_policy_c)
         rss = tss - ess
         return ess / (rss / (T - 2))
+
+    def shock_coords(self, n_vars: int) -> list[str]:
+        """Identified shock first, then rotation-arbitrary padding."""
+        return SignRestriction._build_shock_coords([self.shock_name], n_vars)
+
+
+def _nan_stat(fn, arr: np.ndarray, *args) -> float:
+    """Apply a NaN-aware summary to an array that may be entirely NaN.
+
+    `np.nanmedian` and friends emit a RuntimeWarning and return NaN for an
+    all-NaN slice. Diagnostics are reported even when every draw was
+    blanked, so the empty case is short-circuited instead of warned about.
+    """
+    if not np.isfinite(arr).any():
+        return float("nan")
+    return float(fn(arr, *args))
+
+
+class MaxShare(ImpulsoModel):
+    """Maximum-share identification over a frequency band.
+
+    Identifies the single structural shock that accounts for the largest
+    possible fraction of one target variable's variance over a stated band
+    of frequencies — the "main business-cycle shock" of
+    {cite:t}`angeletosCollardDellas2020`, in the frequency-domain form of
+    {cite:t}`faust1998` and {cite:t}`uhlig2004`. Nothing is searched for:
+    the maximiser is an eigenvector, computed in closed form per draw.
+
+    The reduced-form transfer function is
+    `C(w) = (I - sum_j A_j e^{-i w j})^-1`, so for a candidate impact
+    column `p = L q` (with `q` a real unit vector and `L L' = Sigma`) the
+    target variable's variance over the band `B` is proportional to
+    `q' M q` with `M = int_B (C_i L)^* (C_i L) dw`, where `C_i` is the
+    target's row of `C`. `M` is Hermitian positive semi-definite, and for
+    real `q` only its real part contributes (its imaginary part is
+    antisymmetric), so the maximiser is the leading eigenvector of the
+    real symmetric matrix `Re(M)` and the achieved share is
+    `lambda_max / trace`. The integral is evaluated with a uniform
+    midpoint rule over `n_frequencies` points, which never lands on
+    `w = 0` and so admits an unbounded upper period.
+
+    Only one column is identified. The remaining columns are completed
+    orthogonally via a Householder reflection, so `P P' = Sigma` holds to
+    machine precision and downstream code needing a full invertible matrix
+    keeps working — but they are rotation-arbitrary and are labelled
+    `unidentified_1..`. `IdentifiedVAR.fevd` masks their shares to NaN and
+    `IdentifiedVAR.historical_decomposition` collapses them into a single
+    `unidentified_remainder` column, exactly as for `ProxySVAR`.
+
+    Sign convention: the identified column is flipped so that the shock
+    raises the target variable on impact.
+
+    Two failure modes are reported separately:
+
+    - `I - sum_j A_j e^{-i w j}` near-singular at some grid frequency (a
+      root essentially on the unit circle *at a frequency in the band*),
+      so the transfer function is numerically undefined there. Controlled
+      by `on_undefined` and `max_condition`.
+    - Explosive draws (companion spectral radius above one). The band
+      arithmetic still succeeds — the transfer function may be perfectly
+      well conditioned — but the spectral density is not that of a
+      stationary process, so the "variance share" has no interpretation.
+      Those draws are always returned finite and always warned about.
+
+    Attributes:
+        target: Endogenous variable whose band variance is maximised.
+        band: `(low_period, high_period)` in **periods of the sampling
+            interval**, not radians. Quarterly business cycles are
+            `(6, 32)`; the monthly analogue is `(18, 96)`. Internally the
+            band is `w in [2*pi/high_period, 2*pi/low_period]`. Requires
+            `2 <= low_period < high_period <= inf`; period 2 is the
+            Nyquist frequency and `high_period=inf` selects everything
+            down to (but excluding) the zero frequency.
+        shock_name: Label of the identified shock column.
+        n_frequencies: Midpoint-rule quadrature points across the band.
+            The default of 192 puts the band integral within roughly
+            `1e-6` of its converged value for typical macro VARs; raise it
+            for very narrow bands or near-unit-root draws.
+        on_undefined: `"nan"` (default) blanks draws whose transfer
+            function is numerically singular somewhere in the band and
+            warns; `"raise"` errors instead. NaN draws propagate into
+            IRF/FEVD and are rejected outright by the scenario methods.
+        max_condition: Condition-number threshold above which
+            `I - sum_j A_j e^{-i w j}` counts as numerically singular.
+            Default `1e8`.
+
+    Note:
+        Explaining most of a variable's band variance is a statement about
+        variance, not a causal claim. The scheme finds *a* direction in
+        shock space; whether it deserves an economic name is an
+        interpretation the data cannot supply.
+    """
+
+    target: str
+    band: tuple[float, float]
+    shock_name: str = "max_share"
+    n_frequencies: int = Field(default=192, ge=16)
+    on_undefined: Literal["nan", "raise"] = "nan"
+    max_condition: float = Field(default=1e8, gt=0.0)
+
+    # Single-call scratchpad, mirroring ProxySVAR._last_diagnostics:
+    # identify() writes the band diagnostics; the pipeline reads them back
+    # and attaches them to the shock-matrix attrs.
+    _last_diagnostics: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    # Memoised frequency sweep. The accumulator `K`, the conditioning
+    # screen and the spectral radii depend only on (posterior, n_lags,
+    # target) — not on L, which enters afterwards as `M = L' Re(K) L`. So
+    # under time-varying volatility, where the pipeline calls identify()
+    # once per period with the same posterior, the frequency loop runs
+    # once instead of T times (and the warnings fire once, not T times).
+    # Keyed by object identity: valid while the caller holds the same
+    # posterior object, which is exactly the per-t loop's lifetime.
+    _spectral_cache: tuple | None = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def _validate_band(self) -> "MaxShare":
+        """Reject bands that are not valid period intervals, and bad labels."""
+        low, high = self.band
+        if not np.isfinite(low) or np.isnan(high):
+            raise ValueError(
+                f"band must be (low_period, high_period) in periods of the sampling interval; "
+                f"got {self.band}. The lower bound must be finite."
+            )
+        if low < 2.0:
+            raise ValueError(
+                f"band lower bound must be at least 2 periods (the Nyquist frequency); got {low}. "
+                "The band is given in periods of the sampling interval — quarterly business "
+                "cycles are band=(6, 32), not radians."
+            )
+        if low >= high:
+            raise ValueError(
+                f"band must satisfy low_period < high_period; got {self.band}. The band is given "
+                "in periods of the sampling interval, shortest first — quarterly business cycles "
+                "are band=(6, 32), and band=(32, inf) is the low-frequency band."
+            )
+        if self.shock_name.startswith("unidentified_"):
+            raise ValueError(
+                f"shock_name may not start with the reserved prefix 'unidentified_' (got "
+                f"{self.shock_name!r}). Downstream guards read that prefix to mask "
+                "rotation-arbitrary columns, so such a name would silently hide the identified "
+                "shock from FEVD and historical decomposition."
+            )
+        return self
+
+    def identify(
+        self,
+        L: np.ndarray,
+        var_names: list[str],
+        posterior: "xr.Dataset | None" = None,
+        data: "VARData | None" = None,
+        n_lags: int | None = None,
+    ) -> np.ndarray:
+        """Apply maximum-share identification over the frequency band.
+
+        Args:
+            L: Lower-triangular Cholesky factor, shape (chains, draws, n_vars, n_vars).
+            var_names: Variable names in the data's natural order.
+            posterior: Full posterior; required, because the transfer
+                function is built from the lag coefficients `B`.
+            data: Unused. Accepted for Protocol uniformity.
+            n_lags: Lag order. Inferred from `B`'s trailing axis if omitted.
+
+        Returns:
+            Structural shock matrix, shape (chains, draws, n_vars, n_vars).
+            Rows follow `var_names` (the data's order) by construction;
+            column 0 is the identified shock and columns 1.. are an
+            arbitrary orthogonal completion. Draws whose transfer function
+            is numerically undefined inside the band are NaN when
+            `on_undefined="nan"`.
+
+        Raises:
+            ValueError: If `posterior` is missing or carries no `B`, if
+                `target` is not an endogenous variable, or if
+                `on_undefined="raise"` and some draw is undefined.
+        """
+        del data  # unused
+        vals, vecs, bad, rho, condition = self._band_eigen(L, var_names, posterior, n_lags)
+
+        q = vecs[..., -1]  # eigh returns eigenvalues ascending
+        q = q * self._orientation(L, q, var_names.index(self.target))[..., np.newaxis]
+        P = L @ householder_from_e1(q)
+
+        share, ratio = self._share_and_ratio(vals, bad)
+        self._last_diagnostics = {
+            "max_share_share_median": _nan_stat(np.nanmedian, share),
+            "max_share_share_q05": _nan_stat(np.nanquantile, share, 0.05),
+            "max_share_share_q95": _nan_stat(np.nanquantile, share, 0.95),
+            "max_share_eigen_ratio_median": _nan_stat(np.nanmedian, ratio),
+            "max_share_eigen_ratio_q95": _nan_stat(np.nanquantile, ratio, 0.95),
+            "max_share_singular_draws": float(bad.sum()),
+            "max_share_singular_fraction": float(bad.mean()),
+            "max_share_condition_max": float(np.max(condition)),
+            "max_share_explosive_draws": float((rho > 1.0).sum()),
+            "max_share_explosive_fraction": float((rho > 1.0).mean()),
+            "max_share_spectral_radius_median": float(np.median(rho)),
+            "max_share_spectral_radius_max": float(rho.max()),
+        }
+        self._warn_weakly_identified()
+
+        if bad.any():
+            P = np.where(bad[..., np.newaxis, np.newaxis], np.nan, P)
+        return P
+
+    def _band_eigen(
+        self,
+        L: np.ndarray,
+        var_names: list[str],
+        posterior: "xr.Dataset | None",
+        n_lags: int | None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Eigendecomposition of the band variance form `M = L' Re(K) L`.
+
+        Returns:
+            Tuple `(vals, vecs, bad, rho, condition)`: eigenvalues in
+            ascending order and their eigenvectors, `(C, D, n)` and
+            `(C, D, n, n)`; the numerically-undefined mask, the companion
+            spectral radii and the worst in-band condition number, each
+            `(C, D)`.
+        """
+        if posterior is None or "B" not in posterior:
+            raise ValueError(
+                "MaxShare.identify requires the full posterior with 'B' (the VAR lag "
+                "coefficients): the transfer function C(w) = (I - sum_j A_j e^{-i w j})^-1 is "
+                "built from them. Pass posterior=fitted.idata.posterior to identify() — "
+                "FittedVAR.set_identification_strategy(...) supplies it automatically."
+            )
+        if self.target not in var_names:
+            raise ValueError(f"target {self.target!r} is not an endogenous variable; data has {list(var_names)}.")
+
+        n_vars = L.shape[-1]
+        if n_lags is None:
+            n_lags = posterior["B"].shape[-1] // n_vars
+        K, bad, rho, condition = self._spectral_accumulator(posterior, n_lags, n_vars, var_names.index(self.target))
+
+        M = np.swapaxes(L, -1, -2) @ K @ L
+        M = 0.5 * (M + np.swapaxes(M, -1, -2))
+        vals, vecs = np.linalg.eigh(M)
+        return vals, vecs, bad, rho, condition
+
+    def _spectral_accumulator(
+        self, posterior: "xr.Dataset", n_lags: int, n_vars: int, target_index: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Sweep the band and accumulate `K = sum_w Re(conj(x_w) x_w')`.
+
+        `x_w` is the target's row of the transfer function, obtained from
+        the single batched solve `F(w)' x = e_target` (a plain transpose,
+        not a conjugate one: `x' = e_target' F^-1`). Because `K` does not
+        involve `L`, the whole loop is memoised on
+        `(id(posterior), n_lags, target_index)` — see `_spectral_cache`.
+
+        Returns:
+            Tuple `(K, bad, rho, condition)`: the real symmetric
+            accumulator `(C, D, n, n)`; the mask of draws whose transfer
+            function is numerically singular at some grid frequency; the
+            companion spectral radii; and the worst in-band condition
+            number, the last three all `(C, D)`.
+        """
+        cache_key = (id(posterior), n_lags, target_index)
+        if self._spectral_cache is not None and self._spectral_cache[0] == cache_key:
+            return self._spectral_cache[1]
+
+        A = lag_matrices(posterior["B"].values, n_lags)
+        rho = companion_spectral_radius(A)
+        A_stack = np.stack(A, axis=0)  # (p, C, D, n, n)
+        lags = np.arange(1, n_lags + 1)
+
+        eye = np.eye(n_vars)
+        e_target = np.zeros((n_vars, 1))
+        e_target[target_index, 0] = 1.0
+
+        K = np.zeros((*rho.shape, n_vars, n_vars))
+        bad = np.zeros(rho.shape, dtype=bool)
+        condition_max = np.zeros(rho.shape)
+        for omega in self._frequencies():
+            F = eye - np.tensordot(np.exp(-1j * omega * lags), A_stack, axes=(0, 0))
+            # cond() returns inf for a singular matrix rather than raising,
+            # which is what makes the sanitise-then-blank strategy possible.
+            condition = np.linalg.cond(F)
+            condition_max = np.maximum(condition_max, np.where(np.isfinite(condition), condition, np.inf))
+            bad |= ~np.isfinite(condition) | (condition > self.max_condition)
+            # A batched solve raises for the whole batch if any slice is
+            # singular, so sanitise first and blank the offenders in identify().
+            F_safe = np.where(bad[..., np.newaxis, np.newaxis], eye, F)
+            x = np.linalg.solve(np.swapaxes(F_safe, -1, -2), e_target)[..., 0]  # (C, D, n)
+            # Re(conj(x) x') = Re(x) Re(x)' + Im(x) Im(x)' — symmetric PSD
+            # by construction, so no separate symmetrisation is needed.
+            xr_, xi = x.real, x.imag
+            K += xr_[..., :, np.newaxis] * xr_[..., np.newaxis, :] + xi[..., :, np.newaxis] * xi[..., np.newaxis, :]
+
+        self._report(bad, rho > 1.0)
+        result = (K, bad, rho, condition_max)
+        self._spectral_cache = (cache_key, result)
+        return result
+
+    def _frequencies(self) -> np.ndarray:
+        """Midpoint-rule quadrature nodes across the band, in radians.
+
+        The band is given in periods, so `w = 2 pi / period` and the
+        interval runs from `2 pi / high_period` (zero when `high_period`
+        is infinite) up to `2 pi / low_period`. Midpoints never land on an
+        endpoint, which is what keeps `high_period=inf` — and hence the
+        excluded zero frequency — safe.
+        """
+        low, high = self.band
+        omega_lo = 0.0 if np.isinf(high) else 2.0 * np.pi / high
+        omega_hi = 2.0 * np.pi / low
+        step = (omega_hi - omega_lo) / self.n_frequencies
+        return omega_lo + step * (np.arange(self.n_frequencies) + 0.5)
+
+    @staticmethod
+    def _orientation(L: np.ndarray, q: np.ndarray, target_index: int) -> np.ndarray:
+        """Signs flipping each draw's column so the shock raises the target.
+
+        An eigenvector is only defined up to sign. The convention is that
+        the identified shock moves the target variable up on impact. When
+        the target's impact loading is exactly zero the convention is
+        vacuous there, so the largest-magnitude loading is made positive
+        instead — an arbitrary but deterministic tie-break.
+        """
+        p = (L @ q[..., np.newaxis])[..., 0]
+        sign = np.sign(p[..., target_index])
+        largest = np.argmax(np.abs(p), axis=-1)[..., np.newaxis]
+        fallback = np.sign(np.take_along_axis(p, largest, axis=-1)[..., 0])
+        return np.where(sign != 0.0, sign, np.where(fallback != 0.0, fallback, 1.0))
+
+    @staticmethod
+    def _share_and_ratio(vals: np.ndarray, bad: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Achieved band share and eigenvalue ratio, per draw.
+
+        The share is `lambda_max / trace`: the fraction of the target's
+        band variance the identified shock explains. The ratio
+        `lambda_2 / lambda_max` is the degeneracy diagnostic — near one,
+        the maximiser is only pinned down within a two-dimensional plane
+        and the returned rotation is whatever LAPACK happened to pick.
+        Blanked draws are NaN in both.
+        """
+        total = vals.sum(axis=-1)
+        top = vals[..., -1]
+        share = np.where(total > 0.0, top / np.where(total > 0.0, total, 1.0), np.nan)
+        if vals.shape[-1] > 1:
+            ratio = np.where(top > 0.0, vals[..., -2] / np.where(top > 0.0, top, 1.0), np.nan)
+        else:
+            ratio = np.zeros_like(share)
+        return np.where(bad, np.nan, share), np.where(bad, np.nan, ratio)
+
+    def _report(self, bad: np.ndarray, explosive: np.ndarray) -> None:
+        """Warn (or raise) about undefined and explosive draws.
+
+        The two conditions are distinct. A singular `I - sum_j A_j
+        e^{-i w j}` is an arithmetic failure — the transfer function does
+        not exist at that frequency. An explosive draw is an
+        interpretation failure — the arithmetic is fine, but the process
+        is non-stationary, so "share of variance" means nothing. Bayesian
+        posteriors near a unit root routinely contain explosive draws, so
+        those are reported, never blanked.
+        """
+        import warnings
+
+        total = int(bad.size)
+        n_bad = int(bad.sum())
+        if n_bad:
+            if self.on_undefined == "raise":
+                raise ValueError(
+                    f"The transfer function C(w) = (I - sum_j A_j e^{{-i w j}})^-1 is numerically "
+                    f"undefined for {n_bad}/{total} posterior draws at one or more frequencies in "
+                    f"band={self.band} (condition number above max_condition="
+                    f"{self.max_condition:g}). Pass on_undefined='nan' to blank those draws "
+                    "instead, or raise max_condition if the loss of precision is acceptable."
+                )
+            warnings.warn(
+                f"The transfer function C(w) = (I - sum_j A_j e^{{-i w j}})^-1 is numerically "
+                f"undefined for {n_bad}/{total} posterior draws at one or more frequencies in "
+                f"band={self.band} (condition number above max_condition={self.max_condition:g}); "
+                "those draws are returned as NaN. NaN draws propagate into IRF and FEVD, and the "
+                "scenario methods reject them.",
+                UserWarning,
+                stacklevel=4,
+            )
+        n_explosive = int(explosive.sum())
+        if n_explosive:
+            warnings.warn(
+                f"{n_explosive}/{total} posterior draws are explosive (companion spectral radius "
+                "above 1), so their spectral density is not that of a stationary process and the "
+                "band variance share has no interpretation for them. They are still identified "
+                "arithmetically and returned finite — check max_share_diagnostics() before "
+                "reading the results.",
+                UserWarning,
+                stacklevel=4,
+            )
+
+    def _warn_weakly_identified(self) -> None:
+        """Warn when the leading eigenvalue is barely separated from the next.
+
+        At a ratio near one the band-variance form is close to having a
+        repeated top eigenvalue, so the maximiser is determined only up to
+        a rotation within that plane. The returned column is then whatever
+        the eigensolver produced and is not reproducible across LAPACK
+        builds. Threshold fixed at 0.9 — it is a smoke alarm, not a tuning
+        knob.
+        """
+        ratio = self._last_diagnostics.get("max_share_eigen_ratio_median", np.nan)
+        if np.isfinite(ratio) and ratio > 0.9:
+            import warnings
+
+            warnings.warn(
+                f"The maximum-share shock is weakly identified within the band: posterior-median "
+                f"eigenvalue ratio lambda_2/lambda_1 = {ratio:.3f} > 0.9, so the maximiser is "
+                "nearly degenerate and the returned rotation within that plane is arbitrary. See "
+                "the max_share_eigen_ratio_* diagnostics.",
+                UserWarning,
+                stacklevel=4,
+            )
+
+    def max_share_diagnostics(
+        self,
+        L: np.ndarray,
+        var_names: list[str],
+        posterior: "xr.Dataset",
+        n_lags: int | None = None,
+    ) -> dict[str, np.ndarray]:
+        """Per-draw band shares, degeneracy and conditioning.
+
+        Args:
+            L: Lower-triangular Cholesky factor, shape
+                `(chains, draws, n_vars, n_vars)` — e.g.
+                `identified.volatility.cholesky_at(posterior)`.
+            var_names: Variable names in the data's natural order.
+            posterior: Posterior Dataset carrying `B`
+                (`fitted.idata.posterior`).
+            n_lags: Lag order. Inferred from `B`'s trailing axis if omitted.
+
+        Returns:
+            Dict of `(chains, draws)` arrays. `"share"` is the fraction of
+            the target's band variance the identified shock explains;
+            `"eigen_ratio"` is `lambda_2/lambda_1`, near one when the
+            maximiser is degenerate; `"spectral_radius"` is the companion
+            spectral radius, above one for explosive draws; and
+            `"condition_max"` is the worst condition number of
+            `I - sum_j A_j e^{-i w j}` across the band's grid.
+        """
+        vals, _, bad, rho, condition = self._band_eigen(L, var_names, posterior, n_lags)
+        share, ratio = self._share_and_ratio(vals, bad)
+        return {
+            "share": share,
+            "eigen_ratio": ratio,
+            "spectral_radius": rho,
+            "condition_max": condition,
+        }
 
     def shock_coords(self, n_vars: int) -> list[str]:
         """Identified shock first, then rotation-arbitrary padding."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,3 +288,53 @@ def synthetic_sv_idata_2v():
         "v1_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
     })
     return az.InferenceData(posterior=posterior)
+
+
+@pytest.fixture
+def single_driver_2v():
+    """Exact-arithmetic 2-var VAR(1) where one shock drives `y2` entirely.
+
+    Built backwards from the answer so max-share identification has a
+    closed form to be checked against:
+
+        A_1    = [[0.5, 0.0], [0.0, 0.3]]   (diagonal — rows decouple)
+        P_true = [[0.3, 0.9], [0.7, 0.0]]   (row 1 loads only on shock 0)
+        Sigma  = P_true @ P_true.T = [[0.90, 0.21], [0.21, 0.49]]
+
+    Because `A_1` is diagonal the transfer function is diagonal too, so
+    row 1 of `C(w) P_true` is `c_2(w) * [0.7, 0]` at *every* frequency:
+    shock 0 explains 100% of `y2`'s variance in every band, and the
+    unique maximiser is `p = [0.3, 0.7]` exactly. `P_true` is deliberately
+    not lower-triangular, so it is distinguishable from `chol(Sigma)`.
+
+    Returns:
+        Dict with keys `A1`, `P_true`, `Sigma`, `L` (Cholesky factor of
+        Sigma, broadcast over draws) and `idata` — an InferenceData with
+        2 chains x 50 draws whose draws all equal the truth, laid out like
+        `synthetic_idata_2v`.
+    """
+    n_chains, n_draws, n_vars = 2, 50, 2
+
+    A1 = np.array([[0.5, 0.0], [0.0, 0.3]])
+    P_true = np.array([[0.3, 0.9], [0.7, 0.0]])
+    Sigma = P_true @ P_true.T
+    L = np.linalg.cholesky(Sigma)
+
+    shape = (n_chains, n_draws, n_vars, n_vars)
+    posterior = xr.Dataset({
+        "B": xr.DataArray(np.broadcast_to(A1, shape).copy(), dims=["chain", "draw", "var", "coeff"]),
+        "intercept": xr.DataArray(np.zeros((n_chains, n_draws, n_vars)), dims=["chain", "draw", "var"]),
+        "Sigma": xr.DataArray(
+            np.broadcast_to(Sigma, shape).copy(),
+            dims=["chain", "draw", "var1", "var2"],
+            coords={"var1": ["y1", "y2"], "var2": ["y1", "y2"]},
+        ),
+        "L": xr.DataArray(np.broadcast_to(L, shape).copy(), dims=["chain", "draw", "var1", "var2"]),
+    })
+    return {
+        "A1": A1,
+        "P_true": P_true,
+        "Sigma": Sigma,
+        "L": np.broadcast_to(L, shape).copy(),
+        "idata": az.InferenceData(posterior=posterior),
+    }

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -924,21 +924,39 @@ def _stable_draw():
     )
 
 
-def _reference_band_form(A1: np.ndarray, L: np.ndarray, target: int, band: tuple[float, float]) -> np.ndarray:
+def _multi_lag_draw():
+    """One stable 3-variable VAR(2) draw with a correlated Sigma.
+
+    The lag structure is the point: `A_2` is not proportional to `A_1`,
+    so mis-indexing the lag exponent in `sum_j A_j e^{-i w j}` changes the
+    transfer function and the band share along with it.
+    """
+    A1 = np.array([[0.4, 0.15, 0.0], [0.05, 0.3, 0.1], [0.0, 0.1, 0.2]])
+    A2 = np.array([[0.1, 0.0, 0.05], [0.0, -0.15, 0.0], [0.02, 0.0, 0.1]])
+    Sigma = np.array([[1.0, 0.3, 0.1], [0.3, 0.7, 0.05], [0.1, 0.05, 0.5]])
+    L = np.linalg.cholesky(Sigma)
+    B = np.concatenate([A1, A2], axis=-1)[np.newaxis, np.newaxis]  # (1, 1, 3, 6)
+    return [A1, A2], Sigma, _posterior_with_B(B), L[np.newaxis, np.newaxis]
+
+
+def _reference_band_form(A: list, L: np.ndarray, target: int, band: tuple[float, float], n_grid: int = 4097):
     """Independent, unvectorised build of `Re(M)` by trapezoid quadrature.
 
-    Deliberately shares no code with the implementation: it inverts
-    `F(w)` explicitly, takes the target row, and integrates on a dense
-    uniform grid. Used to check the eigen solution really is the
-    band-variance maximiser.
+    Deliberately shares no code with the implementation: it builds the lag
+    sum term by term with an explicit `e^{-i w j}` per lag `j = 1..p`,
+    inverts `F(w)` outright rather than solving, takes the target row, and
+    integrates on a dense uniform grid. Used to check the eigen solution
+    really is the band-variance maximiser, and to pin the lag indexing.
     """
     omega_lo = 0.0 if np.isinf(band[1]) else 2.0 * np.pi / band[1]
     omega_hi = 2.0 * np.pi / band[0]
-    omegas = np.linspace(omega_lo, omega_hi, 4097)
+    omegas = np.linspace(omega_lo, omega_hi, n_grid)
     integrand = []
     for omega in omegas:
-        C = np.linalg.inv(np.eye(A1.shape[0]) - A1 * np.exp(-1j * omega))
-        row = C[target] @ L
+        F = np.eye(A[0].shape[0], dtype=complex)
+        for j, A_j in enumerate(A, start=1):
+            F -= A_j * np.exp(-1j * omega * j)
+        row = np.linalg.inv(F)[target] @ L
         integrand.append(np.conj(row)[:, np.newaxis] * row[np.newaxis, :])
     return np.trapezoid(np.array(integrand), omegas, axis=0).real
 
@@ -1117,7 +1135,7 @@ class TestMaxShareOptimality:
         scheme = MaxShare(target="y1", band=band)
         P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=1)
 
-        M = _reference_band_form(A1, L[0, 0], target=0, band=band)
+        M = _reference_band_form([A1], L[0, 0], target=0, band=band)
         q = np.linalg.solve(L[0, 0], P[0, 0, :, 0])
         q = q / np.linalg.norm(q)
         achieved = q @ M @ q / np.trace(M)
@@ -1135,7 +1153,7 @@ class TestMaxShareOptimality:
         scheme = MaxShare(target="y1", band=band)
         P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=1)
 
-        M = _reference_band_form(A1, L[0, 0], target=0, band=band)
+        M = _reference_band_form([A1], L[0, 0], target=0, band=band)
         q = np.linalg.solve(L[0, 0], P[0, 0, :, 0])
         q = q / np.linalg.norm(q)
         assert scheme._last_diagnostics["max_share_share_median"] == pytest.approx(q @ M @ q / np.trace(M), abs=1e-5)
@@ -1156,6 +1174,80 @@ class TestMaxShareParseval:
         Theta = Phi @ P[0, 0]
         time_domain = (Theta[:, 0, 0] ** 2).sum() / (Theta[:, 0, :] ** 2).sum()
         assert scheme._last_diagnostics["max_share_share_median"] == pytest.approx(time_domain, abs=1e-6)
+
+
+class TestMaxShareMultiLag:
+    """The lag sum `sum_j A_j e^{-i w j}` on a VAR(2), against an independent reference.
+
+    Every other MaxShare test is VAR(1), where every lag exponent
+    collapses to `e^{-i w}` and a mis-indexed lag would go unnoticed.
+    Here `A_2` carries its own `e^{-2 i w}`, so the reference disagrees
+    with the implementation under any off-by-one.
+    """
+
+    def test_var2_share_matches_independent_reference(self):
+        from impulso.identification import MaxShare
+
+        A, _, posterior, L = _multi_lag_draw()
+        band = (6.0, 32.0)
+        scheme = MaxShare(target="v1", band=band)
+        P = scheme.identify(L, ["v1", "v2", "v3"], posterior=posterior, n_lags=2)
+
+        M = _reference_band_form(A, L[0, 0], target=0, band=band, n_grid=8193)
+        q = np.linalg.solve(L[0, 0], P[0, 0, :, 0])
+        q = q / np.linalg.norm(q)
+        achieved = q @ M @ q / np.trace(M)
+        assert scheme._last_diagnostics["max_share_share_median"] == pytest.approx(achieved, abs=1e-5)
+
+    def test_var2_beats_a_dense_sweep_of_the_sphere(self):
+        from impulso.identification import MaxShare
+
+        A, _, posterior, L = _multi_lag_draw()
+        band = (6.0, 32.0)
+        scheme = MaxShare(target="v1", band=band)
+        P = scheme.identify(L, ["v1", "v2", "v3"], posterior=posterior, n_lags=2)
+
+        M = _reference_band_form(A, L[0, 0], target=0, band=band, n_grid=8193)
+        q = np.linalg.solve(L[0, 0], P[0, 0, :, 0])
+        q = q / np.linalg.norm(q)
+        achieved = q @ M @ q / np.trace(M)
+
+        candidates = np.random.default_rng(7).standard_normal((200_000, 3))
+        candidates /= np.linalg.norm(candidates, axis=-1, keepdims=True)
+        best = (np.einsum("ki,ij,kj->k", candidates, M, candidates) / np.trace(M)).max()
+        assert achieved >= best - 1e-6
+
+    def test_var2_reproduces_sigma_and_signs_the_target(self):
+        from impulso.identification import MaxShare
+
+        _, Sigma, posterior, L = _multi_lag_draw()
+        P = MaxShare(target="v1", band=(6, 32)).identify(L, ["v1", "v2", "v3"], posterior=posterior, n_lags=2)
+
+        np.testing.assert_allclose(P[0, 0] @ P[0, 0].T, Sigma, atol=1e-12)
+        assert P[0, 0, 0, 0] > 0
+
+    def test_var2_full_band_share_equals_time_domain_share(self):
+        """Parseval again, but with two lags in the moving-average recursion."""
+        from impulso._ma import compute_ma_phi
+        from impulso.identification import MaxShare
+
+        A, _, posterior, L = _multi_lag_draw()
+        scheme = MaxShare(target="v1", band=(2.0, float("inf")))
+        P = scheme.identify(L, ["v1", "v2", "v3"], posterior=posterior, n_lags=2)
+
+        Phi = compute_ma_phi([A_j[np.newaxis, np.newaxis] for A_j in A], 600)[0, 0]
+        Theta = Phi @ P[0, 0]
+        time_domain = (Theta[:, 0, 0] ** 2).sum() / (Theta[:, 0, :] ** 2).sum()
+        assert scheme._last_diagnostics["max_share_share_median"] == pytest.approx(time_domain, abs=1e-6)
+
+    def test_var2_n_lags_inferred_from_B(self):
+        """`B` is (n, 2n) here, so a wrong inference would change the answer."""
+        from impulso.identification import MaxShare
+
+        _, _, posterior, L = _multi_lag_draw()
+        explicit = MaxShare(target="v1", band=(6, 32)).identify(L, ["v1", "v2", "v3"], posterior=posterior, n_lags=2)
+        inferred = MaxShare(target="v1", band=(6, 32)).identify(L, ["v1", "v2", "v3"], posterior=posterior)
+        np.testing.assert_array_equal(explicit, inferred)
 
 
 class TestMaxShareScreensAndDiagnostics:

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -893,3 +893,400 @@ class TestLongRunRestrictionMultipleLags:
         scheme = LongRunRestriction(ordering=["y1"], shock_names=["permanent"])
         with pytest.raises(ValueError, match="cover every variable"):
             scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=2)
+# ----------------------------------------------------------------------
+# MaxShare — frequency-band maximum-share identification (issue #145)
+# ----------------------------------------------------------------------
+
+
+def _posterior_with_B(B):
+    """Minimal posterior carrying only the lag coefficients."""
+    import xarray as xr
+
+    return xr.Dataset({"B": xr.DataArray(B, dims=["chain", "draw", "var", "coeff"])})
+
+
+def _stable_draw():
+    """One stable, non-diagonal VAR(1) draw with a correlated Sigma.
+
+    Deliberately different from `single_driver_2v`: here no shock explains
+    everything, so the maximiser is interior and worth checking against
+    brute force.
+    """
+    A1 = np.array([[0.6, 0.15], [0.1, 0.4]])
+    Sigma = np.array([[1.0, 0.3], [0.3, 0.7]])
+    L = np.linalg.cholesky(Sigma)
+    shape = (1, 1, 2, 2)
+    return (
+        A1,
+        Sigma,
+        _posterior_with_B(np.broadcast_to(A1, shape).copy()),
+        np.broadcast_to(L, shape).copy(),
+    )
+
+
+def _reference_band_form(A1: np.ndarray, L: np.ndarray, target: int, band: tuple[float, float]) -> np.ndarray:
+    """Independent, unvectorised build of `Re(M)` by trapezoid quadrature.
+
+    Deliberately shares no code with the implementation: it inverts
+    `F(w)` explicitly, takes the target row, and integrates on a dense
+    uniform grid. Used to check the eigen solution really is the
+    band-variance maximiser.
+    """
+    omega_lo = 0.0 if np.isinf(band[1]) else 2.0 * np.pi / band[1]
+    omega_hi = 2.0 * np.pi / band[0]
+    omegas = np.linspace(omega_lo, omega_hi, 4097)
+    integrand = []
+    for omega in omegas:
+        C = np.linalg.inv(np.eye(A1.shape[0]) - A1 * np.exp(-1j * omega))
+        row = C[target] @ L
+        integrand.append(np.conj(row)[:, np.newaxis] * row[np.newaxis, :])
+    return np.trapezoid(np.array(integrand), omegas, axis=0).real
+
+
+class TestMaxShare:
+    """Construction, validation and labelling."""
+
+    def test_defaults(self):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="gdp", band=(6, 32))
+        assert scheme.shock_name == "max_share"
+        assert scheme.n_frequencies == 192
+        assert scheme.on_undefined == "nan"
+        assert scheme.max_condition == 1e8
+
+    def test_frozen(self):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="gdp", band=(6, 32))
+        with pytest.raises(ValidationError):
+            scheme.target = "inflation"
+
+    def test_satisfies_protocol(self):
+        from impulso.identification import MaxShare
+
+        assert isinstance(MaxShare(target="gdp", band=(6, 32)), IdentificationScheme)
+
+    def test_band_below_nyquist_rejected(self):
+        from impulso.identification import MaxShare
+
+        with pytest.raises(ValidationError, match="periods of the sampling interval"):
+            MaxShare(target="gdp", band=(1.5, 32))
+
+    def test_band_reversed_rejected(self):
+        from impulso.identification import MaxShare
+
+        with pytest.raises(ValidationError, match="low_period < high_period"):
+            MaxShare(target="gdp", band=(32, 6))
+
+    def test_unbounded_upper_period_accepted(self):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="gdp", band=(32, float("inf")))
+        assert scheme._frequencies()[0] > 0.0
+
+    def test_infinite_lower_bound_rejected(self):
+        from impulso.identification import MaxShare
+
+        with pytest.raises(ValidationError, match="lower bound must be finite"):
+            MaxShare(target="gdp", band=(float("inf"), float("inf")))
+
+    def test_n_frequencies_floor(self):
+        from impulso.identification import MaxShare
+
+        with pytest.raises(ValidationError):
+            MaxShare(target="gdp", band=(6, 32), n_frequencies=8)
+
+    def test_reserved_shock_name_rejected(self):
+        from impulso.identification import MaxShare
+
+        with pytest.raises(ValidationError, match="reserved prefix"):
+            MaxShare(target="gdp", band=(6, 32), shock_name="unidentified_1")
+
+    def test_shock_coords_pad_with_unidentified(self):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="gdp", band=(6, 32))
+        assert scheme.shock_coords(3) == ["max_share", "unidentified_1", "unidentified_2"]
+
+    def test_identify_requires_posterior(self):
+        from impulso.identification import MaxShare
+
+        _, _, _, L = _stable_draw()
+        with pytest.raises(ValueError, match="requires the full posterior with 'B'"):
+            MaxShare(target="y1", band=(6, 32)).identify(L, ["y1", "y2"], posterior=None)
+
+    def test_identify_requires_B_in_posterior(self):
+        import xarray as xr
+
+        from impulso.identification import MaxShare
+
+        _, _, _, L = _stable_draw()
+        with pytest.raises(ValueError, match="requires the full posterior with 'B'"):
+            MaxShare(target="y1", band=(6, 32)).identify(L, ["y1", "y2"], posterior=xr.Dataset())
+
+    def test_unknown_target_lists_variables(self):
+        from impulso.identification import MaxShare
+
+        _, _, posterior, L = _stable_draw()
+        with pytest.raises(ValueError, match=r"\['y1', 'y2'\]"):
+            MaxShare(target="nope", band=(6, 32)).identify(L, ["y1", "y2"], posterior=posterior, n_lags=1)
+
+
+class TestMaxShareRecovery:
+    """Exact analytic recovery on a fixture with a known answer."""
+
+    def test_recovers_the_true_column(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="y2", band=(6, 32))
+        P = scheme.identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1
+        )
+        expected = np.broadcast_to(single_driver_2v["P_true"][:, 0], P[..., :, 0].shape)
+        np.testing.assert_allclose(P[..., :, 0], expected, atol=1e-8)
+
+    def test_share_is_one_and_not_degenerate(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="y2", band=(6, 32))
+        scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1)
+        assert scheme._last_diagnostics["max_share_share_median"] >= 1 - 1e-10
+        assert abs(scheme._last_diagnostics["max_share_eigen_ratio_median"]) < 1e-8
+
+    def test_band_invariance(self, single_driver_2v):
+        """One shock drives y2 at every frequency, so the band cannot matter."""
+        from impulso.identification import MaxShare
+
+        posterior = single_driver_2v["idata"].posterior
+        narrow = MaxShare(target="y2", band=(6, 32)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1
+        )
+        wide = MaxShare(target="y2", band=(2.5, 200)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1
+        )
+        np.testing.assert_allclose(narrow[..., :, 0], wide[..., :, 0], atol=1e-8)
+
+    def test_reproduces_sigma_and_stays_in_data_order(self, single_driver_2v):
+        """`P P' = Sigma` in the data's own coordinates — no hidden permutation."""
+        from impulso.identification import MaxShare
+
+        P = MaxShare(target="y2", band=(6, 32)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1
+        )
+        reconstructed = P @ np.swapaxes(P, -1, -2)
+        np.testing.assert_allclose(reconstructed, np.broadcast_to(single_driver_2v["Sigma"], P.shape), atol=1e-10)
+
+    def test_sign_convention_raises_the_target(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        P = MaxShare(target="y2", band=(6, 32)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1
+        )
+        assert (P[..., 1, 0] > 0).all()
+
+    def test_deterministic(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        posterior = single_driver_2v["idata"].posterior
+        first = MaxShare(target="y2", band=(6, 32)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1
+        )
+        second = MaxShare(target="y2", band=(6, 32)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1
+        )
+        np.testing.assert_array_equal(first, second)
+
+    def test_n_lags_inferred_from_B(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        P = MaxShare(target="y2", band=(6, 32)).identify(
+            single_driver_2v["L"], ["y1", "y2"], posterior=single_driver_2v["idata"].posterior
+        )
+        np.testing.assert_allclose(P[0, 0, :, 0], single_driver_2v["P_true"][:, 0], atol=1e-8)
+
+
+class TestMaxShareOptimality:
+    """The returned column really is the band-variance maximiser."""
+
+    def test_beats_every_rotation_on_a_dense_grid(self):
+        from impulso.identification import MaxShare
+
+        A1, _, posterior, L = _stable_draw()
+        band = (6.0, 32.0)
+        scheme = MaxShare(target="y1", band=band)
+        P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        M = _reference_band_form(A1, L[0, 0], target=0, band=band)
+        q = np.linalg.solve(L[0, 0], P[0, 0, :, 0])
+        q = q / np.linalg.norm(q)
+        achieved = q @ M @ q / np.trace(M)
+
+        theta = np.linspace(0.0, np.pi, 1024, endpoint=False)
+        candidates = np.stack([np.cos(theta), np.sin(theta)], axis=-1)
+        grid = np.einsum("ki,ij,kj->k", candidates, M, candidates) / np.trace(M)
+        assert achieved >= grid.max() - 1e-6
+
+    def test_reported_share_matches_independent_recomputation(self):
+        from impulso.identification import MaxShare
+
+        A1, _, posterior, L = _stable_draw()
+        band = (6.0, 32.0)
+        scheme = MaxShare(target="y1", band=band)
+        P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        M = _reference_band_form(A1, L[0, 0], target=0, band=band)
+        q = np.linalg.solve(L[0, 0], P[0, 0, :, 0])
+        q = q / np.linalg.norm(q)
+        assert scheme._last_diagnostics["max_share_share_median"] == pytest.approx(q @ M @ q / np.trace(M), abs=1e-5)
+
+
+class TestMaxShareParseval:
+    """The band share over the full spectrum is the infinite-horizon FEVD share."""
+
+    def test_full_band_share_equals_time_domain_share(self):
+        from impulso._ma import compute_ma_phi
+        from impulso.identification import MaxShare
+
+        _, _, posterior, L = _stable_draw()
+        scheme = MaxShare(target="y1", band=(2.0, float("inf")))
+        P = scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        Phi = compute_ma_phi([posterior["B"].values], 400)[0, 0]  # (H+1, n, n)
+        Theta = Phi @ P[0, 0]
+        time_domain = (Theta[:, 0, 0] ** 2).sum() / (Theta[:, 0, :] ** 2).sum()
+        assert scheme._last_diagnostics["max_share_share_median"] == pytest.approx(time_domain, abs=1e-6)
+
+
+class TestMaxShareScreensAndDiagnostics:
+    """Explosive draws, singular draws, memoisation and degeneracy."""
+
+    def test_explosive_draws_are_warned_but_kept(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        posterior = _posterior_with_B(np.broadcast_to(1.05 * np.eye(2), (2, 50, 2, 2)).copy())
+        scheme = MaxShare(target="y2", band=(6, 32))
+        with pytest.warns(UserWarning, match="explosive"):
+            P = scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        assert np.isfinite(P).all()
+        assert scheme._last_diagnostics["max_share_explosive_draws"] == 100.0
+        assert scheme._last_diagnostics["max_share_explosive_fraction"] == 1.0
+        assert scheme._last_diagnostics["max_share_singular_draws"] == 0.0
+
+    def test_singular_draws_are_blanked_and_counted(self, single_driver_2v):
+        """A unit-circle root at a period inside the band blanks that draw.
+
+        The midpoint grid never lands exactly on the root frequency, so
+        the worst in-band condition number is a few hundred rather than
+        infinite; `max_condition` is tightened accordingly.
+        """
+        from impulso.identification import MaxShare
+
+        B = np.broadcast_to(single_driver_2v["A1"], (2, 50, 2, 2)).copy()
+        phi = 2.0 * np.pi / 12.0  # period 12 lies inside band=(6, 32)
+        B[0, :5] = np.array([[np.cos(phi), -np.sin(phi)], [np.sin(phi), np.cos(phi)]])
+
+        scheme = MaxShare(target="y2", band=(6, 32), max_condition=100.0)
+        with pytest.warns(UserWarning, match="numerically undefined"):
+            P = scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=_posterior_with_B(B), n_lags=1)
+
+        assert np.isnan(P[0, :5]).all()
+        assert np.isfinite(P[0, 5:]).all()
+        assert np.isfinite(P[1]).all()
+        assert scheme._last_diagnostics["max_share_singular_draws"] == 5.0
+        assert scheme._last_diagnostics["max_share_singular_fraction"] == pytest.approx(0.05)
+        assert scheme._last_diagnostics["max_share_condition_max"] > 100.0
+
+    def test_on_undefined_raise(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        B = np.broadcast_to(single_driver_2v["A1"], (2, 50, 2, 2)).copy()
+        phi = 2.0 * np.pi / 12.0
+        B[0, :5] = np.array([[np.cos(phi), -np.sin(phi)], [np.sin(phi), np.cos(phi)]])
+
+        scheme = MaxShare(target="y2", band=(6, 32), max_condition=100.0, on_undefined="raise")
+        with pytest.raises(ValueError, match="numerically undefined"):
+            scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=_posterior_with_B(B), n_lags=1)
+
+    def test_second_identify_reuses_the_cache_and_stays_quiet(self, single_driver_2v):
+        """Under SV the pipeline calls identify() once per period."""
+        import warnings
+
+        from impulso.identification import MaxShare
+
+        posterior = _posterior_with_B(np.broadcast_to(1.05 * np.eye(2), (2, 50, 2, 2)).copy())
+        scheme = MaxShare(target="y2", band=(6, 32))
+        with pytest.warns(UserWarning, match="explosive"):
+            first = scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            second = scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        np.testing.assert_array_equal(first, second)
+
+    def test_weak_identification_is_warned(self, monkeypatch, single_driver_2v):
+        """A repeated top eigenvalue means the maximiser is a plane, not a ray."""
+        from impulso.identification import MaxShare
+
+        def flat_accumulator(self, posterior, n_lags, n_vars, target_index):
+            shape = posterior["B"].values.shape[:2]
+            return (
+                np.broadcast_to(np.eye(n_vars), (*shape, n_vars, n_vars)).copy(),
+                np.zeros(shape, dtype=bool),
+                np.zeros(shape),
+                np.ones(shape),
+            )
+
+        monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_accumulator)
+        scheme = MaxShare(target="y1", band=(6, 32))
+        identity = np.broadcast_to(np.eye(2), (2, 50, 2, 2)).copy()
+        with pytest.warns(UserWarning, match="weakly identified"):
+            scheme.identify(identity, ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1)
+        assert scheme._last_diagnostics["max_share_eigen_ratio_median"] == pytest.approx(1.0)
+
+    def test_diagnostics_keys_are_floats(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="y2", band=(6, 32))
+        scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1)
+        assert set(scheme._last_diagnostics) == {
+            "max_share_share_median",
+            "max_share_share_q05",
+            "max_share_share_q95",
+            "max_share_eigen_ratio_median",
+            "max_share_eigen_ratio_q95",
+            "max_share_singular_draws",
+            "max_share_singular_fraction",
+            "max_share_condition_max",
+            "max_share_explosive_draws",
+            "max_share_explosive_fraction",
+            "max_share_spectral_radius_median",
+            "max_share_spectral_radius_max",
+        }
+        assert all(isinstance(v, float) for v in scheme._last_diagnostics.values())
+
+    def test_per_draw_diagnostics(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        scheme = MaxShare(target="y2", band=(6, 32))
+        diagnostics = scheme.max_share_diagnostics(
+            single_driver_2v["L"], ["y1", "y2"], single_driver_2v["idata"].posterior
+        )
+        assert set(diagnostics) == {"share", "eigen_ratio", "spectral_radius", "condition_max"}
+        assert all(v.shape == (2, 50) for v in diagnostics.values())
+        np.testing.assert_allclose(diagnostics["share"], 1.0, atol=1e-10)
+        np.testing.assert_allclose(diagnostics["spectral_radius"], 0.5, atol=1e-12)
+        assert (diagnostics["condition_max"] > 1.0).all()
+
+    def test_per_draw_share_is_nan_for_blanked_draws(self, single_driver_2v):
+        from impulso.identification import MaxShare
+
+        B = np.broadcast_to(single_driver_2v["A1"], (2, 50, 2, 2)).copy()
+        phi = 2.0 * np.pi / 12.0
+        B[0, :5] = np.array([[np.cos(phi), -np.sin(phi)], [np.sin(phi), np.cos(phi)]])
+
+        scheme = MaxShare(target="y2", band=(6, 32), max_condition=100.0)
+        with pytest.warns(UserWarning, match="numerically undefined"):
+            diagnostics = scheme.max_share_diagnostics(single_driver_2v["L"], ["y1", "y2"], _posterior_with_B(B))
+        assert np.isnan(diagnostics["share"][0, :5]).all()
+        assert np.isfinite(diagnostics["share"][0, 5:]).all()

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -1316,6 +1316,23 @@ class TestMaxShareScreensAndDiagnostics:
             second = scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
         np.testing.assert_array_equal(first, second)
 
+    def test_cache_misses_once_the_posterior_is_collected(self, single_driver_2v):
+        """A collected posterior's address can be recycled, so a dead referent
+        must read as a miss rather than serving another posterior's sweep (#203)."""
+        from impulso.identification import MaxShare
+
+        B = np.broadcast_to(single_driver_2v["A1"], (2, 50, 2, 2)).copy()
+        scheme = MaxShare(target="y2", band=(6, 32))
+        posterior = _posterior_with_B(B)
+        scheme.identify(single_driver_2v["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
+        ref = weakref.ref(posterior)
+
+        del posterior
+        gc.collect()
+        assert ref() is None
+
+        assert scheme._spectral_cache.get(_posterior_with_B(B), (1, 1)) is _CACHE_MISS
+
     def test_weak_identification_is_warned(self, monkeypatch, single_driver_2v):
         """A repeated top eigenvalue means the maximiser is a plane, not a ray."""
         from impulso.identification import MaxShare

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -893,6 +893,8 @@ class TestLongRunRestrictionMultipleLags:
         scheme = LongRunRestriction(ordering=["y1"], shock_names=["permanent"])
         with pytest.raises(ValueError, match="cover every variable"):
             scheme.identify(L, ["y1", "y2"], posterior=posterior, n_lags=2)
+
+
 # ----------------------------------------------------------------------
 # MaxShare — frequency-band maximum-share identification (issue #145)
 # ----------------------------------------------------------------------

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -692,3 +692,99 @@ class TestLongRunRestrictionPipeline:
 
         assert np.isnan(contributions[0, :5]).all()
         assert not np.isnan(contributions[0, 5:]).any()
+
+
+@pytest.fixture
+def identified_max_share(single_driver_2v, var_data_2v):
+    """IdentifiedVAR over the exact-arithmetic max-share fixture."""
+    from impulso.identification import MaxShare
+    from impulso.volatility import Constant
+
+    fitted = FittedVAR(
+        idata=single_driver_2v["idata"],
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    return fitted.set_identification_strategy(MaxShare(target="y2", band=(6, 32)))
+
+
+class TestMaxSharePipeline:
+    """MaxShare through the FittedVAR -> IdentifiedVAR pipeline."""
+
+    def test_shock_matrix_labels_and_attrs(self, identified_max_share, single_driver_2v):
+        P = identified_max_share.shock_matrix()
+
+        assert P.dims == ("chain", "draw", "response", "shock")
+        assert list(P.coords["response"].values) == ["y1", "y2"]
+        assert list(P.coords["shock"].values) == ["max_share", "unidentified_1"]
+        expected = np.broadcast_to(single_driver_2v["P_true"][:, 0], P.values[..., :, 0].shape)
+        np.testing.assert_allclose(P.values[..., :, 0], expected, atol=1e-8)
+        assert P.attrs["max_share_share_median"] >= 1 - 1e-10
+        assert P.attrs["max_share_singular_draws"] == 0.0
+        assert "sign_restriction_acceptance_rate" not in P.attrs
+
+    def test_fevd_masks_the_unidentified_column(self, identified_max_share):
+        with pytest.warns(UserWarning, match="unidentified"):
+            fevd = identified_max_share.fevd(horizon=10)
+        shares = fevd.idata.posterior_predictive["fevd"].values
+
+        identified_col = shares[..., 0]
+        assert np.isfinite(identified_col).all()
+        assert ((identified_col >= 0.0) & (identified_col <= 1.0)).all()
+        assert np.isnan(shares[..., 1]).all()
+
+    def test_fevd_recovers_the_full_share_for_the_target(self, identified_max_share):
+        """The fixture's shock 0 drives y2 entirely, so its FEVD share is 1."""
+        with pytest.warns(UserWarning, match="unidentified"):
+            fevd = identified_max_share.fevd(horizon=20)
+        shares = fevd.idata.posterior_predictive["fevd"].values
+        np.testing.assert_allclose(shares[..., 1, 0], 1.0, atol=1e-10)
+
+    def test_fevd_keeps_nan_draws_nan(self, single_driver_2v, var_data_2v):
+        """A blanked draw must not surface as a clean 0.0 share."""
+        from impulso.identification import MaxShare
+        from impulso.volatility import Constant
+
+        idata = single_driver_2v["idata"].copy()
+        B = idata.posterior["B"].values.copy()
+        phi = 2.0 * np.pi / 12.0  # unit-circle root at a period inside the band
+        B[0, :5] = np.array([[np.cos(phi), -np.sin(phi)], [np.sin(phi), np.cos(phi)]])
+        idata.posterior["B"] = (("chain", "draw", "var", "coeff"), B)
+
+        fitted = FittedVAR(
+            idata=idata,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+        scheme = MaxShare(target="y2", band=(6, 32), max_condition=100.0)
+        identified = fitted.set_identification_strategy(scheme)
+        with pytest.warns(UserWarning, match="numerically undefined"):
+            fevd = identified.fevd(horizon=5)
+        shares = fevd.idata.posterior_predictive["fevd"].values
+
+        assert np.isnan(shares[0, :5, :, :, 0]).all()
+        assert np.isfinite(shares[0, 5:, :, :, 0]).all()
+
+    def test_historical_decomposition_collapses_the_remainder(self, identified_max_share, var_data_2v):
+        hd = identified_max_share.historical_decomposition()
+        contributions = hd.idata.posterior_predictive["hd"]
+
+        assert list(contributions.coords["shock"].values) == ["max_share", "unidentified_remainder"]
+        baseline = hd.idata.posterior_predictive["baseline"].values
+        reconstructed = contributions.values.sum(axis=-1) + baseline
+        expected = np.broadcast_to(var_data_2v.endog[1:], reconstructed.shape)
+        np.testing.assert_allclose(reconstructed, expected, atol=1e-8)
+
+    def test_impulse_response_shapes_and_labels(self, identified_max_share):
+        irf = identified_max_share.impulse_response(horizon=5)
+        da = irf.idata.posterior_predictive["irf"]
+
+        assert da.shape == (2, 50, 6, 2, 2)
+        assert list(da.coords["shock"].values) == ["max_share", "unidentified_1"]
+        assert list(da.coords["response"].values) == ["y1", "y2"]
+        impact = da.values[..., 0, :, 0]
+        np.testing.assert_allclose(impact, np.broadcast_to([0.3, 0.7], impact.shape), atol=1e-8)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -197,6 +197,7 @@ class TestIdentificationPublicAPI:
         import impulso
 
         assert "LongRunRestriction" in impulso.__all__
+
     def test_max_share_importable_from_impulso(self):
         from impulso import MaxShare
         from impulso.identification import MaxShare as Direct

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -197,3 +197,13 @@ class TestIdentificationPublicAPI:
         import impulso
 
         assert "LongRunRestriction" in impulso.__all__
+    def test_max_share_importable_from_impulso(self):
+        from impulso import MaxShare
+        from impulso.identification import MaxShare as Direct
+
+        assert MaxShare is Direct
+
+    def test_max_share_in_all(self):
+        import impulso
+
+        assert "MaxShare" in impulso.__all__

--- a/tests/test_sigma_from_cholesky.py
+++ b/tests/test_sigma_from_cholesky.py
@@ -180,3 +180,67 @@ class TestClarkReconstructionSingleHome:
             rng=np.random.default_rng(42),
         )
         np.testing.assert_array_equal(path_a, path_b)
+
+
+class TestCompanionSpectralRadius:
+    """companion_spectral_radius(A) = max |eig| of the companion matrix."""
+
+    def test_var1_is_the_lag_matrix_itself(self):
+        """With one lag the companion form is A_1, so the radii coincide."""
+        from impulso._linalg import companion_spectral_radius
+
+        A1 = np.array([[0.6, 0.15], [0.1, 0.4]])
+        expected = np.abs(np.linalg.eigvals(A1)).max()
+        result = companion_spectral_radius([np.broadcast_to(A1, (2, 5, 2, 2)).copy()])
+
+        assert result.shape == (2, 5)
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    def test_var2_matches_an_explicit_companion(self):
+        """Two lags: check against a hand-built companion matrix."""
+        from impulso._linalg import companion_spectral_radius
+
+        A1 = np.array([[0.5, 0.1], [0.2, 0.4]])
+        A2 = np.array([[0.1, 0.0], [0.05, -0.2]])
+        companion = np.block([[A1, A2], [np.eye(2), np.zeros((2, 2))]])
+        expected = np.abs(np.linalg.eigvals(companion)).max()
+
+        result = companion_spectral_radius([A1[np.newaxis], A2[np.newaxis]])
+        np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+    def test_detects_explosive_draws(self):
+        from impulso._linalg import companion_spectral_radius
+
+        A1 = np.stack([0.5 * np.eye(2), 1.05 * np.eye(2)])[np.newaxis]  # (1, 2, 2, 2)
+        np.testing.assert_allclose(companion_spectral_radius([A1]), [[0.5, 1.05]], rtol=1e-12)
+
+
+class TestHouseholderFromE1:
+    """householder_from_e1(q) is orthogonal with first column q."""
+
+    def test_first_column_is_q_and_matrix_is_orthogonal(self, rng):
+        from impulso._linalg import householder_from_e1
+
+        q = rng.standard_normal((3, 7, 4))
+        q /= np.linalg.norm(q, axis=-1, keepdims=True)
+        Q = householder_from_e1(q)
+
+        assert Q.shape == (3, 7, 4, 4)
+        np.testing.assert_allclose(Q[..., :, 0], q, atol=1e-12)
+        np.testing.assert_allclose(Q @ np.swapaxes(Q, -1, -2), np.broadcast_to(np.eye(4), Q.shape), atol=1e-12)
+
+    def test_maps_e1_to_q(self, rng):
+        from impulso._linalg import householder_from_e1
+
+        q = rng.standard_normal(5)
+        q /= np.linalg.norm(q)
+        e1 = np.zeros(5)
+        e1[0] = 1.0
+        np.testing.assert_allclose(householder_from_e1(q) @ e1, q, atol=1e-12)
+
+    def test_degenerate_q_equal_to_e1_returns_identity(self):
+        """`w` vanishes when q is already e1; the identity satisfies the contract."""
+        from impulso._linalg import householder_from_e1
+
+        e1 = np.array([1.0, 0.0, 0.0])
+        np.testing.assert_allclose(householder_from_e1(e1), np.eye(3), atol=1e-15)


### PR DESCRIPTION
## Summary

New **`MaxShare`** identification scheme: per posterior draw, find the structural shock explaining the largest share of a target variable's variance over a user-selected **frequency band**, returned through the standard `IdentifiedVAR` pipeline.

- **Math**: the band objective `M = ∫_B (C_i(e^{-iω})L)*(C_i(e^{-iω})L) dω` is Hermitian PSD; for real rotations the maximiser is the top eigenvector of `Re(M)` — *exact*, not an approximation (the two-sided band integral is `2·Re(M)`). Implemented via the factorisation `M = Lᵀ Re(K) L` where the frequency accumulator `K` depends only on the posterior coefficients — computed once and cached, so per-`L` work (including the stochastic-volatility per-period path) is a cheap batched eigendecomposition. Row extraction uses the plain-transpose solve `Fᵀx = eᵢ` (the subtlest point — independently re-derived and numerically confirmed by the reviewer).
- **User-facing convention**: `band=(low, high)` in *periods of the sampling interval* (business cycle = `(6, 32)` quarters; `high=inf` reaches the zero-frequency limit for low-frequency climate bands, safe under the midpoint quadrature which never evaluates ω=0). Nyquist-validated.
- **Partial identification done properly**: the single identified column (sign-normalised to a positive target impact) is completed to a full rotation via a Householder reflection; remaining shocks are labelled `unidentified_*`, flowing through the existing FEVD masking and historical-decomposition remainder collapse unchanged.
- **Failure separation** (following the #183 convention): numerically singular transfer functions at band frequencies are screened by condition number and NaN'd (or raise, via `on_undefined`); explosive draws warn-and-keep (the factorisation is exact; only the variance interpretation weakens). Diagnostics — achieved share quantiles, top-2 **eigenvalue-ratio** (weak-identification indicator, warned at >0.9), singular/explosive counts — ride `shock_matrix().attrs` and a public `max_share_diagnostics()`.
- Includes the same NaN-preserving FEVD `_shares` fix as PR #183 (copied byte-verbatim so the branches auto-merge; reviewer confirmed byte-equality). Docs: explanation section with labelled equations, a how-to with business-cycle and climate examples plus an explicit "variance dominance is not causal identification" admonition, reference entry, CONTEXT.md term, three bib entries.

Closes #145

## Review

Planned by a Fable-tier planning agent that verified the math numerically before design (exact analytic recovery; eigen-solution beating a 1024-point rotation grid; Parseval to 5e-16). Independently reviewed with the row-extraction identity and K-accumulator re-derived from scratch and validated on a VAR(2) against an 8193-point trapezoid reference with explicit inversion. Two mechanical P2s fixed in a follow-up commit — including new VAR(2) tests whose necessity was **mutation-verified**: a reversed lag-order bug invisible to the entire VAR(1) suite fails exactly the three new tests.

## Tests

+50 tests: exact analytic recovery on a single-driver DGP (share = 1.0, impact column recovered to machine precision, deliberately non-triangular so the test discriminates from Cholesky); brute-force optimality against an independent quadrature and a 200k-direction sphere sweep; Parseval/FEVD flow-through (frequency-domain share equals time-domain FEVD share to 1e-16); VAR(2) multi-lag pins; singular/explosive/weak-identification screens; full pipeline composition (IRF/FEVD/HD with `unidentified_*` handling); NaN-draw FEVD preservation.

`ruff` / `ty` / fast suite: all green (577 passed, 29 deselected). New docs content renders clean (the only docs-CI warnings are pre-existing stale stubs from other branches' builds, identical on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV