### PR TITLE
fix(identification): warn once per posterior on weak max-share identification

### DIFF
--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1152,6 +1152,16 @@ class MaxShare(ImpulsoModel):
     # is exactly the per-t loop's lifetime. See `_PosteriorCache`.
     _spectral_cache: _PosteriorCache = PrivateAttr(default_factory=_PosteriorCache)
 
+    # Cache key of the posterior the weak-identification warning last
+    # fired for. The degeneracy check depends on `L` as well as on the
+    # posterior, so unlike the singular and explosive warnings it cannot
+    # ride on `_spectral_cache` — and because the message embeds the
+    # ratio to 3 dp, which moves with `L_t`, Python's warnings registry
+    # sees a fresh message each period and dedups nothing. Warning on the
+    # first crossing per posterior and remembering the key keeps
+    # `shock_matrix(at="all")` to one warning instead of T.
+    _warned_weak_for: tuple | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def _validate_band(self) -> "MaxShare":
         """Reject bands that are not valid period intervals, and bad labels."""
@@ -1215,7 +1225,10 @@ class MaxShare(ImpulsoModel):
             describe the *last* time slice only. The share and eigenvalue
             ratio are the L-dependent ones and so genuinely differ across
             slices; the singular, explosive and spectral-radius counts do
-            not, since they are properties of the posterior alone. Use
+            not, since they are properties of the posterior alone. The
+            weak-identification warning likewise fires at most once per
+            posterior — at the first period whose median ratio crosses the
+            threshold — rather than once per period. Use
             `max_share_diagnostics` with an explicit `L` for a specific
             period.
 
@@ -1225,7 +1238,7 @@ class MaxShare(ImpulsoModel):
                 `on_undefined="raise"` and some draw is undefined.
         """
         del data  # unused
-        vals, vecs, bad, rho, condition = self._band_eigen(L, var_names, posterior, n_lags)
+        vals, vecs, bad, rho, condition, key = self._band_eigen(L, var_names, posterior, n_lags)
 
         q = vecs[..., -1]  # eigh returns eigenvalues ascending
         q = q * self._orientation(L, q, var_names.index(self.target))[..., np.newaxis]
@@ -1246,7 +1259,7 @@ class MaxShare(ImpulsoModel):
             "max_share_spectral_radius_median": float(np.median(rho)),
             "max_share_spectral_radius_max": float(rho.max()),
         }
-        self._warn_weakly_identified()
+        self._warn_weakly_identified(key)
 
         if bad.any():
             P = np.where(bad[..., np.newaxis, np.newaxis], np.nan, P)
@@ -1258,15 +1271,16 @@ class MaxShare(ImpulsoModel):
         var_names: list[str],
         posterior: "xr.Dataset | None",
         n_lags: int | None,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, tuple]:
         """Eigendecomposition of the band variance form `M = L' Re(K) L`.
 
         Returns:
-            Tuple `(vals, vecs, bad, rho, condition)`: eigenvalues in
+            Tuple `(vals, vecs, bad, rho, condition, key)`: eigenvalues in
             ascending order and their eigenvectors, `(C, D, n)` and
             `(C, D, n, n)`; the numerically-undefined mask, the companion
             spectral radii and the worst in-band condition number, each
-            `(C, D)`.
+            `(C, D)`; and the posterior cache key of `_cache_key`, which
+            callers use to fire per-posterior warnings once.
         """
         if posterior is None or "B" not in posterior:
             raise ValueError(
@@ -1281,12 +1295,28 @@ class MaxShare(ImpulsoModel):
         n_vars = L.shape[-1]
         if n_lags is None:
             n_lags = posterior["B"].shape[-1] // n_vars
-        K, bad, rho, condition = self._spectral_accumulator(posterior, n_lags, n_vars, var_names.index(self.target))
+        target_index = var_names.index(self.target)
+        K, bad, rho, condition = self._spectral_accumulator(posterior, n_lags, n_vars, target_index)
 
         M = np.swapaxes(L, -1, -2) @ K @ L
         M = 0.5 * (M + np.swapaxes(M, -1, -2))
         vals, vecs = np.linalg.eigh(M)
-        return vals, vecs, bad, rho, condition
+        return vals, vecs, bad, rho, condition, self._cache_key(posterior, n_lags, target_index)
+
+    @staticmethod
+    def _cache_key(posterior: "xr.Dataset", n_lags: int, target_index: int) -> tuple:
+        """Identity of one (posterior, lag order, target) combination.
+
+        Keys `_warned_weak_for`, so the one-shot degeneracy warning fires
+        once per (posterior, lag order, target) rather than once per
+        `identify()` call. Keyed by object identity, which is exactly the
+        lifetime of the pipeline's per-t loop. `_spectral_cache` does its
+        own keying through `_PosteriorCache`, which additionally validates
+        the referent with a weakref so a recycled `id()` reads as a miss;
+        this set carries no numeric payload, so a recycled address can at
+        worst suppress one warning.
+        """
+        return (id(posterior), n_lags, target_index)
 
     def _spectral_accumulator(
         self, posterior: "xr.Dataset", n_lags: int, n_vars: int, target_index: int
@@ -1440,7 +1470,7 @@ class MaxShare(ImpulsoModel):
                 stacklevel=4,
             )
 
-    def _warn_weakly_identified(self) -> None:
+    def _warn_weakly_identified(self, key: tuple) -> None:
         """Warn when the leading eigenvalue is barely separated from the next.
 
         At a ratio near one the band-variance form is close to having a
@@ -1449,19 +1479,38 @@ class MaxShare(ImpulsoModel):
         the eigensolver produced and is not reproducible across LAPACK
         builds. Threshold fixed at 0.9 — it is a smoke alarm, not a tuning
         knob.
+
+        Fired at most once per posterior. The ratio depends on `L`, so
+        under time-varying volatility the pipeline's per-t loop would
+        otherwise re-evaluate the check `T` times, and because the message
+        embeds the ratio to 3 dp the warnings registry would treat each
+        period as a new message and print all of them. The first crossing
+        wins and its `key` is remembered in `_warned_weak_for`; later
+        periods and later `identify()` calls against the same posterior
+        stay quiet.
+
+        Args:
+            key: Posterior cache key from `_cache_key`, as returned by
+                `_band_eigen`.
         """
         ratio = self._last_diagnostics.get("max_share_eigen_ratio_median", np.nan)
-        if np.isfinite(ratio) and ratio > 0.9:
-            import warnings
+        if self._warned_weak_for == key or not np.isfinite(ratio) or ratio <= 0.9:
+            return
 
-            warnings.warn(
-                f"The maximum-share shock is weakly identified within the band: posterior-median "
-                f"eigenvalue ratio lambda_2/lambda_1 = {ratio:.3f} > 0.9, so the maximiser is "
-                "nearly degenerate and the returned rotation within that plane is arbitrary. See "
-                "the max_share_eigen_ratio_* diagnostics.",
-                UserWarning,
-                stacklevel=4,
-            )
+        import warnings
+
+        self._warned_weak_for = key
+        warnings.warn(
+            f"The maximum-share shock is weakly identified within the band: posterior-median "
+            f"eigenvalue ratio lambda_2/lambda_1 = {ratio:.3f} > 0.9, so the maximiser is "
+            "nearly degenerate and the returned rotation within that plane is arbitrary. Warned "
+            "once per posterior; under time-varying volatility the ratio depends on the period's "
+            "Cholesky factor, so this is the first period to cross the threshold and other "
+            "periods will differ. See the max_share_eigen_ratio_* diagnostics, or "
+            "max_share_diagnostics() with an explicit L for the per-draw, per-period picture.",
+            UserWarning,
+            stacklevel=4,
+        )
 
     def max_share_diagnostics(
         self,
@@ -1490,7 +1539,7 @@ class MaxShare(ImpulsoModel):
             `"condition_max"` is the worst condition number of
             `I - sum_j A_j e^{-i w j}` across the band's grid.
         """
-        vals, _, bad, rho, condition = self._band_eigen(L, var_names, posterior, n_lags)
+        vals, _, bad, rho, condition, _ = self._band_eigen(L, var_names, posterior, n_lags)
         share, ratio = self._share_and_ratio(vals, bad)
         return {
             "share": share,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,29 @@ def permanent_transitory_2v():
     }
 
 
+@pytest.fixture
+def flat_band_accumulator():
+    """Stand-in for `MaxShare._spectral_accumulator` returning `K = I`.
+
+    Monkeypatch it onto the class to reduce the band variance form to
+    `M = L' L`, so the eigenvalue ratio — and with it the degeneracy
+    warning — is steered entirely by the caller's `L`. No draw comes back
+    singular or explosive, so the weak-identification warning is the only
+    one that can fire.
+    """
+
+    def _accumulator(self, posterior, n_lags, n_vars, target_index):
+        shape = posterior["B"].values.shape[:2]
+        return (
+            np.broadcast_to(np.eye(n_vars), (*shape, n_vars, n_vars)).copy(),
+            np.zeros(shape, dtype=bool),
+            np.zeros(shape),
+            np.ones(shape),
+        )
+
+    return _accumulator
+
+
 # --------------- SV fixtures ---------------
 
 

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -963,6 +963,17 @@ def _reference_band_form(A: list, L: np.ndarray, target: int, band: tuple[float,
     return np.trapezoid(np.array(integrand), omegas, axis=0).real
 
 
+def _diag_L(second: float, n_chains: int = 2, n_draws: int = 50) -> np.ndarray:
+    """`diag(1, second)` broadcast over draws.
+
+    Paired with the `flat_band_accumulator` fixture this pins the
+    eigenvalue ratio to `1 / second**2` (for `second >= 1`), so a test can
+    put the diagnostic either side of the 0.9 threshold and vary it at the
+    third decimal place — the digit the warning message embeds.
+    """
+    return np.broadcast_to(np.diag([1.0, second]), (n_chains, n_draws, 2, 2)).copy()
+
+
 class TestMaxShare:
     """Construction, validation and labelling."""
 
@@ -1335,25 +1346,79 @@ class TestMaxShareScreensAndDiagnostics:
 
         assert scheme._spectral_cache.get(_posterior_with_B(B), (1, 1)) is _CACHE_MISS
 
-    def test_weak_identification_is_warned(self, monkeypatch, single_driver_2v):
-        """A repeated top eigenvalue means the maximiser is a plane, not a ray."""
+    def test_weak_identification_is_warned(self, monkeypatch, flat_band_accumulator, single_driver_2v):
+        """A repeated top eigenvalue means the maximiser is a plane, not a ray.
+
+        Regression pin for the constant-volatility path: exactly one
+        warning from the single `identify()` call the pipeline makes.
+        """
         from impulso.identification import MaxShare
 
-        def flat_accumulator(self, posterior, n_lags, n_vars, target_index):
-            shape = posterior["B"].values.shape[:2]
-            return (
-                np.broadcast_to(np.eye(n_vars), (*shape, n_vars, n_vars)).copy(),
-                np.zeros(shape, dtype=bool),
-                np.zeros(shape),
-                np.ones(shape),
-            )
-
-        monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_accumulator)
+        monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_band_accumulator)
         scheme = MaxShare(target="y1", band=(6, 32))
         identity = np.broadcast_to(np.eye(2), (2, 50, 2, 2)).copy()
-        with pytest.warns(UserWarning, match="weakly identified"):
+        with pytest.warns(UserWarning, match="weakly identified") as record:
             scheme.identify(identity, ["y1", "y2"], posterior=single_driver_2v["idata"].posterior, n_lags=1)
+        assert len(record) == 1
         assert scheme._last_diagnostics["max_share_eigen_ratio_median"] == pytest.approx(1.0)
+
+    def test_weak_identification_warns_once_per_posterior(
+        self, monkeypatch, recwarn, flat_band_accumulator, single_driver_2v
+    ):
+        """Re-identifying against the same posterior stays quiet (issue #202).
+
+        The second call uses a different `L`, so the message carries a
+        different ratio and the warnings registry would not dedup it —
+        `_warned_weak_for` has to.
+        """
+        from impulso.identification import MaxShare
+
+        monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_band_accumulator)
+        posterior = single_driver_2v["idata"].posterior
+        scheme = MaxShare(target="y1", band=(6, 32))
+
+        with pytest.warns(UserWarning, match="weakly identified"):
+            scheme.identify(_diag_L(1.0), ["y1", "y2"], posterior=posterior, n_lags=1)
+
+        recwarn.clear()
+        scheme.identify(_diag_L(1.02), ["y1", "y2"], posterior=posterior, n_lags=1)
+        scheme.identify(_diag_L(1.04), ["y1", "y2"], posterior=posterior, n_lags=1)
+        assert scheme._last_diagnostics["max_share_eigen_ratio_median"] > 0.9
+        assert len(recwarn) == 0
+
+    def test_weak_identification_warns_again_for_a_new_posterior(
+        self, monkeypatch, flat_band_accumulator, single_driver_2v
+    ):
+        """The one-shot is keyed on the posterior, not on the scheme."""
+        from impulso.identification import MaxShare
+
+        monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_band_accumulator)
+        first = single_driver_2v["idata"].posterior
+        second = _posterior_with_B(first["B"].values.copy())
+        scheme = MaxShare(target="y1", band=(6, 32))
+
+        with pytest.warns(UserWarning, match="weakly identified"):
+            scheme.identify(_diag_L(1.0), ["y1", "y2"], posterior=first, n_lags=1)
+        with pytest.warns(UserWarning, match="weakly identified") as record:
+            scheme.identify(_diag_L(1.0), ["y1", "y2"], posterior=second, n_lags=1)
+        assert len(record) == 1
+
+    def test_weak_identification_warns_on_the_first_crossing_not_the_first_call(
+        self, monkeypatch, recwarn, flat_band_accumulator, single_driver_2v
+    ):
+        """A quiet first period must not spend the posterior's one warning."""
+        from impulso.identification import MaxShare
+
+        monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_band_accumulator)
+        posterior = single_driver_2v["idata"].posterior
+        scheme = MaxShare(target="y1", band=(6, 32))
+
+        scheme.identify(_diag_L(np.sqrt(2.0)), ["y1", "y2"], posterior=posterior, n_lags=1)
+        assert scheme._last_diagnostics["max_share_eigen_ratio_median"] == pytest.approx(0.5)
+        assert len(recwarn) == 0
+
+        with pytest.warns(UserWarning, match="weakly identified"):
+            scheme.identify(_diag_L(1.0), ["y1", "y2"], posterior=posterior, n_lags=1)
 
     def test_diagnostics_keys_are_floats(self, single_driver_2v):
         from impulso.identification import MaxShare

--- a/tests/test_identified.py
+++ b/tests/test_identified.py
@@ -788,3 +788,99 @@ class TestMaxSharePipeline:
         assert list(da.coords["response"].values) == ["y1", "y2"]
         impact = da.values[..., 0, :, 0]
         np.testing.assert_allclose(impact, np.broadcast_to([0.3, 0.7], impact.shape), atol=1e-8)
+
+
+class _RampSV:
+    """Time-varying volatility whose second variable's scale drifts with `t`.
+
+    Satisfies the `VolatilityProcess` Protocol well enough for
+    `shock_matrix(at="all")`, which is all these tests exercise. Paired
+    with a band accumulator forced to the identity, the eigenvalue ratio
+    at period `t` is `1 / scale_t**2`: above the 0.9 warning threshold at
+    every period, but moving in the third decimal place, so the message
+    text differs from one period to the next.
+    """
+
+    name = "sv"
+    is_time_varying = True
+
+    def __init__(self, n_chains: int = 2, n_draws: int = 50, step: float = 2e-4):
+        self.n_chains = n_chains
+        self.n_draws = n_draws
+        self.step = step
+
+    def build_pymc_latent(self, n_vars, T):  # pragma: no cover
+        raise NotImplementedError
+
+    def cholesky_path(self, posterior, T):
+        L = np.zeros((self.n_chains, self.n_draws, T, 2, 2))
+        L[..., 0, 0] = 1.0
+        L[..., 1, 1] = 1.0 + self.step * np.arange(T)
+        return L
+
+    def cholesky_at(self, posterior, t):  # pragma: no cover
+        return self.cholesky_path(posterior, T=1)[:, :, 0]
+
+    def forecast_cholesky_path(self, posterior, steps, rng):  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.fixture
+def weakly_identified_sv(single_driver_2v, var_data_2v, monkeypatch, flat_band_accumulator):
+    """`IdentifiedVAR` whose every period is near-degenerate under SV."""
+    from impulso.identification import MaxShare
+
+    monkeypatch.setattr(MaxShare, "_spectral_accumulator", flat_band_accumulator)
+    return IdentifiedVAR.model_construct(
+        idata=single_driver_2v["idata"],
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=_RampSV(),
+        scheme=MaxShare(target="y1", band=(6, 32)),
+    )
+
+
+class TestMaxShareWeakIdentificationUnderSV:
+    """The degeneracy warning is per posterior, not per period (issue #202)."""
+
+    def test_shock_matrix_at_all_warns_once(self, weakly_identified_sv, var_data_2v):
+        """`at="all"` runs identify() once per period; the user hears it once."""
+        with pytest.warns(UserWarning, match="weakly identified") as record:
+            P = weakly_identified_sv.shock_matrix(at="all")
+
+        T_eff = var_data_2v.endog.shape[0] - 1
+        assert P.sizes["time"] == T_eff
+        assert T_eff > 1  # otherwise "once" is vacuous
+        assert len(record) == 1
+
+    def test_the_ratio_really_does_move_across_periods(self, weakly_identified_sv):
+        """Guards the fixture: identical messages would dedup on their own."""
+        scheme = weakly_identified_sv.scheme
+        posterior = weakly_identified_sv.idata.posterior
+        L_path = weakly_identified_sv.volatility.cholesky_path(posterior, T=100)
+
+        ratios = set()
+        with pytest.warns(UserWarning, match="weakly identified"):
+            for t in (0, 50, 99):
+                scheme.identify(L_path[:, :, t], ["y1", "y2"], posterior=posterior, n_lags=1)
+                ratios.add(f"{scheme._last_diagnostics['max_share_eigen_ratio_median']:.3f}")
+        assert len(ratios) == 3
+        assert all(float(r) > 0.9 for r in ratios)
+
+    def test_a_second_at_all_pass_stays_quiet(self, weakly_identified_sv, recwarn):
+        """A fresh `IdentifiedVAR` over the same posterior and scheme is silent."""
+        with pytest.warns(UserWarning, match="weakly identified"):
+            weakly_identified_sv.shock_matrix(at="all")
+
+        twin = IdentifiedVAR.model_construct(
+            idata=weakly_identified_sv.idata,
+            n_lags=1,
+            data=weakly_identified_sv.data,
+            var_names=["y1", "y2"],
+            volatility=_RampSV(),
+            scheme=weakly_identified_sv.scheme,
+        )
+        recwarn.clear()
+        twin.shock_matrix(at="all")
+        assert len(recwarn) == 0


### PR DESCRIPTION
## Summary

Follow-up on the max-share branch (#200), stacked on `feat/145-max-share-identification`:

`MaxShare`'s weak-identification warning fired per `identify()` call with the eigen ratio embedded to 3 dp — under `shock_matrix(at="all")` with time-varying volatility the ratio varies with each period's Cholesky factor, defeating the warnings-registry dedup (measured: 76 warnings on one call). It now warns **once per posterior**, keyed alongside the spectral cache, on the *first crossing* rather than the first call (a healthy first period doesn't spend the posterior's one warning). The message states the once-per-posterior semantics and points at `max_share_diagnostics()` with an explicit `L` for the per-period picture. Per-call eigen-ratio diagnostics unchanged.

Tests include a ramped time-varying-volatility stub (all 199 periods weak, ~76 distinct ratios) pinning exactly one warning, a first-crossing-not-first-call pin, a fresh-posterior re-warn pin, and the constant-volatility regression pin. Reverting only the dedup guard fails 3 tests with the original 76-warning behaviour.

Closes #202

## Gates

88 identification/pipeline tests green; branch fast suite 583 passed; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV