### PR TITLE
fix(pooling): exact within-model draw indices, keep score labels on-axis

### DIFF
--- a/src/impulso/plotting/_pooling.py
+++ b/src/impulso/plotting/_pooling.py
@@ -9,6 +9,9 @@ from matplotlib.figure import Figure
 if TYPE_CHECKING:
     from impulso.pooling import PredictivePool
 
+_INSIDE_LABEL_FRACTION = 0.75
+"""Share of the x-axis a bar must cover before its score label moves inside it."""
+
 
 def plot_pool_weights(
     pool: "PredictivePool",
@@ -40,11 +43,20 @@ def plot_pool_weights(
     ax.set_yticks(positions)
     ax.set_yticklabels(labels)
     ax.set_xlabel("weight")
-    ax.set_xlim(0.0, max(1.0, float(weights.max()) * 1.05))
+    upper = max(1.0, float(weights.max()) * 1.05)
+    ax.set_xlim(0.0, upper)
 
-    offset = 0.01 * ax.get_xlim()[1]
+    offset = 0.01 * upper
     for position, weight, score in zip(positions, weights, scores, strict=True):
-        ax.text(weight + offset, position, f"log score {score:,.1f}", va="center", fontsize=8)
+        # A label parked past the end of a near-full bar runs off the right
+        # axis, so once a bar covers most of the width its label moves inside,
+        # right-aligned against the bar end and recoloured to stay legible.
+        if weight > _INSIDE_LABEL_FRACTION * upper:
+            ax.text(
+                weight - offset, position, f"log score {score:,.1f}", va="center", ha="right", fontsize=8, color="white"
+            )
+        else:
+            ax.text(weight + offset, position, f"log score {score:,.1f}", va="center", ha="left", fontsize=8)
 
     pooled = pool.pooled_log_score()
     ax.set_title(

--- a/src/impulso/pooling.py
+++ b/src/impulso/pooling.py
@@ -407,7 +407,7 @@ def _mixture_draws(
     sizes = np.array([stack.shape[0] for stack in stacks])
     total = int(sizes.min()) if n_draws is None else int(n_draws)
     membership = rng.choice(len(stacks), size=total, p=weights)
-    position = np.floor(rng.random(total) * sizes[membership]).astype(int)
+    position = rng.integers(0, sizes[membership])
     pooled = np.empty((total, *stacks[0].shape[1:]))
     for i, stack in enumerate(stacks):
         picked = membership == i

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -172,17 +172,15 @@ def test_plot_volatility_returns_figure(synthetic_sv_idata):
     assert isinstance(fig, Figure)
 
 
-def test_plot_pool_weights_returns_figure():
-    """Smoke test: the pool bar chart renders from a hand-built pool."""
+def _make_pool(weights, log_score_columns):
+    """Hand-build a two-model PredictivePool without running the sampler."""
     import pandas as pd
-    from matplotlib.figure import Figure
 
-    from impulso.plotting import plot_pool_weights
     from impulso.pooling import PredictivePool
 
     labels = ["a", "b"]
     index = pd.DatetimeIndex(pd.date_range("2020-01-01", periods=3, freq="QS"), name="time")
-    log_scores = pd.DataFrame([[-1.0, -2.0], [-1.5, -2.5], [-0.5, -3.0]], index=index, columns=labels)
+    log_scores = pd.DataFrame(np.column_stack(log_score_columns), index=index, columns=labels)
     draws = np.zeros((4, 3, 2))
     da = xr.DataArray(
         draws[np.newaxis],
@@ -190,8 +188,8 @@ def test_plot_pool_weights_returns_figure():
         coords={"variable": ["y1", "y2"], "model": ("draw", np.array(["a", "a", "b", "b"], dtype=object))},
         name="forecast",
     )
-    pool = PredictivePool(
-        weights=pd.Series([0.7, 0.3], index=labels),
+    return PredictivePool(
+        weights=pd.Series(weights, index=labels),
         log_scores=log_scores,
         method="stacking",
         density="gaussian",
@@ -205,7 +203,43 @@ def test_plot_pool_weights_returns_figure():
         ),
         membership=np.array([0, 0, 1, 1]),
     )
+
+
+def test_plot_pool_weights_returns_figure():
+    """Smoke test: the pool bar chart renders from a hand-built pool."""
+    from matplotlib.figure import Figure
+
+    from impulso.plotting import plot_pool_weights
+
+    pool = _make_pool([0.7, 0.3], ([-1.0, -1.5, -0.5], [-2.0, -2.5, -3.0]))
     assert isinstance(plot_pool_weights(pool), Figure)
+
+
+def test_plot_pool_weights_annotation_placement():
+    """Short bars label outside; a near-full bar labels inside, right-aligned (#166)."""
+    from impulso.plotting import plot_pool_weights
+
+    # 'a' takes almost all the weight and scores badly enough that its label is
+    # long, which is the case that used to overflow the right axis.
+    pool = _make_pool([0.98, 0.02], ([-500.0, -400.0, -334.5], [-2.0, -2.5, -3.0]))
+    fig = plot_pool_weights(pool)
+    fig.canvas.draw()
+    ax = fig.axes[0]
+    upper = ax.get_xlim()[1]
+    renderer = fig.canvas.get_renderer()
+    texts = {text.get_text(): text for text in ax.texts}
+
+    inside = texts["log score -1,234.5"]
+    assert inside.get_horizontalalignment() == "right"
+    assert inside.get_position()[0] < 0.98
+    # The whole label must sit within the axes, which is what fails when a long
+    # annotation is parked to the right of a bar that already fills the width.
+    assert inside.get_window_extent(renderer).x1 <= ax.bbox.x1
+
+    outside = texts["log score -7.5"]
+    assert outside.get_horizontalalignment() == "left"
+    assert 0.02 < outside.get_position()[0] < upper
+    assert outside.get_window_extent(renderer).x1 <= ax.bbox.x1
 
 
 def _make_sv_forecast_result(steps=12, index=None):

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -23,6 +23,7 @@ from impulso.pooling import (
     _gaussian_log_scores,
     _index_freq,
     _log_score_weights,
+    _mixture_draws,
     _pooled_row_scores,
     _spawn,
     _stacking_weights,
@@ -864,6 +865,18 @@ class TestCombinedSample:
         pool = pool_forecasts(fits, holdout, n_draws=37, seed=0)
         assert pool.membership.shape == (37,)
         assert pool.holdout_predictive.idata.posterior_predictive["forecast"].shape[1] == 37
+
+    def test_within_model_draw_indices_span_the_member(self):
+        """Within-model indices are exact integers covering [0, S) (issue #165).
+
+        The stacks label each draw with its own index, so the pooled values
+        read back as the indices that were selected.
+        """
+        size = 50
+        stacks = [np.arange(size, dtype=float).reshape(size, 1, 1), np.full((size, 1, 1), -1.0)]
+        pooled, membership = _mixture_draws(stacks, np.array([1.0, 0.0]), 4000, np.random.default_rng(0))
+        assert set(np.unique(membership)) == {0}
+        assert set(np.unique(pooled[:, 0, 0])) == set(range(size))
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups on the pooling branch (#164), stacked on `feat/151-predictive-pooling`:

- **#165**: `_mixture_draws` selected within-model indices via `floor(rng.random(N) * sizes)`; now `rng.integers(0, sizes[membership])` — exact (no theoretical `index == size` rounding edge), clearer, equally vectorised. Behaviour note: `membership` is drawn *before* the index draw, so model membership under fixed seeds is bit-identical and only within-model positions shift — all 103 pre-existing pooling tests pass unmodified, and no doc pins the old mechanism.
- **#166**: `plot_pool_weights` placed the score annotation at `w + 1%` with xlim `max(1, 1.05·w)`, overflowing the axis for weights near 1 (reproduced: label edge ~75 px past the axis). Labels now render inside the bar (right-aligned, white) when the bar exceeds 75% of the axis, outside otherwise. New test asserts alignment *and* `get_window_extent().x1 <= ax.bbox.x1` for both placements, red-verified against the pre-fix code.

Closes #165
Closes #166

## Gates

122 pooling+plotting tests green; branch fast suite 638 passed; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV