### PR TITLE
docs(reference): conjugate and volatility reference pages

### DIFF
--- a/docs/reference/conjugate.md
+++ b/docs/reference/conjugate.md
@@ -1,0 +1,52 @@
+# Conjugate VAR
+
+`ConjugateVAR` is the sibling estimator to `VAR`. It pairs a natural-conjugate
+Normal-Inverse-Wishart prior (`NIWPrior`) with the VAR likelihood, so the
+coefficient and covariance posterior is available in closed form and no PyMC
+model is ever built; Monte Carlo is reserved for the single low-dimensional
+Minnesota tightness hyperparameter, which the data selects by marginal
+likelihood {cite:p}`giannoneLenzaPrimiceri2015`. Prefer it over the
+NUTS-sampled `VAR` when the system is large, when the fit has to be repeated
+many times (rolling windows, real-time exercises), or when the closed-form
+marginal likelihood is itself the quantity of interest. Stay on `VAR` when you
+need per-equation own/cross shrinkage asymmetry, stochastic volatility, or a
+prior the conjugate Kronecker structure cannot express. Both paths return the
+same `FittedVAR`, so identification, impulse responses, variance
+decompositions, and forecasting behave identically downstream.
+
+Time-varying volatility on the conjugate path is deterministic rather than
+latent, which is what keeps the posterior closed-form. `ConjugateVolatility`
+is the adapter surface a conjugate fit attaches when the residual scale
+breaks: it reports a per-period multiplier `s_t` on a base Cholesky factor, so
+`Sigma_t = s_t**2 * Sigma_base`. `PandemicBreak` is the concrete adapter, the
+COVID-19 break of {cite:t}`lenzaPrimiceri2022` — free outbreak scales for
+March, April, and May 2020 followed by a geometric decay back toward the
+pre-break scale. The latent volatility processes used by the `VAR` path live
+on the [volatility](volatility.md) page.
+
+```{eval-rst}
+.. currentmodule:: impulso.conjugate
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   ConjugateVAR
+
+.. currentmodule:: impulso.priors
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   NIWPrior
+
+.. currentmodule:: impulso.conjugate_volatility
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   ConjugateVolatility
+   PandemicBreak
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,6 +9,8 @@ source docstrings by Sphinx autodoc.
 data
 spec
 priors
+conjugate
+volatility
 samplers
 fitted
 identified

--- a/docs/reference/volatility.md
+++ b/docs/reference/volatility.md
@@ -1,0 +1,37 @@
+# Volatility Processes
+
+The volatility argument to `VAR` is a seam: the model specification owns the
+conditional mean, and a volatility process owns the residual covariance. Every
+adapter implements the `VolatilityProcess` protocol on the
+[protocols](protocols.md) page, which is what lets downstream code reconstruct
+the Cholesky factor at a given period without knowing which process produced
+it. `Constant` is the homoscedastic default — one Σ shared across all
+periods, built from a HalfCauchy prior on the diagonal scales and a Normal
+prior on the lower-triangular off-diagonals. `StochasticVolatility` makes Σ_t
+time-varying by placing latent log-volatility dynamics (a random walk or an
+AR(1)) on each variable's scale; it doubles as a standalone univariate
+stochastic-volatility model with its own fit and forecast surface.
+
+Both adapters are sampled with PyMC, so they belong to the `VAR` path. The
+conjugate estimator cannot use them — a closed-form Normal-Inverse-Wishart
+posterior admits only a deterministic scale path — and rejects them at
+construction. Its deterministic counterparts, `ConjugateVolatility` and
+`PandemicBreak`, are documented on the [conjugate](conjugate.md) page.
+
+```{eval-rst}
+.. currentmodule:: impulso.volatility
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   Constant
+
+.. currentmodule:: impulso.sv.spec
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   StochasticVolatility
+```


### PR DESCRIPTION
## Summary

Two long-standing reference-page gaps, one PR:

- **`docs/reference/conjugate.md`** — `ConjugateVAR`, `NIWPrior`, `ConjugateVolatility`, `PandemicBreak`, with a lede covering the closed-form NIW estimator, when to prefer it over NUTS, and the volatility-break adapters ({cite} links to GLP 2015 / Lenza-Primiceri).
- **`docs/reference/volatility.md`** — `Constant` and `StochasticVolatility`, with the volatility-seam framing; links to (rather than duplicates) the `VolatilityProcess` entry already on the protocols page.
- Both registered in the reference toctree between `priors` and `samplers`.

Every `currentmodule` follows the established convention (defining public module, matching each object's `__module__`, so `sphinx-codeautolink` resolves tutorial references). Validated with a targeted Sphinx build of the three pages: all eight autosummary stubs generate, cross-page and bibliography links resolve, zero warnings attributable to the new pages.

Scope note: `SVData`/`FittedSV`/`SVDynamics`/`ProxySVAR` remain unreferenced — pre-existing, tracked separately (`ProxySVAR` is added by PR #183).

Closes #163
Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV