### PR TITLE
fix(identification): return the ordered Cholesky factor in data row order

### DIFF
--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -8,7 +8,7 @@ import xarray as xr
 from pydantic import Field, PrivateAttr
 
 from impulso._base import ImpulsoBaseModel, ImpulsoModel
-from impulso._linalg import lag_matrices, sigma_from_cholesky
+from impulso._linalg import lag_matrices
 from impulso._ma import compute_ma_phi
 
 if TYPE_CHECKING:
@@ -38,20 +38,33 @@ class Cholesky(ImpulsoModel):
     ) -> np.ndarray:
         """Apply Cholesky identification.
 
-        For default variable ordering, `identify` is a no-op and returns
-        `L` unchanged. When `self.ordering` differs from `var_names`,
-        the underlying covariance is permuted and re-decomposed so the
-        Cholesky factor reflects the requested causal ordering.
+        When `self.ordering` matches `var_names` this is a no-op and `L` is
+        returned unchanged. Otherwise the factor is re-derived so that it is
+        lower-triangular in the requested causal ordering, then written back
+        into the data's row order.
+
+        Concretely, with `Pi` the permutation sending data order to
+        `self.ordering`, the ordered factor is the LQ factor of `Pi @ L`:
+        `qr((Pi @ L).T) = Q @ R` gives `G = R.T` lower-triangular with
+        `G @ G.T = Pi @ Sigma @ Pi.T`. Columns are sign-fixed so `G` has a
+        positive diagonal, matching the textbook `cholesky(Pi Sigma Pi.T)`.
+        `Sigma` is never formed, so the conditioning of the decomposition is
+        not squared.
 
         Args:
-            L: Lower-triangular Cholesky factor, shape (chains, draws, n_vars, n_vars).
+            L: Lower-triangular Cholesky factor, shape (..., n_vars, n_vars).
             var_names: Variable names in the data's natural order.
             posterior: Unused. Accepted for Protocol uniformity.
             data: Unused. Accepted for Protocol uniformity.
             n_lags: Unused. Accepted for Protocol uniformity.
 
         Returns:
-            Structural shock matrix, shape (chains, draws, n_vars, n_vars).
+            Structural shock matrix, same shape as `L`. Rows follow
+            `var_names` (the data's order, matching the `response`
+            coordinate downstream); columns follow `shock_coords`, i.e.
+            `self.ordering`. Triangularity therefore holds in the *ordering*
+            row coordinates: permuting the rows by `self.ordering` recovers
+            an exactly lower-triangular factor with a positive diagonal.
         """
         del posterior, data, n_lags  # unused
 
@@ -59,12 +72,18 @@ class Cholesky(ImpulsoModel):
         if list(self.ordering) == list(var_names):
             return L
 
-        # Reordering: reconstruct Sigma, permute, re-decompose.
-        sigma = sigma_from_cholesky(L)
-        perm = [var_names.index(v) for v in self.ordering]
-        ix0, ix1 = np.ix_(perm, perm)
-        sigma_ordered = sigma[:, :, ix0, ix1]
-        return np.linalg.cholesky(sigma_ordered)
+        perm = np.array([var_names.index(v) for v in self.ordering])
+        inv = np.argsort(perm)
+
+        # (Pi L)(Pi L).T = Pi Sigma Pi.T, so any lower-triangular factor of
+        # Pi L is a Cholesky factor of the permuted covariance.
+        L_ord = L[..., perm, :]
+        _, R = np.linalg.qr(np.swapaxes(L_ord, -1, -2))
+        signs = np.sign(np.diagonal(R, axis1=-2, axis2=-1))
+        signs = np.where(signs == 0.0, 1.0, signs)
+        P_ord = np.swapaxes(R, -1, -2) * signs[..., np.newaxis, :]
+
+        return P_ord[..., inv, :]  # back to data row order
 
     def shock_coords(self, n_vars: int) -> list[str]:
         """Cholesky shock labels are simply the causal ordering."""

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -256,6 +256,61 @@ class TestCholeskyNewIdentify:
         # (3) It is a genuine re-decomposition, not a relabelled row swap of L.
         assert np.abs(P - L[..., perm, :]).max() > 1e-6
 
+    def test_matches_textbook_cholesky_of_permuted_sigma(self):
+        """Row-permuting the result reproduces `chol(Pi Sigma Pi')` exactly.
+
+        The QR/LQ construction never forms Sigma, so this pins it against the
+        textbook definition of the ordered Cholesky factor.
+        """
+        rng = np.random.default_rng(0)
+        n_chains, n_draws, n_vars = 2, 8, 3
+        sigma = np.zeros((n_chains, n_draws, n_vars, n_vars))
+        for c in range(n_chains):
+            for d in range(n_draws):
+                A = rng.standard_normal((n_vars, n_vars))
+                sigma[c, d] = A @ A.T + np.eye(n_vars)
+        L = np.linalg.cholesky(sigma)
+
+        var_names = ["a", "b", "c"]
+        ordering = ["c", "a", "b"]
+        perm = np.array([2, 0, 1])
+
+        P = Cholesky(ordering=ordering).identify(L, var_names)
+
+        ix0, ix1 = np.ix_(perm, perm)
+        expected = np.linalg.cholesky(sigma[:, :, ix0, ix1])
+        np.testing.assert_allclose(P[..., perm, :], expected, atol=1e-12)
+
+    def test_identify_is_deterministic(self, synthetic_idata_2v):
+        """Repeated calls return bit-identical output (no RNG in the path)."""
+        L = np.linalg.cholesky(synthetic_idata_2v.posterior["Sigma"].values)
+        scheme = Cholesky(ordering=["v1", "v0"])
+        first = scheme.identify(L, ["v0", "v1"])
+        second = scheme.identify(L, ["v0", "v1"])
+        assert np.array_equal(first, second)
+
+    def test_double_permutation_round_trips(self, synthetic_idata_2v):
+        """Reordering, then reordering back, recovers `L`.
+
+        Guards against transposing `perm` and its inverse: a swapped pair
+        happens to be self-inverse for a reversal, but the intermediate
+        ordering-coordinate factor would not round-trip.
+        """
+        L = np.linalg.cholesky(synthetic_idata_2v.posterior["Sigma"].values)
+        var_names = ["v0", "v1"]
+        reversed_names = ["v1", "v0"]
+        perm = np.array([1, 0])
+
+        # Forward: data order -> reversed ordering. Rows come back in data
+        # order, so permute into ordering coordinates to get a valid factor.
+        P = Cholesky(ordering=reversed_names).identify(L, var_names)
+        L_reversed_world = P[..., perm, :]
+
+        # Backward: treat the reversed world as the data order and ask for
+        # the original ordering. Undo the row permutation the same way.
+        Q = Cholesky(ordering=var_names).identify(L_reversed_world, reversed_names)
+        np.testing.assert_allclose(Q[..., perm, :], L, atol=1e-12)
+
 
 class TestSignRestrictionNewIdentify:
     def test_identify_returns_ndarray_no_horizon(self, synthetic_idata_2v):

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -222,7 +222,15 @@ class TestCholeskyNewIdentify:
         # With identity ordering, identify is a no-op — result equals L.
         np.testing.assert_array_equal(result, L)
 
-    def test_identify_reorders_when_ordering_differs(self, synthetic_idata_2v):
+    def test_reversed_ordering_returns_rows_in_data_order(self, synthetic_idata_2v):
+        """The returned matrix is row-indexed by `var_names`, not by `ordering`.
+
+        Downstream (`IdentifiedVAR.shock_matrix`) labels the row axis with
+        `var_names` and left-multiplies by MA coefficients built in data
+        order, so `identify` must return rows in **data** order while the
+        columns follow the causal `ordering`. Triangularity therefore holds
+        only after permuting rows into ordering coordinates.
+        """
         from impulso.identification import Cholesky
 
         sigma = synthetic_idata_2v.posterior["Sigma"].values
@@ -230,20 +238,23 @@ class TestCholeskyNewIdentify:
         var_names = ["v0", "v1"]
 
         scheme = Cholesky(ordering=["v1", "v0"])  # reverse ordering
-        result = scheme.identify(L, var_names)
+        P = scheme.identify(L, var_names)
 
-        # When ordering reverses, the scheme should re-decompose the
-        # row-permuted Sigma — the result is NOT just a row swap of L.
-        assert result.shape == L.shape
-        # Reconstruct: result @ result.T should equal P @ Sigma @ P.T
-        # where P is the permutation matrix.
+        assert P.shape == L.shape
+
+        # (1) P @ P.T reproduces Sigma in DATA coordinates.
+        np.testing.assert_allclose(np.einsum("cdij,cdkj->cdik", P, P), sigma, atol=1e-12)
+
+        # (2) Permuting rows into ordering coordinates gives an exactly
+        #     lower-triangular factor with a positive diagonal.
         perm = np.array([1, 0])
-        sigma_perm = sigma[:, :, np.ix_(perm, perm)[0], np.ix_(perm, perm)[1]]
-        np.testing.assert_allclose(
-            np.einsum("cdij,cdkj->cdik", result, result),
-            sigma_perm,
-            rtol=1e-6,
-        )
+        P_ord = P[..., perm, :]
+        assert np.triu(P_ord, 1).max() == 0.0
+        assert np.triu(P_ord, 1).min() == 0.0
+        assert np.diagonal(P_ord, axis1=-2, axis2=-1).min() > 0.0
+
+        # (3) It is a genuine re-decomposition, not a relabelled row swap of L.
+        assert np.abs(P - L[..., perm, :]).max() > 1e-6
 
 
 class TestSignRestrictionNewIdentify:

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -412,3 +412,114 @@ class TestHistoricalDecompositionAt:
             identified.historical_decomposition()
             identified.historical_decomposition(at=None)
             identified.historical_decomposition(at="all")
+
+
+class TestCholeskyOrderingLabels:
+    """A non-identity Cholesky ordering must stay label-consistent end to end.
+
+    `Cholesky.identify` returns rows in **data** order and columns in
+    **ordering** order; `shock_matrix` labels them `var_names` / `shock_names`
+    and `impulse_response` left-multiplies by MA coefficients built in data
+    order. If `identify` returned rows in ordering order instead, the labels
+    would be permuted and `Phi @ P` would mix coordinate systems. Regression
+    for #184.
+    """
+
+    @staticmethod
+    def _permuted_idata(synthetic_idata_2v, perm):
+        """Relabel the 2-var VAR(1) posterior into `perm` variable order.
+
+        Sigma -> Pi Sigma Pi', B -> Pi B Pi' (single lag), intercept -> Pi c.
+        This is the *same* model written in a different variable order, so
+        every label-indexed quantity must be invariant to it.
+        """
+        post = synthetic_idata_2v.posterior
+        ix0, ix1 = np.ix_(perm, perm)
+
+        sigma = post["Sigma"].values[:, :, ix0, ix1]
+        B = post["B"].values[:, :, ix0, ix1]  # n_lags == 1, so B is (C, D, n, n)
+        intercept = post["intercept"].values[:, :, perm]
+        L = np.linalg.cholesky(sigma)
+
+        names = [["y1", "y2"][i] for i in perm]
+        return az.InferenceData(
+            posterior=xr.Dataset({
+                "B": xr.DataArray(B, dims=["chain", "draw", "var", "coeff"]),
+                "intercept": xr.DataArray(intercept, dims=["chain", "draw", "var"]),
+                "Sigma": xr.DataArray(
+                    sigma,
+                    dims=["chain", "draw", "var1", "var2"],
+                    coords={"var1": names, "var2": names},
+                ),
+                "L": xr.DataArray(L, dims=["chain", "draw", "var1", "var2"]),
+            })
+        )
+
+    @staticmethod
+    def _identified(idata, var_data_2v, var_names, ordering):
+        from impulso.volatility import Constant
+
+        return IdentifiedVAR.model_construct(
+            idata=idata,
+            n_lags=1,
+            data=var_data_2v,
+            var_names=var_names,
+            volatility=Constant(),
+            scheme=Cholesky(ordering=ordering),
+        )
+
+    def test_shock_matrix_zero_lands_in_the_labelled_cell(self, synthetic_idata_2v, var_data_2v):
+        """With ordering ["y2","y1"], y2 is most exogenous: y2 cannot respond to a y1 shock."""
+        identified = self._identified(synthetic_idata_2v, var_data_2v, ["y1", "y2"], ["y2", "y1"])
+        sm = identified.shock_matrix()
+
+        assert list(sm.coords["response"].values) == ["y1", "y2"]
+        assert list(sm.coords["shock"].values) == ["y2", "y1"]
+
+        # The structural zero belongs to (response=y2, shock=y1) — exactly.
+        assert np.abs(sm.sel(response="y2", shock="y1").values).max() == 0.0
+        # ...and the transposed cell must be non-zero for every draw.
+        assert np.abs(sm.sel(response="y1", shock="y2").values).min() > 0.0
+
+    def test_irf_labels_invariant_to_relabelling(self, synthetic_idata_2v, var_data_2v):
+        """IRFs indexed by (response, shock) labels are invariant to variable order."""
+        perm = np.array([1, 0])
+        sigma = synthetic_idata_2v.posterior["Sigma"].values
+        # Guard: the two variables must be distinguishable, otherwise the
+        # assertion below could pass through symmetry rather than correctness.
+        assert np.abs(sigma[..., 0, 0] - sigma[..., 1, 1]).max() > 0.1
+
+        # (A) Data already in ["y2","y1"] order, identity Cholesky ordering.
+        a = self._identified(self._permuted_idata(synthetic_idata_2v, perm), var_data_2v, ["y2", "y1"], ["y2", "y1"])
+        # (B) Data in ["y1","y2"] order, non-identity Cholesky ordering.
+        b = self._identified(synthetic_idata_2v, var_data_2v, ["y1", "y2"], ["y2", "y1"])
+
+        irf_a = a.impulse_response(horizon=6).idata.posterior_predictive["irf"]
+        irf_b = b.impulse_response(horizon=6).idata.posterior_predictive["irf"]
+
+        for response in ("y1", "y2"):
+            for shock in ("y1", "y2"):
+                np.testing.assert_allclose(
+                    irf_a.sel(response=response, shock=shock).values,
+                    irf_b.sel(response=response, shock=shock).values,
+                    atol=1e-10,
+                    err_msg=f"IRF(response={response}, shock={shock}) is order-dependent",
+                )
+
+    def test_fevd_shares_match_under_relabelling(self, synthetic_idata_2v, var_data_2v):
+        """FEVD squares Theta, so it catches mislabelling that sign flips would hide."""
+        perm = np.array([1, 0])
+        a = self._identified(self._permuted_idata(synthetic_idata_2v, perm), var_data_2v, ["y2", "y1"], ["y2", "y1"])
+        b = self._identified(synthetic_idata_2v, var_data_2v, ["y1", "y2"], ["y2", "y1"])
+
+        fevd_a = a.fevd(horizon=6).idata.posterior_predictive["fevd"]
+        fevd_b = b.fevd(horizon=6).idata.posterior_predictive["fevd"]
+
+        for response in ("y1", "y2"):
+            for shock in ("y1", "y2"):
+                np.testing.assert_allclose(
+                    fevd_a.sel(response=response, shock=shock).values,
+                    fevd_b.sel(response=response, shock=shock).values,
+                    atol=1e-10,
+                    err_msg=f"FEVD(response={response}, shock={shock}) is order-dependent",
+                )


### PR DESCRIPTION
## Summary

Fixes the P1 mislabelling bug #184 and implements #81's QR-based reordering in the same eight lines.

**The bug**: `IdentifiedVAR.shock_matrix` labels response rows with `var_names` (data order) and multiplies by MA coefficients built in data order — for every scheme. `Cholesky.identify` with a non-identity `ordering` returned `chol(ΠΣΠ')` with rows left in *ordering* order: mislabelled response rows and a mixed-coordinate `Φ @ P` product in IRF/FEVD/HD. The red-first proof is in the test commit — pre-fix, the structural zero sat at 2.04 in the cell its labels claimed, and reconstructed variances were transposed between variables.

**The fix (#81's construction)**: the permuted factor is now obtained by LQ-via-QR of the row-permuted factor — `qr((ΠL)')` gives `G = R'` with `GG' = ΠΣΠ'` exactly, sign-fixed to a positive diagonal, then un-permuted back to data row order. Σ is never formed, so input conditioning is not squared (verified at cond 1.4e12: max relative error 1.5e-16, structural zeros *exactly* zero), and one batched decomposition per call is saved. Columns stay in `ordering` order, matching `shock_coords` — the contract is now stated at both the producer and consumer ends.

**Breaking (pre-v0.1)**: any analysis using a custom `Cholesky(ordering=...)` will produce different — previously mislabelled — numbers. Identity orderings are byte-identical (fast path returns `L` unchanged; the pinned IRF/FEVD/HD regression file is untouched and green). A side effect worth knowing: rank-deficient input now yields a zero diagonal instead of `LinAlgError` — unreachable through the pipeline (volatility adapters always produce valid factors), accepted deliberately.

Notable blast radius: the monetary-policy tutorial's prose ("orderings A and B give identical policy IRFs") was *false* in the rendered notebook and becomes true on the next render — no docs edit needed.

Fixes #184
Closes #81

## Review

Independently reviewed (verdict: approve, zero findings): the LQ construction re-derived from scratch, column-vs-row sign scaling explicitly discriminated numerically (row-scaling error 5.3 vs column 1.8e-15), a non-involution 4-cycle permutation stress-tested beyond the committed tests, and test discrimination *proven* by monkeypatching the old implementation back in — all six behavioural tests go red while the pin file stays green under both implementations.

## Merge note

Lands cleanly before #183 (feat/143) — the only contact point is the `_linalg` import line (mechanical rebase; `sigma_from_cholesky` remains used by `fitted.py`).

`ruff` / `ty` / fast suite: all green (533 passed, 29 deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV