### PR TITLE
test: real protocol assertions and an exercised enable_runtime_checks

### DIFF
--- a/src/impulso/__init__.py
+++ b/src/impulso/__init__.py
@@ -7,6 +7,8 @@ from impulso.data import VARData
 from impulso.spec import VAR
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from impulso._linalg import lag_matrices
     from impulso._ma import compute_ma_phi
     from impulso.conjugate import ConjugateVAR
@@ -144,6 +146,47 @@ def __dir__() -> list[str]:
     return sorted(set(globals()) | set(__all__))
 
 
+def _bind_deferred_imports(module: "ModuleType") -> None:
+    """Materialise a module's `if TYPE_CHECKING:` imports for real.
+
+    Beartype resolves stringified annotations (e.g. `-> "ForecastResult"`,
+    `posterior: "xr.Dataset"`) against the defining module's namespace when
+    the wrapped method is *called*. Names imported only under `TYPE_CHECKING`
+    are absent from that namespace, so every such call would raise
+    `BeartypeCallHintForwardRefException`. Binding them for real keeps those
+    annotations resolvable; the extra import cost is acceptable because
+    runtime checking is opt-in and intended for test suites.
+
+    Args:
+        module: Module whose deferred imports should be bound.
+    """
+    import ast
+    import contextlib
+    import importlib
+    import inspect
+
+    def _is_type_checking(test: ast.expr) -> bool:
+        return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+            isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+        )
+
+    with contextlib.suppress(OSError, TypeError, SyntaxError):
+        tree = ast.parse(inspect.getsource(module))
+        for node in tree.body:
+            if not (isinstance(node, ast.If) and _is_type_checking(node.test)):
+                continue
+            for stmt in node.body:
+                if isinstance(stmt, ast.Import):
+                    for alias in stmt.names:
+                        # `import a.b as ab` binds the submodule; `import a.b` binds `a`.
+                        imported = alias.name if alias.asname else alias.name.split(".")[0]
+                        setattr(module, alias.asname or imported, importlib.import_module(imported))
+                elif isinstance(stmt, ast.ImportFrom) and stmt.module and not stmt.level:
+                    source = importlib.import_module(stmt.module)
+                    for alias in stmt.names:
+                        setattr(module, alias.asname or alias.name, getattr(source, alias.name))
+
+
 def enable_runtime_checks() -> None:
     """Enable beartype runtime type checking on public API.
 
@@ -174,8 +217,12 @@ def enable_runtime_checks() -> None:
         impulso.sv.fitted,
         impulso.sv.priors,
     ]:
+        _bind_deferred_imports(mod)
         for name in dir(mod):
             obj = getattr(mod, name)
-            if isinstance(obj, type):
+            # Only classes *defined* here: `dir(mod)` also surfaces imported
+            # names (typing.Protocol, impulso.volatility.Constant, ...), and
+            # wrapping those would mutate classes the module does not own.
+            if isinstance(obj, type) and getattr(obj, "__module__", None) == mod.__name__:
                 with contextlib.suppress(BeartypeDecorHintPep484585Exception):
                     setattr(mod, name, beartype(obj))

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,39 +1,119 @@
-"""Tests for protocol definitions."""
+"""Tests for protocol definitions.
 
-from typing import runtime_checkable
+Two properties are pinned for every Protocol: the exact set of members it
+declares (`get_protocol_members`, which works on 3.11 where the stdlib
+`__protocol_attrs__` attribute does not yet exist), and that `isinstance`
+discriminates a conforming stub from a non-conforming one. The `isinstance`
+calls double as the runtime-checkability assertion — `isinstance` against a
+Protocol raises `TypeError` unless it is decorated `@runtime_checkable`.
+"""
 
-from typing_extensions import get_protocol_members
+from typing_extensions import get_protocol_members, is_protocol
 
 from impulso.protocols import IdentificationScheme, Prior, PyMCVolatilityProcess, Sampler, VolatilityProcess
 
 
+class _ConformingPrior:
+    def build_priors(self, n_vars, n_lags):
+        return {}
+
+
+class _ConformingSampler:
+    def sample(self, model):
+        return None
+
+
+class _ConformingScheme:
+    def identify(self, L, var_names, posterior=None, data=None, n_lags=None):
+        return L
+
+    def shock_coords(self, n_vars):
+        return []
+
+
+class _ConformingVolatility:
+    name = "stub"
+    is_time_varying = False
+
+    def cholesky_at(self, posterior, t):
+        return None
+
+    def cholesky_path(self, posterior, T):
+        return None
+
+    def forecast_cholesky_path(self, posterior, steps, rng):
+        return None
+
+
+class _ConformingPyMCVolatility(_ConformingVolatility):
+    def build_pymc_latent(self, n_vars, T, data=None):
+        return None
+
+
+class _Empty:
+    """Implements nothing — the negative case for every protocol."""
+
+
 class TestProtocols:
-    def test_prior_is_runtime_checkable(self):
-        assert hasattr(Prior, "__protocol_attrs__") or runtime_checkable
+    def test_prior_declares_build_priors(self):
+        assert is_protocol(Prior)
+        assert get_protocol_members(Prior) == frozenset({"build_priors"})
 
-    def test_sampler_is_runtime_checkable(self):
-        assert hasattr(Sampler, "__protocol_attrs__") or runtime_checkable
+    def test_prior_isinstance_discriminates(self):
+        assert isinstance(_ConformingPrior(), Prior)
+        assert not isinstance(_Empty(), Prior)
 
-    def test_identification_is_runtime_checkable(self):
-        assert hasattr(IdentificationScheme, "__protocol_attrs__") or runtime_checkable
+    def test_sampler_declares_sample(self):
+        assert is_protocol(Sampler)
+        assert get_protocol_members(Sampler) == frozenset({"sample"})
+
+    def test_sampler_isinstance_discriminates(self):
+        assert isinstance(_ConformingSampler(), Sampler)
+        assert not isinstance(_Empty(), Sampler)
+
+    def test_identification_declares_identify_and_shock_coords(self):
+        assert is_protocol(IdentificationScheme)
+        assert get_protocol_members(IdentificationScheme) == frozenset({"identify", "shock_coords"})
+
+    def test_identification_isinstance_discriminates(self):
+        assert isinstance(_ConformingScheme(), IdentificationScheme)
+        assert not isinstance(_Empty(), IdentificationScheme)
+        assert not isinstance(_ConformingPrior(), IdentificationScheme)
 
 
 class TestVolatilityProcess:
-    def test_volatility_process_is_runtime_checkable(self):
-        assert hasattr(VolatilityProcess, "__protocol_attrs__") or runtime_checkable
-
     def test_volatility_process_declares_query_surface(self):
         # Query surface only — the PyMC builder lives on the sub-protocol.
-        attrs = set(get_protocol_members(VolatilityProcess))
-        assert {"cholesky_at", "cholesky_path", "forecast_cholesky_path"} <= attrs
-        assert "build_pymc_latent" not in attrs
+        assert is_protocol(VolatilityProcess)
+        assert get_protocol_members(VolatilityProcess) == frozenset({
+            "name",
+            "is_time_varying",
+            "cholesky_at",
+            "cholesky_path",
+            "forecast_cholesky_path",
+        })
+
+    def test_volatility_process_isinstance_discriminates(self):
+        assert isinstance(_ConformingVolatility(), VolatilityProcess)
+        assert not isinstance(_Empty(), VolatilityProcess)
 
     def test_pymc_volatility_process_adds_builder(self):
         # Sub-protocol extends the query surface with build_pymc_latent.
-        assert hasattr(PyMCVolatilityProcess, "__protocol_attrs__") or runtime_checkable
-        attrs = set(get_protocol_members(PyMCVolatilityProcess))
-        assert "build_pymc_latent" in attrs
-        assert {"cholesky_at", "cholesky_path", "forecast_cholesky_path"} <= attrs
+        assert is_protocol(PyMCVolatilityProcess)
+        assert get_protocol_members(PyMCVolatilityProcess) == frozenset({
+            "name",
+            "is_time_varying",
+            "cholesky_at",
+            "cholesky_path",
+            "forecast_cholesky_path",
+            "build_pymc_latent",
+        })
+
+    def test_pymc_volatility_process_isinstance_discriminates(self):
+        assert isinstance(_ConformingPyMCVolatility(), PyMCVolatilityProcess)
+        # Query-only adapters satisfy the parent protocol but not the sub-protocol.
+        assert isinstance(_ConformingVolatility(), VolatilityProcess)
+        assert not isinstance(_ConformingVolatility(), PyMCVolatilityProcess)
 
 
 class TestIdentificationSchemeNewSignature:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,81 @@
 """Tests for public API re-exports."""
 
+import subprocess
+import sys
+
+# Driven in a fresh interpreter: enable_runtime_checks() mutates the library's
+# classes in place, so the beartype wrapping must not leak into the rest of the
+# suite. No MCMC — the posterior is synthetic.
+_RUNTIME_CHECKS_SCRIPT = """
+import arviz as az
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+import impulso
+
+impulso.enable_runtime_checks()
+
+import impulso.fitted
+import impulso.results
+import impulso.sv.spec
+from beartype.roar import BeartypeCallHintViolation
+from impulso import VAR, VARData
+from impulso.fitted import FittedVAR
+from impulso.identification import Cholesky
+from impulso.volatility import Constant
+
+# TYPE_CHECKING-only annotations must be resolvable once checks are on:
+# beartype resolves them against the defining module at call time.
+assert impulso.fitted.ForecastResult is impulso.results.ForecastResult
+assert impulso.sv.spec.xr is xr
+
+rng = np.random.default_rng(0)
+index = pd.date_range("2000-01-01", periods=30, freq="QS")
+frame = pd.DataFrame(rng.standard_normal((30, 2)) * 0.1, columns=["y1", "y2"], index=index)
+
+data = VARData.from_df(frame, endog=["y1", "y2"])
+assert data.endog.shape == (30, 2)
+assert VAR(lags=1).lags == 1
+
+n_chains, n_draws, n_vars = 2, 5, 2
+B = rng.standard_normal((n_chains, n_draws, n_vars, n_vars)) * 0.2
+intercept = rng.standard_normal((n_chains, n_draws, n_vars)) * 0.01
+L = np.zeros((n_chains, n_draws, n_vars, n_vars))
+for c in range(n_chains):
+    for d in range(n_draws):
+        A = rng.standard_normal((n_vars, n_vars)) * 0.3
+        L[c, d] = np.linalg.cholesky(A @ A.T + np.eye(n_vars))
+posterior = xr.Dataset({
+    "B": xr.DataArray(B, dims=["chain", "draw", "var", "coeff"]),
+    "intercept": xr.DataArray(intercept, dims=["chain", "draw", "var"]),
+    "L": xr.DataArray(L, dims=["chain", "draw", "var1", "var2"]),
+})
+
+fitted = FittedVAR(
+    idata=az.InferenceData(posterior=posterior),
+    n_lags=1,
+    data=data,
+    var_names=["y1", "y2"],
+    volatility=Constant(),
+)
+assert fitted.sigma().shape == (n_chains, n_draws, n_vars, n_vars)
+# Return annotations below are TYPE_CHECKING-only forward refs
+# ("ForecastResult", "IdentifiedVAR"), which beartype resolves on call.
+assert type(fitted.forecast(steps=2, seed=0)).__name__ == "ForecastResult"
+identified = fitted.set_identification_strategy(Cholesky(ordering=["y1", "y2"]))
+assert type(identified).__name__ == "IdentifiedVAR"
+assert type(identified.impulse_response(horizon=2)).__name__ == "IRFResult"
+print("HAPPY_PATH_OK")
+
+try:
+    fitted.forecast(steps="two")
+except BeartypeCallHintViolation:
+    print("VIOLATION_CAUGHT")
+else:
+    raise AssertionError("beartype did not flag steps='two'")
+"""
+
 
 class TestPublicAPI:
     def test_var_importable(self):
@@ -21,6 +97,21 @@ class TestPublicAPI:
         from impulso import enable_runtime_checks
 
         assert callable(enable_runtime_checks)
+
+
+class TestRuntimeChecks:
+    def test_enable_runtime_checks_drives_pipeline(self):
+        """Checks-on run of a synthetic pipeline, in a throwaway interpreter."""
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", _RUNTIME_CHECKS_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        assert "HAPPY_PATH_OK" in result.stdout, result.stdout
+        assert "VIOLATION_CAUGHT" in result.stdout, result.stdout
 
 
 class TestVolatilityPublicAPI:


### PR DESCRIPTION
## Summary

Two test-infrastructure issues, one PR — and the new test immediately earned its keep by surfacing two real defects.

- **#174**: five always-true assertions in `tests/test_protocols.py` (`assert hasattr(P, "__protocol_attrs__") or runtime_checkable` — the second operand is a truthy function object) replaced with real ones: `typing_extensions.is_protocol` + exact `get_protocol_members` sets per protocol (py3.11-verified — stdlib `__protocol_attrs__` is 3.12+), plus conforming/non-conforming stub `isinstance` checks that genuinely pin runtime-checkability.
- **#181**: `enable_runtime_checks()` was only ever asserted callable. A new subprocess test enables it in a fresh interpreter, drives a full synthetic pipeline (`VARData → VAR → FittedVAR → sigma/forecast → IdentifiedVAR → IRF`), and asserts a `BeartypeCallHintViolation` actually fires for a mistyped call. **It failed immediately, exposing two pre-existing defects that made the feature unusable** (exactly as the #176 review predicted):
  1. Beartype resolves stringified annotations (`-> "ForecastResult"`, `"xr.Dataset"`) against the defining module *at call time*, and every such name was `TYPE_CHECKING`-only → `BeartypeCallHintForwardRefException` on first use. Fixed with `_bind_deferred_imports()` — AST-parses each wrapped module's `if TYPE_CHECKING:` block and binds the imports for real (no `exec`), including dotted aliases.
  2. The wrap loop decorated every class in `dir(mod)` — including `typing.Protocol` and classes owned by *other* modules (`Constant` reached through `spec`), mutating shared state. Fixed with a `__module__ == mod.__name__` ownership guard.

Test teeth verified: with the src fix stashed, the subprocess test fails with the original forward-ref error.

Closes #174
Closes #181

## Gates

`ruff` / `ty` / fast suite green (532 passed, 29 deselected); the rewritten protocol file passes standalone under Python 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV