### PR TITLE
feat(predictive): prior_predictive on VAR, posterior_predictive on FittedVAR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,10 @@ _Avoid_: presenting the contemporaneous split of the one-step forecast error (`u
 The in-sample "what if": back out the realised structural shocks per posterior draw (`ε_t = P_t⁻¹ u_t`), overwrite a chosen shock's path over a window, and re-propagate the system to get the path history would have followed. Computed by `IdentifiedVAR.counterfactual(shocks=[ShockPath(...)])`. Realised shocks are edited, never re-drawn, so the posterior spread of a counterfactual reflects parameter and identification uncertainty only. `actual − counterfactual` for a shock zeroed over the full sample equals that shock's HD contribution.
 _Avoid_: bare "counterfactual" for forecast-side operations (those are conditional forecasts or structural scenarios); "policy counterfactual" (rule replacement is a different, out-of-scope object — and the Lucas-critique caveat documented on the method applies even to fixed-path edits).
 
+**Predictive check (prior / posterior)**:
+Data simulated from the model on the *estimation window*, to be compared against the data itself. `VAR.prior_predictive(data)` draws from the PyMC graph before conditioning on the likelihood; `FittedVAR.posterior_predictive()` replicates the sample from the posterior. Both are **one step ahead given the observed lags** — `y_t = c + B x_t^obs + L_t ε_t` — so they sit on the data's own time axis and feed `az.plot_ppc` directly. The posterior-predictive innovations come from the volatility seam's `L_t`, so their spread is time-varying under SV (ADR-0011).
+_Avoid_: "forecast" for either — a forecast leaves the sample and iterates its own predictions; a predictive check never does.
+
 **Conditional forecast**:
 An h-step forecast constrained so chosen endogenous variables follow pinned future paths, with *all* structural shocks free to adjust (Waggoner–Zha 1999). Identification-free: the observable-space answer is invariant to the identification scheme, so it lives on `FittedVAR.conditional_forecast()` — the same placement logic as the dynamic multiplier. Hard (point) conditions are the v1 default — pins hold pathwise on every draw; a second v1 mode, `path_uncertainty="unconditional"` (ADPRR's Ω_f = DD′), restricts the forecast *mean* only while bands keep their unconditional width. `NaN` entries in a pinned path mean "unconstrained at that step".
 _Avoid_: "scenario" for an all-shocks-adjust conditional forecast — scenarios restrict *who* adjusts.
@@ -134,6 +138,7 @@ _Avoid_: "number of cointegrating vectors" in API surface (fine in prose); "coin
 - A **FittedVAR** computes **conditional forecasts** on its own — all shocks adjust, so no identification scheme is involved (the dynamic-multiplier placement logic).
 - An **IdentifiedVAR** computes **historical counterfactuals** and **structural scenarios** through the four-layer scenario engine (back out → constrain → solve → propagate); the propagate layer is shared with `forecast()` and the **historical decomposition**.
 - The **condition vocabulary** is consumed by all three scenario methods; each method accepts only the condition types legal for it.
+- A **VAR** simulates its own **prior predictive** from the graph it would fit; a **FittedVAR** replicates the estimation sample as a **posterior predictive**, computed in NumPy from the posterior and the volatility seam so the conjugate estimator gets it for free (ADR-0011).
 - A **VAR** is estimated by NUTS; a **ConjugateVAR** is estimated analytically with a Metropolis step on hyperparameters. Both produce a **FittedVAR**.
 - A **stationarity pretest** consumes `VARData` (endogenous block only), a DataFrame, or a Series, and produces a result object — never a modified dataset and never a specification. It sits *beside* the pipeline, not in it: nothing downstream of `VAR.fit()` reads its output.
 - **Integration order** feeds **cointegration rank**: the Johansen test is only meaningful for series that are individually integrated, and it is conditioned on a lag order (`k_ar_diff = p - 1`) that `select_lag_order` supplies.
@@ -143,6 +148,9 @@ _Avoid_: "number of cointegrating vectors" in API surface (fine in prose); "coin
 
 > **User:** "Fit a 4-variable VAR with stochastic volatility, AR(1) log-vol."
 > **Library:** `VAR(lags=4, volatility=StochasticVolatility(dynamics="ar1")).fit(VARData(...))`. The `volatility` parameter accepts a string shorthand (`"constant"`, `"sv"`) or any `VolatilityProcess` instance.
+>
+> **User:** "Is my prior sane before I spend an hour on NUTS?"
+> **Library:** `VAR(lags=4).prior_predictive(data, draws=500)` then `az.plot_ppc(idata, group="prior")`. After fitting, `fitted.posterior_predictive()` returns the same-shaped in-sample replicates for the other end of the check.
 >
 > **User:** "Show me the IRF for shocks hitting in 2008Q3."
 > **Library:** `identified.impulse_response(horizon=20, at=t_2008Q3)`. The pipeline queries `volatility.cholesky_at(t_2008Q3)` for `L`, the identification scheme rotates it into `B`, and the IRF is computed from `A_1..A_p` and `B`.

--- a/docs/adr/0011-posterior-predictive-computed-in-numpy.md
+++ b/docs/adr/0011-posterior-predictive-computed-in-numpy.md
@@ -1,0 +1,18 @@
+# Posterior predictive is computed in NumPy, not on the PyMC graph
+
+`FittedVAR.posterior_predictive` reconstructs in-sample replicates from the posterior arrays — conditional mean from `B`/`intercept`/`B_exog`, innovations from the volatility seam's `cholesky_path` — rather than calling `pymc.sample_posterior_predictive` on the stored `pymc_model`. `VAR.prior_predictive` does the opposite: it builds the graph and calls `pymc.sample_prior_predictive`.
+
+**Why the asymmetry**: a prior predictive *is* the prior, and the prior only exists in the graph — hand-rolling it is precisely the duplication issue #56 complains about. A posterior predictive, by contrast, needs nothing but the posterior draws and Σ, both of which are already NumPy.
+
+**What NumPy buys**:
+
+- **`ConjugateVAR` parity.** `ConjugateVAR` draws in closed form and builds no PyMC graph at all (`pymc_model is None`; ADR-0004). A graph-based implementation would either exclude the sibling estimator or force it to build a graph it otherwise never needs.
+- **`simulate_innovations=False`.** The conditional-mean mode is a slice of the same computation, exact and RNG-free. On the graph it would need a separate `pm.do`-style intervention.
+- **Backend independence.** No dependence on which NUTS backend produced the draws, on `idata` group layout beyond `posterior`, or on the graph surviving serialisation. `FittedVAR` round-tripped through NetCDF keeps working.
+- **The volatility seam.** `volatility.cholesky_path(posterior, T)` already returns `L_t` per draw per `t` (ADR-0001), which is exactly the innovation scale needed. Under stochastic volatility this gives genuinely time-varying replicate spread; the issue's original "residual covariance of each posterior draw" wording would have flattened it.
+
+**Cost accepted — drift.** Two implementations of the same likelihood can diverge: a change to the observation equation (Student-t errors, a mean shift, a new exogenous block) must land in both `spec.py`'s graph and `_residuals.fitted_values`. The fence is `tests/test_predictive.py::TestPredictiveAgainstPyMC::test_matches_sample_posterior_predictive`, a slow test that fits a real VAR and compares the NumPy replicates against `pm.sample_posterior_predictive` on moments. Its fixture uses strongly cross-correlated shocks on purpose: with a near-diagonal Σ, `L` and `L.T` imply nearly the same covariance and a Cholesky-orientation bug would slip through.
+
+**Considered and rejected**: routing through `pymc_model` when it is present and falling back to NumPy when it is not. Two code paths returning subtly different objects for the same public method is worse than one path plus a fence — and it would make `simulate_innovations=False` mean different things depending on the estimator.
+
+**Side benefit**: nutpie needs no caveat. The replicates never touch the sampler's backend, so a nutpie-sampled `idata` and a PyMC-sampled one behave identically here.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -10,6 +10,7 @@ custom-priors
 lag-selection
 stationarity-testing
 climate-pitfalls
+predictive-checks
 sign-restrictions
 long-run-restrictions
 heavy-tailed-errors

--- a/docs/how-to/predictive-checks.md
+++ b/docs/how-to/predictive-checks.md
@@ -1,0 +1,117 @@
+# Prior and Posterior Predictive Checks
+
+Predictive checks ask whether the model can generate data that looks like the data you have. Impulso exposes them at the two natural points in the pipeline: `VAR.prior_predictive` before fitting, and `FittedVAR.posterior_predictive` after.
+
+Both return a plain ArviZ `InferenceData`, so `az.plot_ppc` and friends work directly.
+
+## Checking the prior before you fit
+
+`VAR.prior_predictive` builds the same PyMC graph `fit` builds and draws from it with `pymc.sample_prior_predictive`. The prior you check is by construction the prior you sample:
+
+```python
+import arviz as az
+from impulso import VAR
+
+spec = VAR(lags=4, prior="minnesota")
+prior = spec.prior_predictive(data, draws=500, random_seed=0)
+
+az.plot_ppc(prior, group="prior", num_pp_samples=50)
+```
+
+The returned object has `prior` (every latent — inspect `prior["B"]` to see what the Minnesota prior actually implies for the coefficients), `prior_predictive` (the simulated `obs`), and `observed_data`.
+
+If the prior band does not contain the data, the prior is fighting the likelihood. If it is orders of magnitude wider, the prior is uninformative and you are paying for it in sampling efficiency.
+
+Compare with quantiles, not with mean ± k·sd: the default scale prior is HalfCauchy, which has no finite moments, so a prior predictive mean is meaningless.
+
+```python
+import numpy as np
+
+draws = prior.prior_predictive["obs"].values[0]   # (draws, time, var)
+lower, upper = np.quantile(draws, [0.025, 0.975], axis=0)
+
+observed = prior.observed_data["obs"].values      # already lag-trimmed
+covered = ((observed >= lower) & (observed <= upper)).mean()
+```
+
+:::{note}
+`pymc.sample_prior_predictive` returns a single chain, so `obs` has shape `(1, draws, T - lags, n_vars)`.
+:::
+
+:::{note}
+With `volatility="sv"`, the per-variable log-volatility priors are seeded from the OLS residuals of `data`. That "prior" is therefore mildly data-informed in its scale. The constant-volatility default is not.
+:::
+
+## Checking the fit afterwards
+
+`FittedVAR.posterior_predictive` replicates the estimation sample from the posterior:
+
+```python
+fitted = spec.fit(data)
+ppc = fitted.posterior_predictive(seed=0)
+
+az.plot_ppc(ppc, num_pp_samples=100)
+```
+
+Each replicate is **one-step-ahead conditioned on the observed lags**:
+
+$$
+y^{rep}_t = c + B x^{obs}_t + B_{exog} z_t + L_t \varepsilon_t, \qquad \varepsilon_t \sim N(0, I)
+$$
+
+That is the standard posterior-predictive object for a conditional model, and the one `az.plot_ppc` expects. It is *not* a path simulated forward from initial conditions — for that, use `fitted.forecast(steps=...)`, which iterates its own predictions.
+
+`L_t` comes from the volatility process, so under `volatility="sv"` the replicate spread genuinely varies with `t`.
+
+### Coverage
+
+A quick calibration check — what fraction of the observed data lands inside the 95% predictive band:
+
+```python
+import numpy as np
+
+draws = ppc.posterior_predictive["obs"].values          # (chain, draw, time, var)
+flat = draws.reshape(-1, *draws.shape[2:])              # (chain*draw, time, var)
+lower, upper = np.quantile(flat, [0.025, 0.975], axis=0)
+
+observed = ppc.observed_data["obs"].values
+coverage = ((observed >= lower) & (observed <= upper)).mean()
+print(f"95% band covers {coverage:.1%} of observations")
+```
+
+Substantially below 95% means the model is over-confident; substantially above means it is over-dispersed.
+
+### Mean mode for residual diagnostics
+
+`simulate_innovations=False` drops the innovation term and returns the conditional mean under parameter uncertainty. Subtracting it from the observed data gives the reduced-form residuals per draw:
+
+```python
+fit_only = fitted.posterior_predictive(simulate_innovations=False)
+
+residuals = fit_only.observed_data["obs"].values - fit_only.posterior_predictive["obs"].values
+```
+
+Mean mode consumes no randomness at all, so `seed` is irrelevant there and repeated calls agree exactly.
+
+## Attaching the result to the fit
+
+`posterior_predictive` never mutates `fitted.idata`; it returns a fresh object. Attach it yourself when you want a single `InferenceData` for downstream ArviZ work:
+
+```python
+fitted.idata.extend(ppc)
+az.plot_ppc(fitted.idata)
+```
+
+:::{admonition} Memory
+:class: warning
+The replicate array is dense: `chains × draws × T × n_vars` float64 values — roughly 19 MB at 4 chains, 1000 draws, 200 dates and 3 variables, and it grows linearly in all four. Thin the posterior before calling if that is too large.
+:::
+
+## Which method for which question
+
+| Question | Method |
+| --- | --- |
+| Is my prior plausible before I see the data? | `VAR.prior_predictive(data)` |
+| Can the fitted model reproduce the sample it was fitted to? | `FittedVAR.posterior_predictive()` |
+| What happens after the sample ends? | `FittedVAR.forecast(steps=...)` |
+| What happens if a variable follows a pinned path? | `FittedVAR.conditional_forecast(...)` |

--- a/src/impulso/_residuals.py
+++ b/src/impulso/_residuals.py
@@ -1,9 +1,10 @@
-"""Reduced-form residual reconstruction from posterior draws.
+"""Reduced-form fitted values and residuals from posterior draws.
 
-Shared by `IdentifiedVAR.historical_decomposition` and identification
-schemes that need residuals (e.g. `ProxySVAR`). Reconstruction from
-`B`/`intercept` draws is cheap and exact, so residuals are never stored
-in the posterior.
+Shared by `IdentifiedVAR.historical_decomposition`, identification
+schemes that need residuals (e.g. `ProxySVAR`), and
+`FittedVAR.posterior_predictive` (which needs the conditional mean
+only). Reconstruction from `B`/`intercept` draws is cheap and exact, so
+neither fitted values nor residuals are stored in the posterior.
 """
 
 from typing import TYPE_CHECKING
@@ -14,6 +15,45 @@ if TYPE_CHECKING:
     import xarray as xr
 
     from impulso.data import VARData
+
+
+def fitted_values(posterior: "xr.Dataset", data: "VARData", n_lags: int) -> np.ndarray:
+    """Reconstruct per-draw one-step-ahead conditional means on the estimation sample.
+
+    Computes `E[y_t | y_{t-1}, ..., y_{t-p}, theta] = intercept + B @ x_lag_t`
+    for every posterior draw, where `x_lag_t` stacks lags 1..n_lags (lag-1
+    block first) of the **observed** data. For models with exogenous
+    variables, the `B_exog @ x_exog_t` contribution is added.
+
+    Because the lags are the observed ones (never simulated), this is the
+    one-step-ahead in-sample fit, not an iterated simulated path — the
+    latter is `FittedVAR.forecast`'s job.
+
+    Args:
+        posterior: Posterior Dataset holding `B` (chains, draws, n, n*p),
+            `intercept` (chains, draws, n) and, when the model has
+            exogenous variables, `B_exog`.
+        data: The VARData used at fit time.
+        n_lags: Lag order of the fitted VAR.
+
+    Returns:
+        Conditional-mean array of shape `(chains, draws, T - n_lags, n_vars)`,
+        time-aligned with `data.index[n_lags:]`.
+    """
+    B_draws = posterior["B"].values  # (C, D, n, n*p)
+    intercept_draws = posterior["intercept"].values  # (C, D, n)
+
+    y = data.endog  # (T, n)
+    T = y.shape[0]
+
+    x_lag = np.concatenate(
+        [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
+        axis=1,
+    )  # (T-p, n*p)
+    y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
+    if data.exog is not None and "B_exog" in posterior:
+        y_hat = y_hat + np.einsum("cdij,tj->cdti", posterior["B_exog"].values, data.exog[n_lags:])
+    return y_hat
 
 
 def reduced_form_residuals(posterior: "xr.Dataset", data: "VARData", n_lags: int) -> np.ndarray:
@@ -35,18 +75,6 @@ def reduced_form_residuals(posterior: "xr.Dataset", data: "VARData", n_lags: int
         Residual array of shape `(chains, draws, T - n_lags, n_vars)`,
         time-aligned with `data.index[n_lags:]`.
     """
-    B_draws = posterior["B"].values  # (C, D, n, n*p)
-    intercept_draws = posterior["intercept"].values  # (C, D, n)
-
-    y = data.endog  # (T, n)
-    T = y.shape[0]
-
-    x_lag = np.concatenate(
-        [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
-        axis=1,
-    )  # (T-p, n*p)
-    y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
-    if data.exog is not None and "B_exog" in posterior:
-        y_hat = y_hat + np.einsum("cdij,tj->cdti", posterior["B_exog"].values, data.exog[n_lags:])
-    y_obs = y[n_lags:]
+    y_hat = fitted_values(posterior, data, n_lags)
+    y_obs = data.endog[n_lags:]
     return y_obs[np.newaxis, np.newaxis, :, :] - y_hat

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -152,6 +152,7 @@ class FittedVAR(ImpulsoBaseModel):
         inflation = np.asarray(inflation)
         extra_dims = sigma.ndim - inflation.ndim
         return sigma * inflation.reshape(inflation.shape + (1,) * extra_dims)
+
     def posterior_predictive(
         self,
         *,

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -152,6 +152,104 @@ class FittedVAR(ImpulsoBaseModel):
         inflation = np.asarray(inflation)
         extra_dims = sigma.ndim - inflation.ndim
         return sigma * inflation.reshape(inflation.shape + (1,) * extra_dims)
+    def posterior_predictive(
+        self,
+        *,
+        simulate_innovations: bool = True,
+        seed: int | np.random.Generator | None = None,
+    ) -> az.InferenceData:
+        """Replicate the estimation sample from the posterior.
+
+        For every posterior draw and every in-sample date `t`,
+
+            y_rep[t] = intercept + B x_t^obs (+ B_exog z_t) + L_t eps_t,
+            eps_t ~ N(0, I)
+
+        where `x_t^obs` stacks the **observed** lags. The replicates are
+        therefore *one-step-ahead conditioned on the observed history*, the
+        same object `pymc.sample_posterior_predictive` returns on the fitted
+        graph and the one `arviz.plot_ppc` expects — not an iterated
+        simulated path from initial conditions, which is `forecast`'s job.
+
+        `L_t` comes from the volatility seam
+        (`volatility.cholesky_path(posterior, T=T)`), so the innovations use
+        the *model's own* Σ: a single Σ under constant volatility, and a
+        genuinely per-draw, per-`t` Σ_t under stochastic volatility (an
+        empirical residual covariance would flatten exactly the
+        heteroscedasticity an SV fit exists to capture).
+
+        With `simulate_innovations=False` the conditional means come back
+        unperturbed — the in-sample fit under parameter uncertainty, useful
+        for residual diagnostics (`observed - mean` is exactly the
+        reduced-form residual). Mean mode consumes no randomness at all, so
+        `seed` is irrelevant there.
+
+        Computed in NumPy rather than on a PyMC graph, so it works for
+        `ConjugateVAR`-derived posteriors too (no graph exists there); see
+        ADR-0011.
+
+        Note:
+            `self.idata` is never mutated — a fresh `InferenceData` comes
+            back. To attach the result to the fit, extend it yourself:
+
+                ppc = fitted.posterior_predictive(seed=0)
+                fitted.idata.extend(ppc)
+
+        Note:
+            The replicate array is dense: `chains * draws * T * n_vars`
+            float64 values, roughly 19 MB at 4 chains, 1000 draws, 200
+            dates and 3 variables. Thin the posterior before calling if
+            that is too large.
+
+        Args:
+            simulate_innovations: If `True` (default), add shock
+                innovations drawn from the volatility process's in-sample
+                Cholesky path — a true posterior-predictive density. If
+                `False`, return the conditional mean only.
+            seed: RNG seed (int) or Generator for reproducible replicates.
+                Ignored when `simulate_innovations=False`.
+
+        Returns:
+            ArviZ InferenceData with a `posterior_predictive` group holding
+            `obs` with dims `(chain, draw, time, var)` and an
+            `observed_data` group holding the realised `obs` with dims
+            `(time, var)`. Both are time-aligned with
+            `data.index[n_lags:]`.
+
+        Raises:
+            ValueError: If the data carries exogenous regressors the
+                estimator never consumed (no `B_exog` in the posterior).
+        """
+        import xarray as xr
+
+        from impulso._residuals import fitted_values
+
+        posterior = self.idata.posterior
+        if self.data.exog is not None and "B_exog" not in posterior:
+            raise ValueError(
+                "This FittedVAR's data carries exogenous regressors the estimator "
+                "never consumed (no B_exog in the posterior); refit with an "
+                "estimator that supports them before replicating the sample."
+            )
+
+        mu = fitted_values(posterior, self.data, self.n_lags)  # (C, D, T, n)
+        y_rep = mu
+        if simulate_innovations:
+            rng = np.random.default_rng(seed) if not isinstance(seed, np.random.Generator) else seed
+            L_path = self.volatility.cholesky_path(posterior, T=mu.shape[2])  # (C, D, T, n, n)
+            eps = rng.standard_normal(mu.shape)
+            y_rep = mu + np.einsum("cdtij,cdtj->cdti", L_path, eps)
+
+        time = self.data.index[self.n_lags :]
+        coords = {"time": time, "var": self.var_names}
+        return az.InferenceData(
+            posterior_predictive=xr.Dataset({
+                "obs": xr.DataArray(y_rep, dims=["chain", "draw", "time", "var"], coords=coords, name="obs")
+            }),
+            observed_data=xr.Dataset({
+                "obs": xr.DataArray(self.data.endog[self.n_lags :], dims=["time", "var"], coords=coords, name="obs")
+            }),
+        )
 
     def forecast(
         self,

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -221,6 +221,7 @@ class VAR(ImpulsoBaseModel):
             data=data,
             var_names=data.endog_names,
             volatility=self.resolved_volatility,
+            error_dist=self.resolved_error_dist,
             pymc_model=model,
         )
 
@@ -396,16 +397,4 @@ class VAR(ImpulsoBaseModel):
             error_dist = self.resolved_error_dist
             error_dist.build_likelihood("obs", mu=mu, chol=L, observed=Y, dims=("time", "var"))
 
-        # Sample
-        idata = sampler.sample(model)
-
-        return FittedVAR.model_construct(
-            idata=idata,
-            n_lags=n_lags,
-            data=data,
-            var_names=data.endog_names,
-            volatility=self.resolved_volatility,
-            error_dist=error_dist,
-            pymc_model=model,
-        )
         return model, n_lags

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -15,6 +15,7 @@ from impulso.sv.spec import StochasticVolatility
 from impulso.volatility import Constant
 
 if TYPE_CHECKING:
+    import arviz as az
     import pymc as pm
 
     from impulso.fitted import FittedVAR
@@ -221,6 +222,59 @@ class VAR(ImpulsoBaseModel):
             volatility=self.resolved_volatility,
             pymc_model=model,
         )
+
+    def prior_predictive(
+        self,
+        data: VARData,
+        *,
+        draws: int = 500,
+        random_seed: int | np.random.Generator | None = None,
+    ) -> "az.InferenceData":
+        """Simulate data from the prior, before seeing the likelihood.
+
+        Builds the same PyMC graph `fit` builds and calls
+        `pymc.sample_prior_predictive` on it, so the prior that gets
+        simulated is exactly the prior that gets sampled — no hand-rolled
+        second implementation to drift out of sync.
+
+        The simulated `obs` paths are **one-step-ahead given the observed
+        lags**: for each prior draw, `y_t = c + B x_t^obs (+ B_exog z_t) +
+        L_t eps_t` where `x_t^obs` stacks the *observed* lags of `data`.
+        The design matrices are baked into the graph, so this is the prior
+        predictive of the estimation-sample conditional means, not a
+        simulated path iterated from initial conditions. That is what
+        `arviz.plot_ppc(..., group="prior")` expects and what makes the
+        prior comparable to the data on the same time axis.
+
+        Note:
+            Under `volatility="sv"` the per-variable log-volatility priors
+            are seeded from the OLS residuals of `data` (see
+            `StochasticVolatility.build_pymc_latent`), so the "prior" is
+            mildly data-informed in its scale. The constant-volatility
+            default is not.
+
+        Note:
+            PyMC returns a single chain, so the `obs` variable has shape
+            `(1, draws, T - n_lags, n_vars)`.
+
+        Args:
+            data: VARData instance. Anchors the prior simulation on the real
+                lags (and, if present, the real exogenous regressors), and
+                fixes the lag order when `lags` is a selection criterion.
+            draws: Number of prior draws.
+            random_seed: Seed or Generator passed straight through to
+                `pymc.sample_prior_predictive`.
+
+        Returns:
+            ArviZ InferenceData with `prior` (every latent), `prior_predictive`
+            (the simulated `obs`, dims `(chain, draw, time, var)`) and
+            `observed_data` (the realised `obs`) groups.
+        """
+        import pymc as pm
+
+        model, _ = self._build_pymc_model(data)
+        with model:
+            return pm.sample_prior_predictive(draws=draws, random_seed=random_seed)
 
     def _build_pymc_model(self, data: VARData) -> tuple["pm.Model", int]:
         """Build the PyMC model graph for this specification.

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -1,8 +1,9 @@
 """VAR model specification."""
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
+import arviz as az
 import numpy as np
 from pydantic import Field, model_validator
 
@@ -15,9 +16,6 @@ from impulso.sv.spec import StochasticVolatility
 from impulso.volatility import Constant
 
 if TYPE_CHECKING:
-    import arviz as az
-    import pymc as pm
-
     from impulso.fitted import FittedVAR
 
 _PRIOR_REGISTRY: dict[str, type] = {
@@ -229,7 +227,7 @@ class VAR(ImpulsoBaseModel):
         *,
         draws: int = 500,
         random_seed: int | np.random.Generator | None = None,
-    ) -> "az.InferenceData":
+    ) -> az.InferenceData:
         """Simulate data from the prior, before seeing the likelihood.
 
         Builds the same PyMC graph `fit` builds and calls
@@ -276,7 +274,7 @@ class VAR(ImpulsoBaseModel):
         with model:
             return pm.sample_prior_predictive(draws=draws, random_seed=random_seed)
 
-    def _build_pymc_model(self, data: VARData) -> tuple["pm.Model", int]:
+    def _build_pymc_model(self, data: VARData) -> tuple[Any, int]:
         """Build the PyMC model graph for this specification.
 
         Resolves the lag order (running `select_lag_order` when `lags` is a
@@ -292,7 +290,9 @@ class VAR(ImpulsoBaseModel):
             data: VARData instance.
 
         Returns:
-            Tuple of the built `pymc.Model` and the resolved lag order.
+            Tuple of the built `pymc.Model` and the resolved lag order. The
+            model is typed `Any` so that importing `impulso.spec` does not
+            pull in PyMC — the same reason `FittedVAR.pymc_model` is.
         """
         import pymc as pm
 

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -15,6 +15,8 @@ from impulso.sv.spec import StochasticVolatility
 from impulso.volatility import Constant
 
 if TYPE_CHECKING:
+    import pymc as pm
+
     from impulso.fitted import FittedVAR
 
 _PRIOR_REGISTRY: dict[str, type] = {
@@ -201,13 +203,46 @@ class VAR(ImpulsoBaseModel):
         Returns:
             FittedVAR with posterior draws.
         """
-        import pymc as pm
-
-        from impulso._lag_selection import select_lag_order
         from impulso.fitted import FittedVAR
 
         if sampler is None:
             sampler = self._default_sampler()
+
+        model, n_lags = self._build_pymc_model(data)
+
+        # Sample
+        idata = sampler.sample(model)
+
+        return FittedVAR.model_construct(
+            idata=idata,
+            n_lags=n_lags,
+            data=data,
+            var_names=data.endog_names,
+            volatility=self.resolved_volatility,
+            pymc_model=model,
+        )
+
+    def _build_pymc_model(self, data: VARData) -> tuple["pm.Model", int]:
+        """Build the PyMC model graph for this specification.
+
+        Resolves the lag order (running `select_lag_order` when `lags` is a
+        criterion string), assembles the design matrices, and registers the
+        intercept, coefficient, volatility and likelihood nodes. The design
+        matrices are baked into the graph as constants, so the returned model
+        is tied to `data`.
+
+        Shared by `fit` (which samples the graph) and `prior_predictive`
+        (which draws from it without conditioning on the observations).
+
+        Args:
+            data: VARData instance.
+
+        Returns:
+            Tuple of the built `pymc.Model` and the resolved lag order.
+        """
+        import pymc as pm
+
+        from impulso._lag_selection import select_lag_order
 
         # Resolve lags
         if isinstance(self.lags, str):
@@ -313,3 +348,4 @@ class VAR(ImpulsoBaseModel):
             error_dist=error_dist,
             pymc_model=model,
         )
+        return model, n_lags

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -132,6 +132,9 @@ class VAR(ImpulsoBaseModel):
             degrees of freedom; pass `StudentT(nu=5.0)` to fix them. Heavy-
             tailed errors are rejected in combination with time-varying
             volatility.
+            Governs the exogenous block only; `prior` governs the lag
+            coefficients. Both `VAR.fit` and `VAR.prior_predictive` build the
+            same graph, so it applies to either.
     """
 
     lags: int | Literal["aic", "bic", "hq"] = Field(...)
@@ -279,12 +282,15 @@ class VAR(ImpulsoBaseModel):
 
         Resolves the lag order (running `select_lag_order` when `lags` is a
         criterion string), assembles the design matrices, and registers the
-        intercept, coefficient, volatility and likelihood nodes. The design
-        matrices are baked into the graph as constants, so the returned model
-        is tied to `data`.
+        intercept, coefficient, exogenous, volatility and likelihood nodes.
+        The design matrices are baked into the graph as constants, so the
+        returned model is tied to `data`.
 
         Shared by `fit` (which samples the graph) and `prior_predictive`
-        (which draws from it without conditioning on the observations).
+        (which draws from it without conditioning on the observations). Every
+        prior lives here, including the scale-adaptive `B_exog` prior
+        (`_exog_prior_sigma`), so a prior-predictive check cannot describe a
+        different model from the one `fit` estimates.
 
         Args:
             data: VARData instance.

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -15,6 +15,7 @@ from impulso import VAR, VARData
 from impulso._lag_selection import select_lag_order
 from impulso._residuals import fitted_values, reduced_form_residuals
 from impulso.fitted import FittedVAR
+from impulso.spec import _exog_prior_sigma
 from impulso.volatility import Constant
 
 # Driven in a fresh interpreter: enable_runtime_checks() beartype-wraps the
@@ -155,6 +156,27 @@ class TestPriorPredictive:
 
         assert "B_exog" in idata.prior
         assert idata.prior["B_exog"].shape == (1, 10, 2, 1)
+
+    def test_b_exog_draws_use_the_scale_adaptive_prior(self, var_data_2v_exog):
+        """The simulated `B_exog` spreads at `_exog_prior_sigma`, not at 1 (#192).
+
+        `_build_pymc_model` owns the scaled exog prior, so the graph this
+        method draws from is the graph `fit` samples. Were the scaling to
+        live in `fit`, these draws would come out at unit scale and the
+        check would describe a model nobody fitted.
+        """
+        idata = VAR(lags=1).prior_predictive(var_data_2v_exog, draws=4000, random_seed=0)
+
+        expected = _exog_prior_sigma(
+            var_data_2v_exog.endog,
+            var_data_2v_exog.exog[1:],
+            100.0,
+        )
+        got = idata.prior["B_exog"].values[0].std(axis=0, ddof=1)
+
+        np.testing.assert_allclose(got, expected, rtol=0.1)
+        # The old unit-scale prior is orders of magnitude away from this.
+        assert np.all(expected > 10.0)
 
     def test_observed_series_falls_within_the_prior_band(self, var_data_2v):
         """Issue AC: the observed series must sit inside the 95% prior band.

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -1,0 +1,101 @@
+"""Tests for the prior- and posterior-predictive APIs (issue #56)."""
+
+import arviz as az
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+from impulso import VAR, VARData
+from impulso._lag_selection import select_lag_order
+
+
+@pytest.fixture
+def var_data_2v_exog(var_data_2v):
+    """`var_data_2v` plus a single deterministic exogenous column."""
+    T = var_data_2v.endog.shape[0]
+    exog = np.linspace(-1.0, 1.0, T).reshape(T, 1)
+    return VARData(
+        endog=var_data_2v.endog,
+        endog_names=list(var_data_2v.endog_names),
+        exog=exog,
+        exog_names=["x1"],
+        index=var_data_2v.index,
+    )
+
+
+class TestPriorPredictive:
+    """`VAR.prior_predictive` draws from the same graph `fit` samples."""
+
+    def test_groups_and_variable(self, var_data_2v):
+        idata = VAR(lags=1).prior_predictive(var_data_2v, draws=50, random_seed=0)
+
+        assert {"prior", "prior_predictive", "observed_data"} <= set(idata.groups())
+        assert "obs" in idata.prior_predictive
+        assert "obs" in idata.observed_data
+        # The latents are simulated too, so the prior itself is inspectable.
+        assert {"intercept", "B", "sigma_sd"} <= set(idata.prior.data_vars)
+
+    def test_shape_dims_and_coords(self, var_data_2v):
+        idata = VAR(lags=1).prior_predictive(var_data_2v, draws=50, random_seed=0)
+
+        obs = idata.prior_predictive["obs"]
+        # PyMC's prior predictive is a single chain.
+        assert obs.shape == (1, 50, 199, 2)
+        assert obs.dims == ("chain", "draw", "time", "var")
+        assert list(obs.coords["var"].values) == ["y1", "y2"]
+        assert np.array_equal(
+            pd.to_datetime(obs.coords["time"].values),
+            var_data_2v.index[1:],
+        )
+        assert idata.observed_data["obs"].dims == ("time", "var")
+        assert np.array_equal(idata.observed_data["obs"].values, var_data_2v.endog[1:])
+
+    def test_random_seed_is_reproducible(self, var_data_2v):
+        spec = VAR(lags=1)
+        a = spec.prior_predictive(var_data_2v, draws=20, random_seed=0)
+        b = spec.prior_predictive(var_data_2v, draws=20, random_seed=0)
+        c = spec.prior_predictive(var_data_2v, draws=20, random_seed=1)
+
+        assert np.array_equal(a.prior_predictive["obs"].values, b.prior_predictive["obs"].values)
+        assert not np.array_equal(a.prior_predictive["obs"].values, c.prior_predictive["obs"].values)
+
+    def test_lag_order_trims_the_time_axis(self, var_data_2v):
+        idata = VAR(lags=3).prior_predictive(var_data_2v, draws=10, random_seed=0)
+
+        assert idata.prior_predictive["obs"].shape[2] == 197
+
+    def test_criterion_lags_resolve_like_fit(self, var_data_2v):
+        idata = VAR(lags="bic").prior_predictive(var_data_2v, draws=10, random_seed=0)
+
+        expected_lags = select_lag_order(var_data_2v, max_lags=12).bic
+        assert idata.prior_predictive["obs"].shape[2] == 200 - expected_lags
+
+    def test_exogenous_regressors_are_simulated(self, var_data_2v_exog):
+        idata = VAR(lags=1).prior_predictive(var_data_2v_exog, draws=10, random_seed=0)
+
+        assert "B_exog" in idata.prior
+        assert idata.prior["B_exog"].shape == (1, 10, 2, 1)
+
+    def test_observed_series_falls_within_the_prior_band(self, var_data_2v):
+        """Issue AC: the observed series must sit inside the 95% prior band.
+
+        Quantiles, never mean +/- k*sd: the HalfCauchy scale prior has no
+        finite moments, so a moment-based band is meaningless here.
+        """
+        idata = VAR(lags=1).prior_predictive(var_data_2v, draws=500, random_seed=0)
+
+        draws = idata.prior_predictive["obs"].values[0]  # (draws, time, var)
+        lower, upper = np.quantile(draws, [0.025, 0.975], axis=0)
+        observed = var_data_2v.endog[1:]
+        covered = (observed >= lower) & (observed <= upper)
+        assert covered.mean() >= 0.9
+
+    def test_plot_ppc_smoke(self, var_data_2v):
+        """`az.plot_ppc` must accept the group as returned (datetime time coord)."""
+        idata = VAR(lags=1).prior_predictive(var_data_2v, draws=20, random_seed=0)
+
+        axes = az.plot_ppc(idata, group="prior", num_pp_samples=5)
+        assert axes is not None

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -1,5 +1,8 @@
 """Tests for the prior- and posterior-predictive APIs (issue #56)."""
 
+import subprocess
+import sys
+
 import arviz as az
 import matplotlib
 import numpy as np
@@ -13,6 +16,43 @@ from impulso._lag_selection import select_lag_order
 from impulso._residuals import fitted_values, reduced_form_residuals
 from impulso.fitted import FittedVAR
 from impulso.volatility import Constant
+
+# Driven in a fresh interpreter: enable_runtime_checks() beartype-wraps the
+# library's classes in place, so the wrapping must not leak into the rest of
+# the suite. Beartype resolves return annotations on call, and it cannot
+# resolve a DOTTED forward reference whose module is TYPE_CHECKING-only
+# (`"pm.Model"` blows up with BeartypeCallHintForwardRefException). This
+# script is the regression fence for that.
+_RUNTIME_CHECKS_SCRIPT = """
+import numpy as np
+import pandas as pd
+
+import impulso
+
+impulso.enable_runtime_checks()
+
+from beartype.roar import BeartypeCallHintViolation
+from impulso import VAR, VARData
+
+rng = np.random.default_rng(0)
+index = pd.date_range("2000-01-01", periods=40, freq="QS")
+data = VARData(endog=rng.standard_normal((40, 2)) * 0.1, endog_names=["y1", "y2"], index=index)
+
+spec = VAR(lags=1)
+prior = spec.prior_predictive(data, draws=5, random_seed=0)
+assert prior.prior_predictive["obs"].shape == (1, 5, 39, 2)
+
+fitted = spec.fit(data, sampler=impulso.NUTSSampler(draws=5, tune=5, chains=1, cores=1, progressbar=False))
+assert fitted.posterior_predictive(seed=0).posterior_predictive["obs"].shape == (1, 5, 39, 2)
+print("PREDICTIVE_OK")
+
+try:
+    spec.prior_predictive(data, draws="five")
+except BeartypeCallHintViolation:
+    print("VIOLATION_CAUGHT")
+else:
+    raise AssertionError("beartype did not flag draws='five'")
+"""
 
 
 @pytest.fixture
@@ -248,6 +288,23 @@ class TestPosteriorPredictive:
 
         axes = az.plot_ppc(ppc, num_pp_samples=5)
         assert axes is not None
+
+
+class TestPredictiveRuntimeChecks:
+    """Both methods must survive `impulso.enable_runtime_checks()`."""
+
+    @pytest.mark.slow
+    def test_beartype_resolves_the_predictive_annotations(self):
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", _RUNTIME_CHECKS_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        assert "PREDICTIVE_OK" in result.stdout, result.stdout
+        assert "VIOLATION_CAUGHT" in result.stdout, result.stdout
 
 
 class TestPredictiveAgainstPyMC:

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -10,6 +10,9 @@ matplotlib.use("Agg")
 
 from impulso import VAR, VARData
 from impulso._lag_selection import select_lag_order
+from impulso._residuals import fitted_values, reduced_form_residuals
+from impulso.fitted import FittedVAR
+from impulso.volatility import Constant
 
 
 @pytest.fixture
@@ -23,6 +26,40 @@ def var_data_2v_exog(var_data_2v):
         exog=exog,
         exog_names=["x1"],
         index=var_data_2v.index,
+    )
+
+
+@pytest.fixture
+def var_data_2v_correlated():
+    """VAR(1) DGP whose reduced-form shocks are strongly cross-correlated.
+
+    `var_data_2v`'s shocks are independent, so `L` and `L.T` imply almost
+    the same covariance and a Cholesky-orientation bug would slip through
+    the drift fence. Here `corr(u1, u2) ~ 0.83`.
+    """
+    rng = np.random.default_rng(11)
+    T, n = 200, 2
+    A = np.array([[0.5, 0.1], [0.0, 0.4]])
+    L_true = np.array([[0.20, 0.0], [0.15, 0.10]])
+    y = np.zeros((T, n))
+    for t in range(1, T):
+        y[t] = A @ y[t - 1] + L_true @ rng.standard_normal(n)
+    return VARData(
+        endog=y,
+        endog_names=["y1", "y2"],
+        index=pd.date_range("2000-01-01", periods=T, freq="QS"),
+    )
+
+
+@pytest.fixture
+def fitted_2v(synthetic_idata_2v, var_data_2v):
+    """FittedVAR over the synthetic 2-var posterior — no MCMC."""
+    return FittedVAR(
+        idata=synthetic_idata_2v,
+        n_lags=1,
+        data=var_data_2v,
+        var_names=["y1", "y2"],
+        volatility=Constant(),
     )
 
 
@@ -99,3 +136,227 @@ class TestPriorPredictive:
 
         axes = az.plot_ppc(idata, group="prior", num_pp_samples=5)
         assert axes is not None
+
+
+class TestPosteriorPredictive:
+    """`FittedVAR.posterior_predictive` replicates the estimation sample."""
+
+    def test_shape_dims_and_observed_data(self, fitted_2v, var_data_2v):
+        ppc = fitted_2v.posterior_predictive(seed=0)
+
+        obs = ppc.posterior_predictive["obs"]
+        assert obs.shape == (2, 50, 199, 2)
+        assert obs.dims == ("chain", "draw", "time", "var")
+        assert list(obs.coords["var"].values) == ["y1", "y2"]
+        assert np.array_equal(pd.to_datetime(obs.coords["time"].values), var_data_2v.index[1:])
+        assert ppc.observed_data["obs"].dims == ("time", "var")
+        assert np.array_equal(ppc.observed_data["obs"].values, var_data_2v.endog[1:])
+
+    def test_mean_mode_ties_the_residual_helpers(self, fitted_2v, var_data_2v):
+        """Mean mode IS the conditional mean, so observed - mean IS the residual."""
+        ppc = fitted_2v.posterior_predictive(simulate_innovations=False)
+
+        posterior = fitted_2v.idata.posterior
+        mu = fitted_values(posterior, var_data_2v, 1)
+        assert np.array_equal(ppc.posterior_predictive["obs"].values, mu)
+
+        implied = ppc.observed_data["obs"].values - ppc.posterior_predictive["obs"].values
+        assert np.array_equal(implied, reduced_form_residuals(posterior, var_data_2v, 1))
+
+    def test_mean_mode_consumes_no_randomness(self, fitted_2v):
+        """Two unseeded mean-mode calls must agree exactly."""
+        a = fitted_2v.posterior_predictive(simulate_innovations=False)
+        b = fitted_2v.posterior_predictive(simulate_innovations=False)
+
+        assert np.array_equal(
+            a.posterior_predictive["obs"].values,
+            b.posterior_predictive["obs"].values,
+        )
+
+    def test_seed_is_reproducible_and_accepts_a_generator(self, fitted_2v):
+        a = fitted_2v.posterior_predictive(seed=0)
+        b = fitted_2v.posterior_predictive(seed=0)
+        c = fitted_2v.posterior_predictive(seed=1)
+        g = fitted_2v.posterior_predictive(seed=np.random.default_rng(0))
+
+        assert np.array_equal(a.posterior_predictive["obs"].values, b.posterior_predictive["obs"].values)
+        assert not np.array_equal(a.posterior_predictive["obs"].values, c.posterior_predictive["obs"].values)
+        assert np.array_equal(a.posterior_predictive["obs"].values, g.posterior_predictive["obs"].values)
+
+    def test_innovations_carry_the_models_sigma(self, fitted_2v, var_data_2v):
+        """Standardising by each draw's own L must leave white noise.
+
+        This is the assertion that pins the deviation from the issue text:
+        Sigma comes from the volatility seam (the model's own Sigma), not
+        from an empirical residual covariance.
+        """
+        ppc = fitted_2v.posterior_predictive(seed=0)
+
+        posterior = fitted_2v.idata.posterior
+        mu = fitted_values(posterior, var_data_2v, 1)
+        innovations = ppc.posterior_predictive["obs"].values - mu  # (C, D, T, n)
+        L = posterior["L"].values  # (C, D, n, n)
+
+        # eps = L^-1 @ innovation, solved per draw against the whole time block.
+        eps = np.linalg.solve(
+            L[:, :, np.newaxis, :, :],
+            innovations[..., np.newaxis],
+        )[..., 0]
+        pooled = eps.reshape(-1, eps.shape[-1])  # (C*D*T, n)
+
+        assert pooled.shape[0] == 2 * 50 * 199
+        assert np.abs(pooled.mean(axis=0)).max() < 0.05
+        assert np.allclose(np.cov(pooled, rowvar=False), np.eye(2), atol=0.06)
+
+    def test_does_not_mutate_the_fit(self, fitted_2v):
+        before = set(fitted_2v.idata.groups())
+        ppc = fitted_2v.posterior_predictive(seed=0)
+
+        assert set(fitted_2v.idata.groups()) == before
+        assert "posterior_predictive" not in before
+
+        # The documented recipe for attaching it must work.
+        fitted_2v.idata.extend(ppc)
+        assert "posterior_predictive" in set(fitted_2v.idata.groups())
+
+    def test_exog_without_b_exog_raises(self, synthetic_idata_2v, var_data_2v_exog):
+        fitted = FittedVAR(
+            idata=synthetic_idata_2v,
+            n_lags=1,
+            data=var_data_2v_exog,
+            var_names=["y1", "y2"],
+            volatility=Constant(),
+        )
+
+        with pytest.raises(ValueError, match="B_exog"):
+            fitted.posterior_predictive(seed=0)
+
+    def test_conjugate_var_posterior_predictive(self, var_data_2v):
+        """ConjugateVAR builds no PyMC graph, so NumPy parity is the point."""
+        from impulso.conjugate import ConjugateVAR
+        from impulso.priors import NIWPrior
+
+        fitted = ConjugateVAR(lags=1, prior=NIWPrior(), draws=40, tune=40, seed=0).fit(var_data_2v)
+        assert fitted.pymc_model is None
+
+        ppc = fitted.posterior_predictive(seed=0)
+        assert ppc.posterior_predictive["obs"].shape == (1, 40, 199, 2)
+        assert np.isfinite(ppc.posterior_predictive["obs"].values).all()
+
+    def test_plot_ppc_smoke(self, fitted_2v):
+        ppc = fitted_2v.posterior_predictive(seed=0)
+
+        axes = az.plot_ppc(ppc, num_pp_samples=5)
+        assert axes is not None
+
+
+class TestPredictiveAgainstPyMC:
+    """The drift fence for ADR-0011: NumPy replicates must match the graph."""
+
+    @pytest.mark.slow
+    def test_matches_sample_posterior_predictive(self, var_data_2v_correlated):
+        """Moment agreement with `pm.sample_posterior_predictive` on a real fit.
+
+        Both routes reuse the same posterior draws, so the conditional
+        means are identical by construction and only the innovation law
+        can differ. The comparison is therefore stated on the innovations:
+        per-(time, var) means in Monte Carlo standard-error units (a
+        fixed atol would depend on the DGP's scale) plus the pooled
+        innovation covariance, which a transposed or mis-scaled Cholesky
+        breaks immediately.
+
+        The fixture's shocks are strongly cross-correlated on purpose: with
+        a near-diagonal Sigma, `L` and `L.T` produce nearly the same
+        covariance, so the fence would not bite.
+        """
+        import pymc as pm
+
+        from impulso.samplers import NUTSSampler
+
+        data = var_data_2v_correlated
+        draws = 400
+        sampler = NUTSSampler(draws=draws, tune=400, chains=1, cores=1, random_seed=3, progressbar=False)
+        fitted = VAR(lags=1).fit(data, sampler=sampler)
+
+        ours = fitted.posterior_predictive(seed=0).posterior_predictive["obs"].values
+        with fitted.pymc_model:
+            theirs = (
+                pm
+                .sample_posterior_predictive(
+                    fitted.idata,
+                    random_seed=1,
+                    progressbar=False,
+                )
+                .posterior_predictive["obs"]
+                .values
+            )
+
+        assert ours.shape == theirs.shape
+
+        mu = fitted_values(fitted.idata.posterior, data, 1)
+        ours_innov = (ours - mu).reshape(-1, 2)
+        theirs_innov = (theirs - mu).reshape(-1, 2)
+
+        # Per-(time, var) means, normalised by the Monte Carlo standard
+        # error of the difference (sigma * sqrt(2 / draws)). 398 cells, so
+        # 5 sigma is a ~2e-4 false-failure budget.
+        se = theirs_innov.std(axis=0) * np.sqrt(2.0 / draws)
+        z = np.abs(ours.mean(axis=(0, 1)) - theirs.mean(axis=(0, 1))) / se
+        assert z.max() < 5.0
+
+        assert np.allclose(ours_innov.std(axis=0), theirs_innov.std(axis=0), rtol=0.05)
+        theirs_cov = np.cov(theirs_innov, rowvar=False)
+        assert np.allclose(
+            np.cov(ours_innov, rowvar=False),
+            theirs_cov,
+            atol=0.05 * np.abs(theirs_cov).max(),
+        )
+
+    @pytest.mark.slow
+    def test_observed_falls_within_the_posterior_band(self, var_data_2v):
+        from impulso.samplers import NUTSSampler
+
+        sampler = NUTSSampler(draws=200, tune=200, chains=1, cores=1, random_seed=3, progressbar=False)
+        fitted = VAR(lags=1).fit(var_data_2v, sampler=sampler)
+
+        draws = fitted.posterior_predictive(seed=0).posterior_predictive["obs"].values
+        flat = draws.reshape(-1, *draws.shape[2:])  # (chain*draw, time, var)
+        lower, upper = np.quantile(flat, [0.025, 0.975], axis=0)
+        observed = var_data_2v.endog[1:]
+        covered = (observed >= lower) & (observed <= upper)
+        assert covered.mean() >= 0.85
+
+    @pytest.mark.slow
+    def test_stochastic_volatility_innovations_vary_with_t(self, var_data_2v):
+        """Under SV the replicate spread must track the model's own Sigma_t.
+
+        This is the assertion behind the volatility-seam deviation: the
+        innovations come from `cholesky_path` (per-t), so their spread
+        follows Sigma_t. A single pooled residual covariance — or
+        `cholesky_at` — would give a flat spread across t.
+        """
+        from impulso.samplers import NUTSSampler
+        from impulso.sv.spec import StochasticVolatility
+
+        sampler = NUTSSampler(
+            draws=30, tune=30, chains=1, cores=1, random_seed=0, progressbar=False, nuts_sampler="pymc"
+        )
+        fitted = VAR(lags=1, volatility=StochasticVolatility()).fit(var_data_2v, sampler=sampler)
+
+        ppc = fitted.posterior_predictive(seed=0).posterior_predictive["obs"].values
+        assert np.isfinite(ppc).all()
+
+        posterior = fitted.idata.posterior
+        T = var_data_2v.endog.shape[0] - 1
+        mu = fitted_values(posterior, var_data_2v, 1)
+        empirical_sd = (ppc - mu).std(axis=(0, 1))  # (T, n)
+
+        L_path = fitted.volatility.cholesky_path(posterior, T=T)  # (C, D, T, n, n)
+        model_sd = np.sqrt((L_path**2).sum(axis=-1)).mean(axis=(0, 1))  # (T, n)
+
+        # Not flat across t ...
+        assert empirical_sd.max() / empirical_sd.min() > 1.5
+        # ... and varying in step with the model's own per-t scale.
+        for i in range(2):
+            corr = np.corrcoef(empirical_sd[:, i], model_sd[:, i])[0, 1]
+            assert corr > 0.4

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -98,6 +98,13 @@ class TestPublicAPI:
 
         assert callable(enable_runtime_checks)
 
+    def test_predictive_methods_are_public(self):
+        """The predictive checks are methods on the pipeline objects (#56)."""
+        import impulso
+
+        assert callable(impulso.VAR.prior_predictive)
+        assert callable(impulso.FittedVAR.posterior_predictive)
+
 
 class TestRuntimeChecks:
     def test_enable_runtime_checks_drives_pipeline(self):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -453,6 +453,40 @@ class TestExogPriorWiredIntoModel:
         # Same column with lags=1 keeps the switch, so it is estimable.
         self._capture(data, VAR(lags=1))
 
+    def test_prior_predictive_graph_carries_the_same_scaled_sigma(self, rng):
+        """The graph `prior_predictive` draws from is the graph `fit` samples (#56, #192).
+
+        `VAR.prior_predictive` builds its graph through `_build_pymc_model`,
+        the same seam `fit` uses. If the scale-adaptive exog prior lived in
+        `fit` instead, a prior-predictive check would silently describe a
+        unit-scale model that was never fitted.
+        """
+        endog = rng.standard_normal((150, 2))
+        exog = rng.standard_normal((150, 2)) * np.array([0.01, 250.0])
+        data = _exog_data(endog, exog, ["tiny", "huge"])
+        spec = VAR(lags=1)
+
+        prior_predictive_model, _ = spec._build_pymc_model(data)
+        got = _captured_sigma(prior_predictive_model, "B_exog")
+
+        np.testing.assert_allclose(got, _exog_prior_sigma(endog, exog[1:], 100.0))
+        assert not np.allclose(got, 1.0)
+        # Belt and braces: identical to what the fit path builds, so the two
+        # cannot drift apart.
+        np.testing.assert_allclose(got, _captured_sigma(self._capture(data, spec), "B_exog"))
+
+    def test_prior_predictive_graph_honours_the_knob(self, rng):
+        endog = rng.standard_normal((150, 2))
+        exog = rng.standard_normal((150, 1)) * 0.01
+        data = _exog_data(endog, exog, ["tiny"])
+
+        model, _ = VAR(lags=1, exog_prior_scale=5.0)._build_pymc_model(data)
+
+        np.testing.assert_allclose(
+            _captured_sigma(model, "B_exog"),
+            _exog_prior_sigma(endog, exog[1:], 5.0),
+        )
+
 
 def _capture_model(var_data, **var_kwargs):
     """Build the production PyMC graph via VAR.fit, aborting before MCMC."""


### PR DESCRIPTION
## Summary

- **`VAR.prior_predictive(data, *, draws=500, random_seed=None)`** — samples the model's actual prior via `pm.sample_prior_predictive` on a freshly built graph (the prior lives in the PyTensor graph; hand-rolling it is the anti-pattern the issue names). Returns arviz-idiomatic `InferenceData`; `az.plot_ppc(idata, group="prior")` works directly.
- **`FittedVAR.posterior_predictive(*, simulate_innovations=True, seed=None)`** — pure-NumPy in-sample replicates from the posterior draws and the volatility seam, `(chain, draw, time, var)` with the data's own time axis and `observed_data` attached. Works identically for `ConjugateVAR` fits (no PyMC graph needed — asserted, not assumed), never mutates the fitted object (the `fitted.idata.extend(ppc)` recipe is documented), and mean mode ties exactly to `reduced_form_residuals`.
- Enabling refactor (verbatim-lift, verified byte-identical by mechanical diff): `VAR._build_pymc_model` and `_residuals.fitted_values` — the conditional mean is now one shared seam under residuals, historical decomposition, and the new replicates.

**Two deliberate deviations from the issue text**, per the plan and both reviewer-endorsed:
1. **One-step-ahead semantics**: replicates are conditioned on the *observed* lags (`y_rep[t] = c + B x_t^obs + L_t ε_t`), not an iterated simulated path — the issue's own mean-mode wording ("effectively a one-step-ahead in-sample forecast") and its `az.plot_ppc` requirement both entail this object; iterated paths are `forecast()`'s job.
2. **Σ from the volatility seam** (`cholesky_path`, per-draw and per-t), not the empirical residual covariance — which would flatten exactly the heteroscedasticity an SV fit exists to capture. Recorded in ADR-0011 and pinned by tests.

Also note: the issue's AC-2 references `docs/tutorials/supply-chain.qmd`, which no longer exists (tutorials are jupytext `.py`); tutorial consumption is #57's, which already has the API surface it needs.

Closes #56

## Review

Independently reviewed (verdict: approve). The reviewer diffed the extracted builder against main's `fit` mechanically (empty diff), re-ran the drift fence, and verified the adversarial fixture numerically — on the correlated DGP a transposed-Cholesky saboteur violates tolerances by >10×, where the original independent-shock fixture let it pass. The fence's one gap (matched-variance shape drift, relevant when Student-t errors land) is filed as a follow-up.

## Tests

21 tests (17 fast, 4 slow): the issue's coverage acceptance criterion, standardised-innovation pooling to cov ≈ I over 19,900 samples, exact mean-mode/residual ties, seed contracts, no-mutation pin, ConjugateVAR parity, the PyMC drift fence with MC-error-calibrated z-checks, an SV per-t variance test, and a beartype-resolution subprocess fence. Fast suite: 628 passed, 33 deselected. `ruff`/`ty`/docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV