### PR TITLE
fix(stationarity): re-emit non-target KPSS warnings; define p in the Johansen snippet

### DIFF
--- a/docs/how-to/climate-pitfalls.md
+++ b/docs/how-to/climate-pitfalls.md
@@ -117,8 +117,9 @@ cointegrated, and the cointegrating relationship is the physically meaningful
 part.
 
 ```python
-from impulso import johansen_test
+from impulso import select_lag_order, johansen_test
 
+p = select_lag_order(data, max_lags=8).bic
 result = johansen_test(data, det_order=0, k_ar_diff=p - 1)
 result.rank
 ```

--- a/src/impulso/_stationarity.py
+++ b/src/impulso/_stationarity.py
@@ -187,12 +187,24 @@ def _kpss_single(
     alpha = 0.01 and always rejects above 0.10. Comparing against the
     critical value is the published test, and agrees with the p-value rule
     everywhere inside that range.
+
+    The clip is detected by catching statsmodels' `InterpolationWarning`, which
+    is absorbed into `pvalue_bounded`. Every other warning raised inside the
+    call is re-emitted unchanged, so nothing else is hidden from the caller.
     """
     kpss, interpolation_warning = _kpss()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         stat, pvalue, used_lag, crit = kpss(x, regression=regression, nlags=nlags)
     bounded = any(issubclass(w.category, interpolation_warning) for w in caught)
+    # The interpolation warning is the only one we absorb — it is reported as
+    # `pvalue_bounded` instead. Anything else statsmodels raised is the
+    # caller's business, so re-emit it outside the recorder with its original
+    # category, message, and provenance (the statsmodels file and line that
+    # raised it), which keeps module-scoped warning filters working.
+    for w in caught:
+        if not issubclass(w.category, interpolation_warning):
+            warnings.warn_explicit(w.message, w.category, w.filename, w.lineno, source=w.source)
     reject = bool(stat > crit[_KPSS_CRIT_KEY[alpha]])
     return {
         "statistic": float(stat),

--- a/tests/test_stationarity.py
+++ b/tests/test_stationarity.py
@@ -563,6 +563,30 @@ def test_kpss_flags_bounded_pvalue_without_leaking_a_warning(i2_series):
     assert row["pvalue"] == pytest.approx(0.01)
 
 
+def test_kpss_reemits_warnings_it_did_not_ask_for(monkeypatch, stationary_series):
+    """Only the interpolation warning is absorbed; anything else reaches the caller."""
+    import statsmodels.tsa.stattools as stattools
+    from statsmodels.tools.sm_exceptions import InterpolationWarning
+
+    def fake_kpss(x, regression="c", nlags="auto"):
+        warnings.warn("p-value is smaller than the indicated p-value", InterpolationWarning, stacklevel=2)
+        warnings.warn("invalid value encountered in scalar divide", RuntimeWarning, stacklevel=2)
+        return 1.5, 0.01, 7, {"10%": 0.347, "5%": 0.463, "2.5%": 0.574, "1%": 0.739}
+
+    monkeypatch.setattr(stattools, "kpss", fake_kpss)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = kpss_test(stationary_series)
+
+    assert not any(issubclass(w.category, InterpolationWarning) for w in caught)
+    escaped = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert len(escaped) == 1
+    assert str(escaped[0].message) == "invalid value encountered in scalar divide"
+    # Absorbing the interpolation warning is what the column is for.
+    assert bool(result.table.loc["ar1", "pvalue_bounded"])
+
+
 def test_integration_order_does_not_leak_warnings(mixed_frame):
     with warnings.catch_warnings():
         warnings.simplefilter("error")


### PR DESCRIPTION
## Summary

Two follow-ups on the stationarity branch (#197), stacked on `feat/140-stationarity-diagnostics`:

- **#198**: `_kpss_single` recorded all warnings while catching statsmodels' `InterpolationWarning` and re-emitted none — an unrelated `RuntimeWarning` inside the KPSS call was dropped silently. Non-target warnings are now re-emitted via `warnings.warn_explicit` *outside* the recording block (so the caller's filter stack — `-W error`, `pytest.warns` — sees them), preserving the original statsmodels filename/lineno so module-scoped filters keep matching, with a fresh registry so cross-call dedup can't swallow repeats. `pvalue_bounded` behaviour unchanged. Test red-verified against the unfixed code.
- **#199**: the climate-pitfalls Johansen fence used `k_ar_diff=p - 1` without defining `p`; it now carries the same one-line `select_lag_order(...).bic` prelude as the stationarity-testing guide.

Closes #198
Closes #199

## Gates

66 stationarity tests green, full fast suite 593 passed on the branch; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV