### PR TITLE
fix(scenario): finite shock-matrix guard; infer shock order in from_zero_restrictions

### DIFF
--- a/docs/how-to/long-run-restrictions.md
+++ b/docs/how-to/long-run-restrictions.md
@@ -17,7 +17,7 @@ scheme = LongRunRestriction(
 
 That single zero says the demand shock has no permanent effect on the level of output. Shock `j` has no long-run effect on any variable ordered before it, so the ordering is the restriction — with two variables there is exactly one.
 
-If naming the zeros directly is clearer than reasoning about an ordering, use the alternative constructor. It recovers the ordering from the pattern, and refuses patterns that no ordering can produce:
+If naming the zeros directly is clearer than reasoning about an ordering, use the alternative constructor. It recovers both orderings from the pattern — the variables' and the shocks', so neither list has to be given in order — and refuses patterns that no ordering can produce:
 
 ```python
 scheme = LongRunRestriction.from_zero_restrictions(

--- a/src/impulso/_scenario.py
+++ b/src/impulso/_scenario.py
@@ -22,6 +22,40 @@ if TYPE_CHECKING:
     from impulso.scenario import ShockPath, VariablePath
 
 
+def _require_finite_shock_matrix(P: np.ndarray) -> None:
+    """Reject `NaN` structural shock matrices at the engines' entry seam.
+
+    Both engines are linear solves in `P`: the in-sample one inverts it
+    (`eps_t = P_t⁻¹ u_t`, which silently yields an all-`NaN`
+    counterfactual), the forecast one takes the numerical rank of
+    constraint rows built from it (which dies inside LAPACK as `SVD did
+    not converge`). Neither failure names the cause, so the check runs
+    once where the matrix enters — `structural_shock_context` for
+    `counterfactual`, `_forecast_shock_matrices` for
+    `structural_scenario`.
+
+    Args:
+        P: Structural shock matrices, `(C, D, ..., n, n)`. The leading two
+            axes are chain and draw.
+
+    Raises:
+        ValueError: If any draw carries a `NaN`.
+    """
+    nan_mask = np.isnan(P)
+    if not nan_mask.any():
+        return
+    bad = nan_mask.reshape(P.shape[0], P.shape[1], -1).any(axis=-1)
+    raise ValueError(
+        f"The structural shock matrix is NaN for {int(bad.sum())}/{bad.size} posterior draws, "
+        "and scenario analysis needs a finite P on every draw (its solves would otherwise fail "
+        "opaquely inside LAPACK or return all-NaN paths). The usual cause is an identification "
+        "scheme running with on_undefined='nan', which blanks the draws where its restrictions "
+        "leave the shock matrix undefined — e.g. LongRunRestriction on a draw whose long-run "
+        "multiplier C(1) is numerically singular. Re-identify with on_undefined='raise' to catch "
+        "those draws at identification time, where the diagnostics say how many there are and why."
+    )
+
+
 def structural_shock_context(identified: IdentifiedVAR) -> tuple[np.ndarray, np.ndarray, bool]:
     """Realised structural shocks and the matrices mapping them to residuals.
 
@@ -38,16 +72,19 @@ def structural_shock_context(identified: IdentifiedVAR) -> tuple[np.ndarray, np.
         Tuple `(P, eps, per_t)`: `P` has shape `(C, D, T, n, n)` when
         `per_t` else `(C, D, n, n)`; `eps` has shape `(C, D, T, n)` with
         `eps_t = P_t⁻¹ u_t`.
+
+    Raises:
+        ValueError: If any posterior draw's shock matrix carries a `NaN`.
     """
     from impulso._residuals import reduced_form_residuals
 
     resid = reduced_form_residuals(identified.idata.posterior, identified.data, identified.n_lags)
     per_t = identified.volatility.is_time_varying
+    P = identified.shock_matrix(at="all" if per_t else None).values
+    _require_finite_shock_matrix(P)
     if per_t:
-        P = identified.shock_matrix(at="all").values
         eps = np.einsum("cdtij,cdtj->cdti", np.linalg.inv(P), resid)
     else:
-        P = identified.shock_matrix(at=None).values
         eps = np.einsum("cdij,cdtj->cdti", np.linalg.inv(P), resid)
     return P, eps, per_t
 
@@ -550,29 +587,35 @@ def _forecast_shock_matrices(identified: IdentifiedVAR, steps: int, rng: np.rand
     identifies each forecast Cholesky slice; rotation-sampling schemes
     (the `_samples_rotations` capability flag, e.g. `SignRestriction`)
     cannot yet pin one rotation per draw across steps and error there.
+
+    Raises:
+        ValueError: On a rotation-sampling scheme under time-varying
+            volatility, or if any posterior draw's matrix carries a `NaN`.
     """
     posterior = identified.idata.posterior
     if not identified.volatility.is_time_varying:
         P = identified.shock_matrix(at=None).values  # (C, D, n, n)
-        return np.broadcast_to(P[:, :, np.newaxis, :, :], (*P.shape[:2], steps, *P.shape[2:])).copy()
-    if getattr(identified.scheme, "_samples_rotations", False):
-        raise ValueError(
-            f"structural_scenario under time-varying volatility is not supported for "
-            f"rotation-sampling schemes ({type(identified.scheme).__name__}): rotations are "
-            "re-sampled per identify() call, so no single structural coordinate system "
-            "spans the forecast steps. Use a rotation-free scheme (Cholesky, ProxySVAR), "
-            "or constant volatility."
-        )
-    L_path = identified.volatility.forecast_cholesky_path(posterior, steps=steps, rng=rng)
-    P_path = np.zeros_like(L_path)
-    for h in range(steps):
-        P_path[:, :, h] = identified.scheme.identify(
-            L_path[:, :, h],
-            identified.var_names,
-            posterior=posterior,
-            data=identified.data,
-            n_lags=identified.n_lags,
-        )
+        P_path = np.broadcast_to(P[:, :, np.newaxis, :, :], (*P.shape[:2], steps, *P.shape[2:])).copy()
+    else:
+        if getattr(identified.scheme, "_samples_rotations", False):
+            raise ValueError(
+                f"structural_scenario under time-varying volatility is not supported for "
+                f"rotation-sampling schemes ({type(identified.scheme).__name__}): rotations are "
+                "re-sampled per identify() call, so no single structural coordinate system "
+                "spans the forecast steps. Use a rotation-free scheme (Cholesky, ProxySVAR), "
+                "or constant volatility."
+            )
+        L_path = identified.volatility.forecast_cholesky_path(posterior, steps=steps, rng=rng)
+        P_path = np.zeros_like(L_path)
+        for h in range(steps):
+            P_path[:, :, h] = identified.scheme.identify(
+                L_path[:, :, h],
+                identified.var_names,
+                posterior=posterior,
+                data=identified.data,
+                n_lags=identified.n_lags,
+            )
+    _require_finite_shock_matrix(P_path)
     return P_path
 
 

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -558,27 +558,29 @@ class LongRunRestriction(ImpulsoModel):
 
         Each entry maps a variable to the shocks that must have *no*
         long-run effect on it. The pattern must be triangular under some
-        ordering of the variables — that is what a recursive long-run
-        scheme means — and this constructor recovers that ordering.
+        ordering of the variables *and* some ordering of the shocks — that
+        is what a recursive long-run scheme means — and this constructor
+        recovers both from the restriction counts. Neither `var_names` nor
+        `shock_names` need be given in that order; the names are labels,
+        the pattern decides the positions.
 
         Args:
             restrictions: Variable name -> list of shock names with zero
                 long-run effect on it. Variables with no zeros may be
                 omitted.
-            var_names: All endogenous variable names.
-            shock_names: All shock names, ordered most long-run-restricted
-                first (the shock that is zero-restricted nowhere comes
-                first, and so on).
+            var_names: All endogenous variable names, in any order.
+            shock_names: All shock names, in any order. Their order in the
+                returned scheme is inferred from the pattern.
             **kwargs: Forwarded to the constructor (`on_undefined`,
                 `max_condition`).
 
         Returns:
-            A `LongRunRestriction` whose `ordering` reproduces the named
-            pattern.
+            A `LongRunRestriction` whose `ordering` and `shock_names`
+            reproduce the named pattern.
 
         Raises:
             ValueError: If a name is unknown, or the pattern is not
-                triangular under any ordering.
+                triangular under any pair of orderings.
         """
         n = len(var_names)
         if len(shock_names) != n:
@@ -591,7 +593,8 @@ class LongRunRestriction(ImpulsoModel):
         if unknown_shocks:
             raise ValueError(f"restrictions name shocks absent from shock_names: {unknown_shocks}")
 
-        counts = {v: len(set(restrictions.get(v, []))) for v in var_names}
+        zeros = {v: set(restrictions.get(v, [])) for v in var_names}
+        counts = {v: len(zeros[v]) for v in var_names}
         if sorted(counts.values()) != list(range(n)):
             raise ValueError(
                 f"A recursive long-run structure needs one variable restricted by each of "
@@ -599,9 +602,18 @@ class LongRunRestriction(ImpulsoModel):
                 f"(non-recursive) long-run zero patterns are not supported — see {_NONRECURSIVE_ISSUE}."
             )
         ordering = sorted(var_names, key=lambda v: -counts[v])
+        # The shock order is the same count, read down the other axis. In a
+        # triangular pattern the variable at position i is restricted by the
+        # shocks at positions i+1..n-1, so the shock at position k is
+        # restricted out of exactly the k variables at positions 0..k-1: a
+        # shock's position is the number of restriction lists it appears in.
+        # Ties mean no ordering makes the pattern triangular; they sort
+        # stably and are rejected by the exact per-position check below.
+        appearances = {s: sum(s in zeros[v] for v in var_names) for s in shock_names}
+        shock_order = sorted(shock_names, key=lambda s: appearances[s])
         for i, variable in enumerate(ordering):
-            expected = set(shock_names[i + 1 :])
-            got = set(restrictions.get(variable, []))
+            expected = set(shock_order[i + 1 :])
+            got = zeros[variable]
             if got != expected:
                 raise ValueError(
                     f"Variable {variable!r} is restricted by {sorted(got)}, but its restriction "
@@ -609,7 +621,7 @@ class LongRunRestriction(ImpulsoModel):
                     f"requires exactly {sorted(expected)}. Only recursive (triangular) long-run "
                     f"patterns are supported — see {_NONRECURSIVE_ISSUE}."
                 )
-        return cls(ordering=ordering, shock_names=list(shock_names), **kwargs)
+        return cls(ordering=ordering, shock_names=shock_order, **kwargs)
 
     def identify(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,35 @@ def permanent_transitory_2v():
     }
 
 
+@pytest.fixture
+def identified_long_run_nan_draws(permanent_transitory_2v, var_data_2v):
+    """Long-run-identified 2-var VAR whose first 5 draws of chain 0 are NaN.
+
+    Setting `B = I` on those draws makes `M = I - A_1` exactly singular, so
+    `on_undefined="nan"` (the default) blanks them. Callers must expect the
+    "long-run multiplier" warning the first time identification runs.
+    """
+    from impulso.fitted import FittedVAR
+    from impulso.identification import LongRunRestriction
+    from impulso.volatility import Constant
+
+    n_bad = 5
+    idata = permanent_transitory_2v["idata"].copy()
+    B = idata.posterior["B"].values.copy()
+    B[0, :n_bad] = np.eye(2)
+    idata.posterior["B"] = (("chain", "draw", "var", "coeff"), B)
+
+    fitted = FittedVAR(
+        idata=idata,
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
+    )
+    scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
+    return fitted.set_identification_strategy(scheme)
+
+
 # --------------- SV fixtures ---------------
 
 

--- a/tests/test_counterfactual.py
+++ b/tests/test_counterfactual.py
@@ -344,6 +344,26 @@ class TestGuards:
             apply_shock_edits(eps, [ShockPath(shock="a", values=0.0)], index, ["a", "b"], _ScaledScheme())
 
 
+class TestNaNShockMatrixGuard:
+    """#187: NaN draws are named, not left to LAPACK or to silent NaN output."""
+
+    def test_nan_draws_error_before_the_inverse(self, identified_long_run_nan_draws):
+        with (
+            pytest.warns(UserWarning, match="long-run multiplier"),
+            pytest.raises(ValueError) as excinfo,
+        ):
+            identified_long_run_nan_draws.counterfactual(shocks=[])
+        message = str(excinfo.value)
+        assert not isinstance(excinfo.value, np.linalg.LinAlgError)
+        assert "NaN for 5/100 posterior draws" in message
+        assert "on_undefined='nan'" in message
+        assert "on_undefined='raise'" in message
+
+    def test_nan_free_identification_is_unaffected(self, identified_2v):
+        cf = identified_2v.counterfactual(shocks=[ShockPath(shock="y1", values=0.0)])
+        assert np.isfinite(cf.idata.posterior_predictive["counterfactual"].values).all()
+
+
 class TestDisplaySlice:
     def test_start_end_slice_matches_full(self, identified_2v, var_data_2v):
         idx = var_data_2v.index[1:]

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -769,13 +769,43 @@ class TestLongRunRestriction:
             )
 
     def test_from_zero_restrictions_names_the_offending_variable(self):
-        """Counts are a valid permutation, but the restricted shocks are the wrong ones."""
+        """Counts are a valid permutation, but the restriction sets do not nest."""
         with pytest.raises(ValueError, match="'b'"):
             LongRunRestriction.from_zero_restrictions(
-                restrictions={"a": ["s2", "s3"], "b": ["s2"]},
+                restrictions={"a": ["s2", "s3"], "b": ["s1"]},
                 var_names=["a", "b", "c"],
                 shock_names=["s1", "s2", "s3"],
             )
+
+    def test_from_zero_restrictions_infers_the_shock_order(self, permanent_transitory_2v):
+        """#188: an unsorted `shock_names` is recoverable from the counts, not an error."""
+        fx = permanent_transitory_2v
+        unsorted = LongRunRestriction.from_zero_restrictions(
+            restrictions={"y1": ["transitory"]},
+            var_names=["y1", "y2"],
+            shock_names=["transitory", "permanent"],
+        )
+        sorted_call = LongRunRestriction.from_zero_restrictions(
+            restrictions={"y1": ["transitory"]},
+            var_names=["y1", "y2"],
+            shock_names=["permanent", "transitory"],
+        )
+        assert unsorted.ordering == ["y1", "y2"]
+        assert unsorted.shock_names == ["permanent", "transitory"]
+        np.testing.assert_array_equal(self._identify(unsorted, fx), self._identify(sorted_call, fx))
+
+    def test_from_zero_restrictions_infers_a_three_variable_shock_order(self):
+        """Shock position = the number of restriction lists it appears in."""
+        restrictions = {"a": ["s2", "s3"], "b": ["s2"]}
+        schemes = [
+            LongRunRestriction.from_zero_restrictions(
+                restrictions=restrictions, var_names=["a", "b", "c"], shock_names=names
+            )
+            for names in (["s1", "s2", "s3"], ["s3", "s2", "s1"], ["s2", "s3", "s1"])
+        ]
+        for scheme in schemes:
+            assert scheme.ordering == ["a", "b", "c"]
+            assert scheme.shock_names == ["s1", "s3", "s2"]
 
     def test_from_zero_restrictions_rejects_unknown_names(self):
         with pytest.raises(ValueError, match="var_names"):

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -596,27 +596,6 @@ def identified_long_run(permanent_transitory_2v, var_data_2v):
     return fitted.set_identification_strategy(scheme)
 
 
-def _identified_with_singular_draws(permanent_transitory_2v, var_data_2v, n_bad: int = 5):
-    """Same pipeline, but the first `n_bad` draws of chain 0 have M = 0."""
-    from impulso.identification import LongRunRestriction
-    from impulso.volatility import Constant
-
-    idata = permanent_transitory_2v["idata"].copy()
-    B = idata.posterior["B"].values.copy()
-    B[0, :n_bad] = np.eye(2)
-    idata.posterior["B"] = (("chain", "draw", "var", "coeff"), B)
-
-    fitted = FittedVAR(
-        idata=idata,
-        n_lags=1,
-        data=var_data_2v,
-        var_names=["y1", "y2"],
-        volatility=Constant(),
-    )
-    scheme = LongRunRestriction(ordering=["y1", "y2"], shock_names=["permanent", "transitory"])
-    return fitted.set_identification_strategy(scheme)
-
-
 class TestLongRunRestrictionPipeline:
     """LongRunRestriction through the FittedVAR -> IdentifiedVAR pipeline."""
 
@@ -659,8 +638,8 @@ class TestLongRunRestrictionPipeline:
 
     # --- 23. undefined draws stay undefined through FEVD -------------------
 
-    def test_fevd_propagates_nan_draws(self, permanent_transitory_2v, var_data_2v):
-        identified = _identified_with_singular_draws(permanent_transitory_2v, var_data_2v)
+    def test_fevd_propagates_nan_draws(self, identified_long_run_nan_draws):
+        identified = identified_long_run_nan_draws
         with pytest.warns(UserWarning, match="long-run multiplier"):
             fevd = identified.fevd(horizon=5)
         shares = fevd.idata.posterior_predictive["fevd"].values
@@ -684,8 +663,8 @@ class TestLongRunRestrictionPipeline:
 
     # --- 25. undefined draws do not crash the decomposition ----------------
 
-    def test_historical_decomposition_survives_nan_draws(self, permanent_transitory_2v, var_data_2v):
-        identified = _identified_with_singular_draws(permanent_transitory_2v, var_data_2v)
+    def test_historical_decomposition_survives_nan_draws(self, identified_long_run_nan_draws):
+        identified = identified_long_run_nan_draws
         with pytest.warns(UserWarning, match="long-run multiplier"):
             hd = identified.historical_decomposition()
         contributions = hd.idata.posterior_predictive["hd"].values

--- a/tests/test_structural_scenario.py
+++ b/tests/test_structural_scenario.py
@@ -404,6 +404,30 @@ class TestPartialIdentification:
         assert scn.idata.posterior_predictive["plausibility"].values.min() >= 3.0 - 1e-10
 
 
+class TestNaNShockMatrixGuard:
+    """#187: NaN draws are named, not surfaced as LAPACK's 'SVD did not converge'."""
+
+    def test_nan_draws_error_before_the_rank_check(self, identified_long_run_nan_draws):
+        with (
+            pytest.warns(UserWarning, match="long-run multiplier"),
+            pytest.raises(ValueError) as excinfo,
+        ):
+            identified_long_run_nan_draws.structural_scenario(
+                steps=3,
+                conditions=[VariablePath(variable="y1", values=0.4)],
+                seed=0,
+            )
+        message = str(excinfo.value)
+        assert not isinstance(excinfo.value, np.linalg.LinAlgError)
+        assert "NaN for 5/100 posterior draws" in message
+        assert "on_undefined='nan'" in message
+        assert "on_undefined='raise'" in message
+
+    def test_nan_free_identification_is_unaffected(self, identified_2v):
+        scn = identified_2v.structural_scenario(steps=3, conditions=[VariablePath(variable="y1", values=0.4)], seed=0)
+        assert np.isfinite(scn.idata.posterior_predictive["forecast"].values).all()
+
+
 class TestNumericalGuards:
     def test_near_collinear_adjusting_block_warns(self):
         """cond(C_A C_A') check fires where the full-Gram check cannot."""


### PR DESCRIPTION
## Summary

Two follow-ups on the long-run-restrictions branch (#183), stacked on `feat/143-long-run-restrictions`:

- **#187**: NaN shock-matrix draws (reachable via `LongRunRestriction(on_undefined="nan")`, and soon MaxShare/ZeroSignRestriction) hit the scenario engines as either an opaque `SVD did not converge` (`structural_scenario`) or — worse than the issue knew — a **silent all-NaN counterfactual** (`np.linalg.inv` on NaN does not raise on NumPy 2.4). A single `_require_finite_shock_matrix` guard now sits at the two seams where P enters the engines, counting the offending draws and pointing at `on_undefined="raise"`. IRF/FEVD/HD deliberately keep propagating NaN (pinned by existing tests) — the guard is scenario-only. Tests assert the new error is *not* a `LinAlgError` (which subclasses `ValueError`).
- **#188**: `from_zero_restrictions` rejected genuinely-recursive patterns whose `shock_names` weren't pre-sorted. The shock order is now inferred — a shock's position equals the number of restriction lists it appears in (derived from the triangularity structure) — with the exact per-position set check unchanged as final validation, so non-recursive patterns still fail with the same messages. One existing test had encoded the bug (a valid-but-unsorted pattern asserted as rejected) and was rewritten to a genuine violation.

Closes #187
Closes #188

## Gates

156 targeted tests green; branch fast suite 580 passed; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV