### PR TITLE
fix(data): reject duplicate and overlapping variable names in VARData

### DIFF
--- a/src/impulso/data.py
+++ b/src/impulso/data.py
@@ -1,5 +1,7 @@
 """VARData — validated, immutable data container for VAR models."""
 
+from collections import Counter
+from collections.abc import Iterable, Sequence
 from typing import Self
 
 import numpy as np
@@ -9,14 +11,31 @@ from pydantic import Field, model_validator
 from impulso._base import ImpulsoBaseModel
 
 
+def _duplicates(names: Iterable[str]) -> list[str]:
+    """Return the values appearing more than once, in first-appearance order."""
+    names = list(names)
+    counts = Counter(names)
+    return [name for name in dict.fromkeys(names) if counts[name] > 1]
+
+
+def _format_names(names: Sequence[str]) -> str:
+    """Render a name list for error messages."""
+    return ", ".join(repr(name) for name in names)
+
+
 class VARData(ImpulsoBaseModel):
     """Immutable, validated container for VAR estimation data.
 
+    Variable names must be unique. `endog_names` and `exog_names` are each
+    checked for internal duplicates, and the two must not share any name —
+    a single label cannot refer to both an endogenous and an exogenous column.
+
     Attributes:
         endog: Endogenous variable array of shape (T, n) where T >= 1 and n >= 2.
-        endog_names: Names for each endogenous variable.
+        endog_names: Names for each endogenous variable. Must be unique.
         exog: Optional exogenous variable array of shape (T, k).
         exog_names: Names for each exogenous variable. Required if exog is provided.
+            Must be unique and disjoint from `endog_names`.
         index: DatetimeIndex of length T.
     """
 
@@ -31,6 +50,7 @@ class VARData(ImpulsoBaseModel):
         t, n = self.endog.shape
         self._validate_shapes(t, n)
         self._validate_exog(t)
+        self._validate_unique_names()
         self._validate_finite()
         self._make_readonly()
         return self
@@ -53,6 +73,30 @@ class VARData(ImpulsoBaseModel):
                 raise ValueError(f"exog_names length {len(self.exog_names)} != exog columns {self.exog.shape[1]}")
         elif self.exog_names is not None:
             raise ValueError("exog_names provided without exog")
+
+    def _validate_unique_names(self) -> None:
+        endog_dupes = _duplicates(self.endog_names)
+        if endog_dupes:
+            raise ValueError(
+                f"endog_names must be unique, got duplicates: {_format_names(endog_dupes)}. "
+                "Rename the repeated columns (or drop the repeats) before constructing VARData — "
+                "duplicate names make variable selection, plotting, and result labelling ambiguous."
+            )
+        if self.exog_names is None:
+            return
+        exog_dupes = _duplicates(self.exog_names)
+        if exog_dupes:
+            raise ValueError(
+                f"exog_names must be unique, got duplicates: {_format_names(exog_dupes)}. "
+                "Rename the repeated columns (or drop the repeats) before constructing VARData."
+            )
+        endog_set = set(self.endog_names)
+        overlap = [name for name in self.exog_names if name in endog_set]
+        if overlap:
+            raise ValueError(
+                f"endog_names and exog_names must not overlap, got shared names: {_format_names(overlap)}. "
+                "A variable cannot be both endogenous and exogenous; rename one of the columns."
+            )
 
     def _validate_finite(self) -> None:
         if not np.isfinite(self.endog).all():
@@ -78,6 +122,11 @@ class VARData(ImpulsoBaseModel):
     ) -> Self:
         """Construct VARData from a pandas DataFrame.
 
+        Column names must be unique within `endog`, within `exog`, and across
+        the two — pandas silently widens the selection when a label is repeated
+        or when `df` itself carries duplicate column labels, which would produce
+        arrays that no longer match their names.
+
         Args:
             df: DataFrame with a DatetimeIndex.
             endog: Column names for endogenous variables.
@@ -89,6 +138,8 @@ class VARData(ImpulsoBaseModel):
         if not isinstance(df.index, pd.DatetimeIndex):
             raise TypeError(f"DataFrame must have a DatetimeIndex, got {type(df.index).__name__}")
 
+        cls._validate_df_columns(df, endog, exog)
+
         endog_arr = df[endog].to_numpy(dtype=np.float64)
         exog_arr = df[exog].to_numpy(dtype=np.float64) if exog is not None else None
 
@@ -99,3 +150,15 @@ class VARData(ImpulsoBaseModel):
             exog_names=exog,
             index=df.index,
         )
+
+    @staticmethod
+    def _validate_df_columns(df: pd.DataFrame, endog: list[str], exog: list[str] | None) -> None:
+        """Reject selections that pandas would silently widen into misaligned arrays."""
+        requested = [*endog, *(exog or [])]
+        df_dupes = _duplicates(name for name in df.columns if name in set(requested))
+        if df_dupes:
+            raise ValueError(
+                f"DataFrame has duplicate column labels for selected variables: {_format_names(df_dupes)}. "
+                "pandas returns every matching column, so the extracted array would not line up with its "
+                "names. De-duplicate the DataFrame columns before calling from_df."
+            )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -98,6 +98,87 @@ class TestVARDataValidation:
             )
 
 
+class TestVARDataNameUniqueness:
+    def test_rejects_duplicate_endog_names(self, sample_endog, sample_index):
+        with pytest.raises(ValueError, match=r"endog_names must be unique, got duplicates: 'gdp'"):
+            VARData(
+                endog=sample_endog,
+                endog_names=["gdp", "gdp", "rate"],
+                index=sample_index,
+            )
+
+    def test_duplicate_endog_message_lists_every_duplicate(self, sample_index, rng):
+        endog = rng.standard_normal((100, 4))
+        with pytest.raises(ValueError, match=r"duplicates: 'gdp', 'rate'"):
+            VARData(
+                endog=endog,
+                endog_names=["gdp", "rate", "gdp", "rate"],
+                index=sample_index,
+            )
+
+    def test_rejects_duplicate_exog_names(self, sample_endog, sample_index, endog_names, rng):
+        with pytest.raises(ValueError, match=r"exog_names must be unique, got duplicates: 'oil'"):
+            VARData(
+                endog=sample_endog,
+                endog_names=endog_names,
+                exog=rng.standard_normal((100, 2)),
+                exog_names=["oil", "oil"],
+                index=sample_index,
+            )
+
+    def test_rejects_endog_exog_overlap(self, sample_endog, sample_index, endog_names, rng):
+        with pytest.raises(ValueError, match=r"endog_names and exog_names must not overlap, got shared names: 'gdp'"):
+            VARData(
+                endog=sample_endog,
+                endog_names=endog_names,
+                exog=rng.standard_normal((100, 1)),
+                exog_names=[endog_names[0]],
+                index=sample_index,
+            )
+
+    def test_accepts_unique_names(self, sample_endog, sample_index, endog_names, rng):
+        data = VARData(
+            endog=sample_endog,
+            endog_names=endog_names,
+            exog=rng.standard_normal((100, 2)),
+            exog_names=["oil", "fx"],
+            index=sample_index,
+        )
+        assert data.endog_names == endog_names
+        assert data.exog_names == ["oil", "fx"]
+
+
+class TestVARDataFromDFNameUniqueness:
+    @staticmethod
+    def _frame(columns: list[str], rng) -> pd.DataFrame:
+        index = pd.date_range("2000-01-01", periods=100, freq="QS")
+        return pd.DataFrame(
+            rng.standard_normal((100, len(columns))),
+            columns=columns,
+            index=index,
+        )
+
+    def test_from_df_rejects_duplicated_endog_selection(self, rng):
+        df = self._frame(["gdp", "inflation", "rate"], rng)
+        with pytest.raises(ValueError, match=r"endog_names must be unique, got duplicates: 'gdp'"):
+            VARData.from_df(df, endog=["gdp", "gdp", "rate"])
+
+    def test_from_df_rejects_endog_exog_overlap(self, rng):
+        df = self._frame(["gdp", "inflation", "rate"], rng)
+        with pytest.raises(ValueError, match=r"must not overlap, got shared names: 'rate'"):
+            VARData.from_df(df, endog=["gdp", "inflation", "rate"], exog=["rate"])
+
+    def test_from_df_rejects_duplicate_dataframe_labels(self, rng):
+        df = self._frame(["gdp", "gdp", "rate"], rng)
+        with pytest.raises(ValueError, match=r"duplicate column labels for selected variables: 'gdp'"):
+            VARData.from_df(df, endog=["gdp", "rate"])
+
+    def test_from_df_ignores_duplicate_labels_outside_selection(self, rng):
+        df = self._frame(["gdp", "inflation", "rate", "rate"], rng)
+        data = VARData.from_df(df, endog=["gdp", "inflation"])
+        assert data.endog.shape == (100, 2)
+
+
 class TestVARDataFromDF:
     def test_from_df_endog_only(self):
         rng = np.random.default_rng(42)


### PR DESCRIPTION
## Summary

`VARData` validated only name *counts*, so duplicate `endog_names`, duplicate `exog_names`, or a label naming both an endogenous and an exogenous column all passed silently — making variable selection, plotting, result labelling, and the evidence sample-digest (PR #160) ambiguous. Now:

- `endog_names` and `exog_names` are each checked for internal duplicates, and their union must be disjoint; three distinct actionable errors name the offending labels in first-appearance order.
- `from_df` gains a guard for duplicated column labels *in the DataFrame itself* (pandas returns extra columns for a duplicated label, which previously surfaced as a misleading length-mismatch error); duplicate labels elsewhere in the frame are ignored.
- `SVData` verified unaffected (scalar `name`, no collection field).

Closes #162

## Tests

+9 tests: constructor-level rejection of each of the three cases, `from_df` duplicate-selection and duplicate-label paths, unique names still passing, and message content pinned. Fast suite: 536 passed, 29 deselected; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV