### PR TITLE
docs(claude-md): drop the nonexistent synthetic_identified_idata_2v fixture line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,6 @@ Shared fixtures available in all test files:
 - **`var_data_2v`**: 2-var VAR(1) DGP, 200 obs (stable coefficients).
 - **`var_data_3v_dgp2`**: 3-var VAR(2) DGP, 200 obs.
 - **`synthetic_idata_2v`**: Synthetic `InferenceData` mimicking a fitted 2-var VAR(1) — no MCMC needed. Use for fast tests of post-fitting logic.
-- **`synthetic_identified_idata_2v`**: Same plus `structural_shock_matrix` (Cholesky of Sigma).
 
 ## Code Conventions
 


### PR DESCRIPTION
## Summary

CLAUDE.md's Test Fixtures section documented a `synthetic_identified_idata_2v` fixture that `tests/conftest.py` has never defined — planning agents kept tripping on it (first flagged during the #143 work). One line removed; if the fixture ever gets added, the line comes back with it.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV