### PR TITLE
fix(deterministic): carry intraday times in BreakDummy names and errors

### DIFF
--- a/docs/how-to/deterministic-regressors.md
+++ b/docs/how-to/deterministic-regressors.md
@@ -133,6 +133,13 @@ what `build` and `extend` emit, in that order:
 | `SeasonalDummies(season="dayofweek")` | `dow_1` … `dow_6` |
 | `BreakDummy(date="1991-06-15")` | `level_1991-06-15` |
 | `BreakDummy(date="1991-06-15", kind="pulse")` | `pulse_1991-06-15` |
+| `BreakDummy(date="1991-06-15 12:00", kind="pulse")` | `pulse_1991-06-15T12:00` |
+
+A break at midnight — every timestamp on a daily-or-coarser index — renders as
+a bare `YYYY-MM-DD`. On intraday sampling the time is kept, ISO-8601 extended,
+with seconds and a fractional part appended only when they are non-zero. That
+keeps two breaks on the same day apart instead of colliding into one column
+name, and `pd.Timestamp` reads the rendered form straight back.
 
 Those names travel: they become `exog_names` on `VARData`, and PyMC labels the
 `exog` coordinate of `B_exog` with them, so the posterior comes back

--- a/src/impulso/deterministic.py
+++ b/src/impulso/deterministic.py
@@ -176,6 +176,33 @@ def _format_period(period: float) -> str:
     return str(int(period)) if float(period).is_integer() else str(float(period))
 
 
+def _format_break_timestamp(timestamp: pd.Timestamp) -> str:
+    """Render a break timestamp for a column name or an error message.
+
+    Midnight — the overwhelmingly common case, and every timestamp on a
+    daily-or-coarser index — renders as a bare ISO date, `2000-02-01`.
+    Anything with an intraday component keeps it, ISO-8601 extended:
+    `2000-02-01T12:00`, with seconds and a fractional part appended only
+    when they are non-zero.
+
+    Two properties matter. The rendering is *injective* — distinct
+    timestamps never collide, so two intraday breaks on the same day
+    stay distinct columns rather than tripping the duplicate-name check
+    — and it round-trips, `pd.Timestamp("2000-02-01T12:00")` recovering
+    the break date from its own column name.
+    """
+    date = timestamp.strftime("%Y-%m-%d")
+    fraction = timestamp.microsecond * 1000 + timestamp.nanosecond
+    if not (timestamp.hour or timestamp.minute or timestamp.second or fraction):
+        return date
+    rendered = f"{date}T{timestamp.hour:02d}:{timestamp.minute:02d}"
+    if timestamp.second or fraction:
+        rendered += f":{timestamp.second:02d}"
+    if fraction:
+        rendered += f".{fraction:09d}".rstrip("0")
+    return rendered
+
+
 # --------------------------------------------------------------------------- #
 # Terms
 # --------------------------------------------------------------------------- #
@@ -351,6 +378,13 @@ class BreakDummy(ImpulsoBaseModel):
     A `"pulse"` break is 1 on `date` alone — a one-off event whose
     influence you want held out of the dynamics.
 
+    The column is named `{kind}_{date}`, with the date rendered as
+    `YYYY-MM-DD` at midnight and `YYYY-MM-DDTHH:MM` (seconds and
+    fractional seconds appended when non-zero) at any other time of day.
+    Intraday sampling therefore keeps two breaks on the same day apart,
+    and a `"pulse"` that missed the index says so with the time
+    included — the dropped time being the usual reason it missed.
+
     Attributes:
         date: Timestamp of the break. Strings, `datetime` objects and
             `numpy.datetime64` are coerced.
@@ -372,7 +406,7 @@ class BreakDummy(ImpulsoBaseModel):
     @property
     def column_names(self) -> list[str]:
         """The single column name contributed by this term."""
-        return [f"{self.kind}_{self.date.strftime('%Y-%m-%d')}"]
+        return [f"{self.kind}_{_format_break_timestamp(self.date)}"]
 
     def build(self, index: pd.DatetimeIndex, origin: pd.Timestamp, alias: str) -> np.ndarray:
         """Evaluate the indicator on `index`. `origin` and `alias` are unused."""
@@ -382,30 +416,31 @@ class BreakDummy(ImpulsoBaseModel):
 
     def _check_in_sample(self, index: pd.DatetimeIndex) -> None:
         """Raise if the break is not identified from the estimation sample."""
+        stamp = _format_break_timestamp(self.date)
         if self.kind == "pulse":
             if self.date not in index:
                 position = int(index.searchsorted(self.date))
                 before = index[position - 1] if position > 0 else None
                 after = index[position] if position < len(index) else None
                 raise ValueError(
-                    f"BreakDummy(kind='pulse', date={self.date.date()}) does not fall on "
+                    f"BreakDummy(kind='pulse', date={stamp}) does not fall on "
                     f"the sampled index, so the column is zero everywhere and its "
-                    f"coefficient is not identified. Nearest sampled dates: "
-                    f"{before.date() if before is not None else None} (before) and "
-                    f"{after.date() if after is not None else None} (after)."
+                    f"coefficient is not identified. Nearest sampled timestamps: "
+                    f"{_format_break_timestamp(before) if before is not None else None} (before) and "
+                    f"{_format_break_timestamp(after) if after is not None else None} (after)."
                 )
             return
         if self.date <= index[0]:
             raise ValueError(
-                f"BreakDummy(kind='level', date={self.date.date()}) is at or before the "
-                f"start of the sample ({index[0].date()}), so the column is 1 everywhere "
-                f"and is collinear with the intercept every estimator fits."
+                f"BreakDummy(kind='level', date={stamp}) is at or before the "
+                f"start of the sample ({_format_break_timestamp(index[0])}), so the column "
+                f"is 1 everywhere and is collinear with the intercept every estimator fits."
             )
         if self.date > index[-1]:
             raise ValueError(
-                f"BreakDummy(kind='level', date={self.date.date()}) is after the end of "
-                f"the sample ({index[-1].date()}), so the shift never occurs in-sample "
-                f"and its coefficient is not identified."
+                f"BreakDummy(kind='level', date={stamp}) is after the end of "
+                f"the sample ({_format_break_timestamp(index[-1])}), so the shift never "
+                f"occurs in-sample and its coefficient is not identified."
             )
 
 

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -32,6 +32,7 @@ _FREQ_SPECS = {
     "QS": ("1980-01-01", 240),
     "D": ("2010-01-01", 1200),
     "YS": ("1900-01-01", 150),
+    "h": ("2010-01-01", 1200),
 }
 
 #: Reserved tail length: continuation cases build on `index[: T + h]`.
@@ -88,6 +89,19 @@ _DESIGNS_BY_FREQ: dict[str, dict[str, list]] = {
         "level": [BreakDummy(date="1950-01-01")],
         "composed": [Trend(degree=1, scale=10.0), BreakDummy(date="1950-01-01")],
     },
+    # Intraday sampling: break-dummy column names carry a time component, and
+    # they have to be the same string in `build` and `extend`.
+    "h": {
+        "fourier": [Fourier(period=24, order=2)],
+        "level_intraday": [BreakDummy(date="2010-01-05 06:00")],
+        "pulse_intraday": [BreakDummy(date="2010-01-05 06:00", kind="pulse")],
+        "composed": [
+            Trend(degree=1, scale=24.0),
+            Fourier(period=24, order=2),
+            BreakDummy(date="2010-01-05 06:00"),
+            BreakDummy(date="2010-01-05 18:00", kind="pulse"),
+        ],
+    },
 }
 
 
@@ -116,6 +130,11 @@ def daily_index():
 @pytest.fixture
 def annual_index():
     return _index_for("YS")
+
+
+@pytest.fixture
+def hourly_index():
+    return _index_for("h")
 
 
 @pytest.fixture
@@ -257,6 +276,38 @@ class TestColumnNames:
         assert BreakDummy(date="2000-01-01").column_names == ["level_2000-01-01"]
         assert BreakDummy(date=pd.Timestamp("2000-03-15"), kind="pulse").column_names == ["pulse_2000-03-15"]
 
+    @pytest.mark.parametrize(
+        ("date", "expected"),
+        [
+            # Midnight stays bare — the regression pin for daily-or-coarser data.
+            ("2000-02-01", "level_2000-02-01"),
+            ("2000-02-01 00:00:00", "level_2000-02-01"),
+            ("2000-02-01 12:00", "level_2000-02-01T12:00"),
+            ("2000-02-01 00:30", "level_2000-02-01T00:30"),
+            ("2000-02-01 12:00:30", "level_2000-02-01T12:00:30"),
+            ("2000-02-01 12:00:00.5", "level_2000-02-01T12:00:00.5"),
+            ("2000-02-01 23:59:59.123456789", "level_2000-02-01T23:59:59.123456789"),
+        ],
+    )
+    def test_break_names_keep_an_intraday_time(self, date, expected):
+        assert BreakDummy(date=date).column_names == [expected]
+
+    def test_break_name_round_trips_through_timestamp(self):
+        term = BreakDummy(date="2000-02-01 12:30", kind="pulse")
+        (name,) = term.column_names
+
+        assert pd.Timestamp(name.removeprefix("pulse_")) == term.date
+
+    def test_breaks_differing_only_by_time_of_day_are_distinct_columns(self):
+        design = DeterministicDesign(
+            terms=[
+                BreakDummy(date="2000-02-01", kind="pulse"),
+                BreakDummy(date="2000-02-01 12:00", kind="pulse"),
+            ]
+        )
+
+        assert design.column_names == ["pulse_2000-02-01", "pulse_2000-02-01T12:00"]
+
     def test_design_column_names_concatenate_in_term_order(self, simple_design):
         assert simple_design.column_names == [
             "trend",
@@ -320,6 +371,32 @@ class TestBuildValidation:
         design = DeterministicDesign(terms=[BreakDummy(date="1990-01-15", kind="pulse")])
         with pytest.raises(ValueError, match=r"1990-01-01 \(before\) and 1990-02-01 \(after\)"):
             design.build(monthly_index)
+
+    def test_intraday_pulse_builds_and_fires_on_its_own_timestamp(self, hourly_index):
+        design = DeterministicDesign(terms=[BreakDummy(date="2010-01-05 06:00", kind="pulse")])
+
+        frame = design.build(hourly_index)
+
+        assert list(frame.columns) == ["pulse_2010-01-05T06:00"]
+        assert frame.to_numpy().sum() == 1.0
+        assert frame.loc[pd.Timestamp("2010-01-05 06:00"), "pulse_2010-01-05T06:00"] == 1.0
+
+    def test_intraday_pulse_off_the_index_names_the_full_timestamp(self, hourly_index):
+        # The date alone is on the index; the 06:30 is what missed it, so the
+        # message has to say 06:30 or it accuses an innocent date.
+        design = DeterministicDesign(terms=[BreakDummy(date="2010-01-05 06:30", kind="pulse")])
+
+        with pytest.raises(ValueError, match=r"date=2010-01-05T06:30\) does not fall on") as excinfo:
+            design.build(hourly_index)
+
+        assert "2010-01-05T06:00 (before)" in str(excinfo.value)
+        assert "2010-01-05T07:00 (after)" in str(excinfo.value)
+
+    def test_intraday_level_break_after_the_sample_names_the_full_timestamp(self, hourly_index):
+        design = DeterministicDesign(terms=[BreakDummy(date="2030-06-01 09:15")])
+
+        with pytest.raises(ValueError, match=r"date=2030-06-01T09:15\) is after the end"):
+            design.build(hourly_index)
 
     def test_level_break_at_sample_start_is_rejected(self, monthly_index):
         design = DeterministicDesign(terms=[BreakDummy(date="1980-01-01")])


### PR DESCRIPTION
## Summary

Follow-up on the deterministic-regressors branch (#191), stacked on `feat/135-deterministic-regressors`:

`BreakDummy` truncated timestamps to dates in both column names and error messages — an intraday pulse errored with a message naming a date that *is* on the index (the dropped time being the real cause), and two same-day intraday breaks collided in the duplicate-name check. Names now render `{kind}_{YYYY-MM-DD}` at midnight (unchanged, regression-pinned) and ISO-8601 extended (`...THH:MM`, seconds/fractions only when non-zero) otherwise. The rendering is **injective** (distinct timestamps cannot collide) and **round-trips** (`pd.Timestamp(name.removeprefix("pulse_"))` recovers the date) — both properties tested. Error messages use the same renderer for the break date and the neighbour timestamps.

Also adds an hourly-frequency fixture to the continuation-property matrix (including a two-intraday-breaks design), and the how-to's column-name contract table gains the intraday row.

Closes #195

## Gates

400 deterministic tests green (was 313); branch fast suite 935 passed; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV