### PR TITLE
fix(conjugate): reject volatility adapters with no hyperparameters to estimate

### DIFF
--- a/src/impulso/conjugate.py
+++ b/src/impulso/conjugate.py
@@ -37,7 +37,10 @@ class ConjugateVAR(ImpulsoBaseModel):
         prior: The conjugate Minnesota :class:`~impulso.priors.NIWPrior`.
         volatility: Optional deterministic volatility break
             (:class:`~impulso.conjugate_volatility.ConjugateVolatility`), or ``None``
-            for a homoscedastic conjugate VAR.
+            for a homoscedastic conjugate VAR. The break must declare at least
+            one hyperparameter to estimate; an adapter with none is rejected
+            at construction because the closed-form fast path would silently
+            ignore it.
         draws: Number of retained posterior draws.
         tune: Number of Metropolis warm-up iterations (ignored on the fixed-prior fast path).
         seed: Seed for the single RNG driving selection, sampling and coefficient draws.
@@ -71,6 +74,31 @@ class ConjugateVAR(ImpulsoBaseModel):
                 f"ConjugateVAR only accepts a ConjugateVolatility break, got {type(value).__name__}. "
                 "PyMC volatility processes (Constant, StochasticVolatility) belong to the "
                 "PyMC/NUTS estimator: use `impulso.VAR(volatility=...)` instead."
+            )
+        return value
+
+    @field_validator("volatility", mode="after")
+    @classmethod
+    def _require_estimable_hyperparameters(cls, value: ConjugateVolatility | None) -> ConjugateVolatility | None:
+        """Reject a volatility break with nothing to estimate (issue #161).
+
+        The conjugate engine has no seam for fixed, known scales: it estimates the
+        volatility hyperparameters jointly with the Minnesota tightness by Metropolis,
+        and with no free hyperparameter at all `select_and_sample` takes the
+        closed-form fast path — which fits homoscedastically and never calls the
+        adapter's `log_scales`. Such a break would be silently ignored, so refuse it
+        at construction rather than return a fit that quietly disregards it.
+        """
+        if value is not None and not value.hyperparameter_priors():
+            raise ValueError(
+                f"{type(value).__name__} declares no volatility hyperparameters: "
+                "hyperparameter_priors() returned an empty mapping. The conjugate engine "
+                "estimates volatility hyperparameters jointly with the Minnesota tightness "
+                "by Metropolis, so a break with none to estimate leaves the fit on the "
+                "closed-form fast path, which is homoscedastic and never consults the "
+                "adapter's log_scales — the break would be silently ignored. Give the "
+                "adapter at least one hyperparameter prior, or apply fixed known scales "
+                "by pre-scaling the data before building VARData."
             )
         return value
 

--- a/tests/test_conjugate_var.py
+++ b/tests/test_conjugate_var.py
@@ -1,11 +1,13 @@
 """End-to-end tests for the conjugate VAR estimator (ConjugateVAR)."""
 
+from typing import Literal
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from impulso.conjugate import ConjugateVAR
-from impulso.conjugate_volatility import PandemicBreak
+from impulso.conjugate_volatility import ConjugateVolatility, PandemicBreak, Prior1D
 from impulso.data import VARData
 from impulso.fitted import FittedVAR
 from impulso.identification import Cholesky
@@ -161,3 +163,51 @@ def test_rejects_non_niw_prior():
 def test_rejects_pymc_volatility():
     with pytest.raises(ValueError, match="VAR"):
         ConjugateVAR(lags=1, prior=NIWPrior(), volatility=Constant())
+
+
+class _NoHyperparameterBreak(ConjugateVolatility):
+    """A well-formed adapter that declares nothing to estimate.
+
+    Its ``log_scales`` would double every residual sd, but with no hyperparameter the
+    sampler takes the closed-form fast path and never calls it (issue #161).
+    """
+
+    name: Literal["no_hyperparameters"] = "no_hyperparameters"
+
+    def hyperparameter_priors(self) -> dict[str, Prior1D]:
+        return {}
+
+    def log_scales(self, theta: dict[str, float], T: int) -> np.ndarray:
+        return np.full(T, np.log(2.0))
+
+
+def test_rejects_zero_hyperparameter_volatility():
+    """A break with nothing to estimate would be silently ignored (issue #161)."""
+    with pytest.raises(ValueError) as excinfo:
+        ConjugateVAR(lags=1, prior=NIWPrior(), volatility=_NoHyperparameterBreak())
+
+    message = str(excinfo.value)
+    assert "_NoHyperparameterBreak declares no volatility hyperparameters" in message
+    assert "silently ignored" in message
+    assert "pre-scaling the data" in message
+
+
+def test_rejects_zero_hyperparameter_volatility_match():
+    """The rejection message is pinned by pattern as well as by substring."""
+    with pytest.raises(ValueError, match=r"hyperparameter_priors\(\) returned an empty mapping"):
+        ConjugateVAR(lags=1, prior=NIWPrior(), volatility=_NoHyperparameterBreak())
+
+
+def test_accepts_pandemic_break_hyperparameters():
+    """The shipped adapter declares four hyperparameters, so it still constructs."""
+    break_ = PandemicBreak(start=3)
+    assert set(break_.hyperparameter_priors()) == {"s_march", "s_april", "s_may", "rho"}
+
+    model = ConjugateVAR(lags=1, prior=NIWPrior(), volatility=break_)
+
+    assert model.volatility is break_
+
+
+def test_accepts_no_volatility():
+    """`volatility=None` is a homoscedastic conjugate VAR and stays unaffected."""
+    assert ConjugateVAR(lags=1, prior=NIWPrior()).volatility is None


### PR DESCRIPTION
## Summary

A custom `ConjugateVolatility` adapter with empty `hyperparameter_priors()` was **silently ignored**: `select_and_sample`'s `d == 0` fast path fits homoscedastically and never consults the adapter's `log_scales` — and on the #160 branch the evidence metadata would still have claimed the break was modelled. No shipped adapter triggers this (`PandemicBreak` declares 4 hyperparameters), but the silent-ignore was a latent correctness trap.

Per the issue's recommended option, such adapters are now **rejected at `ConjugateVAR` construction** via a `field_validator` (house style for single-field rejections in this file; `hyperparameter_priors()` is contractually data-free and sub-millisecond, so construction-time is safe). The error names the adapter, explains the mechanism (joint Metropolis estimation; nothing to estimate ⇒ closed-form fast path ⇒ `log_scales` never called), and gives both escapes: declare a hyperparameter prior, or apply fixed known scales by pre-scaling the data.

With rejection in place, #160's metadata half of the bug is unreachable: no fit can carry `evidence.volatility = <adapter>` while the fast path ignores it — the only remaining states are `volatility=None` (fast path, no metadata) and ≥1 hyperparameter (Metropolis path, `log_scales` genuinely consumed). `_conjugate_sampler.py` is untouched.

Closes #161

## Tests

+4: a minimal zero-hyperparameter stub rejected with the pinned message; `PandemicBreak` still accepted (its 4 hyperparameter names asserted); `volatility=None` unaffected. Fast suite: 614 passed, 29 deselected; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV