### PR TITLE
fix(identification): weakref-validated posterior cache for ProxySVAR

### DIFF
--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -1,6 +1,7 @@
 """Identification schemes for structural VAR analysis."""
 
-from typing import TYPE_CHECKING, ClassVar
+import weakref
+from typing import TYPE_CHECKING, Any, ClassVar, Final
 
 import numpy as np
 import pandas as pd
@@ -13,6 +14,132 @@ from impulso._ma import compute_ma_phi
 
 if TYPE_CHECKING:
     from impulso.data import VARData
+
+
+_CACHE_MISS: Final = object()
+"""Sentinel returned by `_PosteriorCache.get` when there is no valid entry.
+
+A dedicated sentinel (rather than `None`) keeps `None` usable as a cached
+value, and makes the hit test at call sites an unambiguous `is` check.
+"""
+
+
+class _PosteriorCache:
+    """Single-slot memo keyed on object identity, validated by weak references.
+
+    Several identification schemes memoise a quantity that depends only on
+    the posterior (plus a few scalars) so that a per-period identification
+    loop — `IdentifiedVAR._identify_per_t` calls `identify()` once per time
+    index with the same posterior — pays the expensive part once instead of
+    `T` times.
+
+    Keying such a memo on `id(posterior)` is unsafe: once the posterior is
+    garbage collected its address can be reused by a new object, and a
+    subsequent lookup with a *different* posterior that happens to land on
+    the recycled address returns a stale value silently (issue #203). This
+    cache stores `weakref.ref(owner)` instead and treats a dead referent —
+    or a live referent that is not the object being looked up — as a miss.
+    The referent identity check (`ref() is owner`) subsumes an `id()`
+    comparison exactly, so no `id()` is kept in the key.
+
+    Usage is a get/compute/set triple:
+
+        cached = self._cache.get(posterior, (n_lags,))
+        if cached is _CACHE_MISS:
+            cached = expensive(posterior, n_lags)
+            self._cache.set(posterior, (n_lags,), cached)
+
+    `owners` may be a single object or a tuple of objects when validity
+    depends on more than one identity (`ProxySVAR` keys on the posterior
+    *and* the `VARData`). Every owner must support weak references —
+    `xr.Dataset` and Pydantic models such as `VARData` both do. If any
+    owner does not (plain tuples, ints and strings do not), `set` declines
+    to cache rather than falling back to an unsafe key, so the only cost is
+    a lost speed-up.
+
+    Entries in `key` are ordinary scalars compared with `==` (lag order, a
+    variable name, a horizon). Do not put arrays there — elementwise
+    comparison would not yield a bool.
+
+    Intended adoption (issue #203). The other identity-keyed memos in this
+    module collapse to the same three lines once their branches merge:
+
+        MaxShare._spectral_cache:
+            self._spectral_cache.get(posterior, (n_lags, target))
+            self._spectral_cache.set(posterior, (n_lags, target), value)
+
+        LongRunRestriction._lr_cache:
+            self._lr_cache.get(posterior, (n_lags,))
+            self._lr_cache.set(posterior, (n_lags,), value)
+
+    Declare the attribute on the (frozen) scheme with
+    `PrivateAttr(default_factory=_PosteriorCache)` so each instance gets
+    its own slot, and mutate it in place — no `object.__setattr__` needed.
+    """
+
+    __slots__ = ("_key", "_refs", "_value")
+
+    def __init__(self) -> None:
+        self._refs: tuple[weakref.ref, ...] | None = None
+        self._key: tuple[Any, ...] = ()
+        self._value: Any = _CACHE_MISS
+
+    @staticmethod
+    def _as_tuple(owners: Any) -> tuple[Any, ...]:
+        """Normalise a single owner or a tuple of owners to a tuple."""
+        return owners if isinstance(owners, tuple) else (owners,)
+
+    def get(self, owners: Any, key: tuple[Any, ...] = ()) -> Any:
+        """Look up the memoised value.
+
+        Args:
+            owners: The object (or tuple of objects) whose identity the
+                cached value is tied to.
+            key: Scalar key tail — everything the value depends on that is
+                not an owner identity.
+
+        Returns:
+            The cached value, or `_CACHE_MISS` if there is no entry, the
+            key tail differs, the owners differ, or any owner has been
+            garbage collected.
+        """
+        if self._refs is None or self._key != key:
+            return _CACHE_MISS
+        owner_tuple = self._as_tuple(owners)
+        if len(owner_tuple) != len(self._refs):
+            return _CACHE_MISS
+        # A dead referent dereferences to None, which can never be an
+        # owner (weakref.ref(None) is not constructible), so the same
+        # check covers both "collected" and "different object".
+        if any(ref() is not owner for ref, owner in zip(self._refs, owner_tuple, strict=True)):
+            return _CACHE_MISS
+        return self._value
+
+    def set(self, owners: Any, key: tuple[Any, ...], value: Any) -> None:
+        """Store `value`, tying its validity to the owners staying alive.
+
+        Args:
+            owners: The object (or tuple of objects) whose identity the
+                value depends on.
+            key: Scalar key tail.
+            value: The value to memoise.
+        """
+        try:
+            refs = tuple(weakref.ref(owner) for owner in self._as_tuple(owners))
+        except TypeError:
+            # An owner that cannot be weakly referenced has no validity
+            # token, so caching it would reintroduce the id()-reuse bug.
+            self.clear()
+            return
+        self._refs = refs
+        self._key = key
+        self._value = value
+
+    def clear(self) -> None:
+        """Drop any stored entry."""
+        self._refs = None
+        self._key = ()
+        self._value = _CACHE_MISS
 
 
 class Cholesky(ImpulsoModel):
@@ -326,9 +453,10 @@ class ProxySVAR(ImpulsoBaseModel):
     # — not on L — so under time-varying volatility, where the pipeline
     # calls identify() once per period with the same posterior/data, the
     # expensive residual reconstruction runs once instead of T times.
-    # Keyed by object identity: valid while the caller holds the same
-    # posterior/data objects, which is exactly the per-t loop's lifetime.
-    _impact_cache: tuple | None = PrivateAttr(default=None)
+    # Keyed by object identity, with weak references as the validity token:
+    # valid while the caller holds the same posterior/data objects, which
+    # is exactly the per-t loop's lifetime. See `_PosteriorCache`.
+    _impact_cache: _PosteriorCache = PrivateAttr(default_factory=_PosteriorCache)
 
     def identify(
         self,
@@ -370,10 +498,8 @@ class ProxySVAR(ImpulsoBaseModel):
             raise ValueError(f"policy_variable {self.policy_variable!r} not in var_names {var_names}")
         policy_idx = var_names.index(self.policy_variable)
 
-        cache_key = (id(posterior), id(data), n_lags)
-        if self._impact_cache is not None and self._impact_cache[0] == cache_key:
-            d = self._impact_cache[1]
-        else:
+        d = self._impact_cache.get((posterior, data), (n_lags,))
+        if d is _CACHE_MISS:
             z, u = self._aligned_residuals(posterior, data, n_lags)
 
             # Impact direction: per-draw covariance between instrument and
@@ -391,7 +517,7 @@ class ProxySVAR(ImpulsoBaseModel):
                 "proxy_first_stage_f_q05": float(np.quantile(f_draws, 0.05)),
                 "proxy_first_stage_f_q95": float(np.quantile(f_draws, 0.95)),
             }
-            self._impact_cache = (cache_key, d)
+            self._impact_cache.set((posterior, data), (n_lags,), d)
             if f_median < 10.0:
                 import warnings
 

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -1,10 +1,14 @@
 """Tests for identification schemes."""
 
+import gc
+import weakref
+
 import numpy as np
 import pytest
+import xarray as xr
 from pydantic import ValidationError
 
-from impulso.identification import Cholesky, SignRestriction
+from impulso.identification import _CACHE_MISS, Cholesky, SignRestriction, _PosteriorCache
 from impulso.protocols import IdentificationScheme
 
 
@@ -365,3 +369,108 @@ class TestSignRestrictionNewIdentify:
         # synthetic_idata_2v has B in posterior; should run without raising.
         P = scheme.identify(L, var_names, posterior=synthetic_idata_2v.posterior)
         assert P.shape == L.shape
+
+
+class TestPosteriorCache:
+    """Weakref-validated identity cache shared by the identification schemes (#203)."""
+
+    def test_xr_dataset_supports_weak_references(self):
+        """The whole design rests on this — assert it rather than assume it."""
+        ds = xr.Dataset()
+        assert weakref.ref(ds)() is ds
+
+    def test_empty_cache_misses(self):
+        cache = _PosteriorCache()
+        assert cache.get(xr.Dataset(), (1,)) is _CACHE_MISS
+
+    def test_hit_on_the_same_owner(self):
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        sentinel = object()
+        cache.set(owner, (2,), sentinel)
+        assert cache.get(owner, (2,)) is sentinel
+
+    def test_none_is_a_storable_value(self):
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        cache.set(owner, (), None)
+        assert cache.get(owner, ()) is None
+
+    def test_live_owner_with_different_identity_misses(self):
+        """Two live, equal-looking owners must not share an entry."""
+        cache = _PosteriorCache()
+        first, second = xr.Dataset(), xr.Dataset()
+        cache.set(first, (1,), "value")
+        assert cache.get(second, (1,)) is _CACHE_MISS
+        assert cache.get(first, (1,)) == "value"
+
+    def test_key_tail_mismatch_misses(self):
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        cache.set(owner, (1, "gdp"), "value")
+        assert cache.get(owner, (2, "gdp")) is _CACHE_MISS
+        assert cache.get(owner, (1, "inflation")) is _CACHE_MISS
+        assert cache.get(owner, (1, "gdp")) == "value"
+
+    def test_dead_referent_misses(self):
+        """The defect this cache exists to close: a collected owner's
+        address may be recycled, so a dead referent must read as a miss."""
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        cache.set(owner, (1,), "stale")
+        ref = weakref.ref(owner)
+
+        del owner
+        gc.collect()
+        assert ref() is None
+
+        assert cache.get(xr.Dataset(), (1,)) is _CACHE_MISS
+
+    def test_multiple_owners_all_must_match(self):
+        cache = _PosteriorCache()
+        a, b, other = xr.Dataset(), xr.Dataset(), xr.Dataset()
+        cache.set((a, b), (1,), "value")
+        assert cache.get((a, b), (1,)) == "value"
+        assert cache.get((a, other), (1,)) is _CACHE_MISS
+        assert cache.get((other, b), (1,)) is _CACHE_MISS
+
+    def test_owner_arity_mismatch_misses(self):
+        cache = _PosteriorCache()
+        a, b = xr.Dataset(), xr.Dataset()
+        cache.set((a, b), (1,), "value")
+        assert cache.get(a, (1,)) is _CACHE_MISS
+
+    def test_single_owner_and_one_tuple_are_equivalent(self):
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        cache.set(owner, (1,), "value")
+        assert cache.get((owner,), (1,)) == "value"
+
+    def test_non_weakrefable_owner_declines_to_cache(self):
+        """No validity token means no cache — never an unsafe fallback key."""
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        cache.set((owner, 3), (1,), "value")
+        assert cache.get((owner, 3), (1,)) is _CACHE_MISS
+
+    def test_non_weakrefable_owner_evicts_a_previous_entry(self):
+        cache = _PosteriorCache()
+        a, b = xr.Dataset(), xr.Dataset()
+        cache.set(a, (1,), "value")
+        cache.set((b, "not-weakrefable"), (1,), "other")
+        assert cache.get(a, (1,)) is _CACHE_MISS
+
+    def test_set_overwrites_the_single_slot(self):
+        cache = _PosteriorCache()
+        a, b = xr.Dataset(), xr.Dataset()
+        cache.set(a, (1,), "first")
+        cache.set(b, (1,), "second")
+        assert cache.get(b, (1,)) == "second"
+        assert cache.get(a, (1,)) is _CACHE_MISS
+
+    def test_clear(self):
+        cache = _PosteriorCache()
+        owner = xr.Dataset()
+        cache.set(owner, (1,), "value")
+        cache.clear()
+        assert cache.get(owner, (1,)) is _CACHE_MISS

--- a/tests/test_proxy_svar.py
+++ b/tests/test_proxy_svar.py
@@ -1,5 +1,9 @@
 """Tests for ProxySVAR external-instrument identification."""
 
+import gc
+import warnings
+import weakref
+
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -7,7 +11,7 @@ import pytest
 import xarray as xr
 
 from impulso.data import VARData
-from impulso.identification import ProxySVAR
+from impulso.identification import _CACHE_MISS, ProxySVAR
 
 
 def _make_svar_world(relevance_noise: float = 0.1, T: int = 400, seed: int = 3):
@@ -349,8 +353,22 @@ class TestProxySVARPipelineSlow:
         assert (da.isel(horizon=0).sel(response="y1") > 0).all()
 
 
+@pytest.fixture
+def residual_calls(monkeypatch):
+    """Count `_aligned_residuals` invocations — the expensive cache-missed step."""
+    calls: list[int] = []
+    original = ProxySVAR._aligned_residuals
+
+    def counting(self, posterior, data, n_lags):
+        calls.append(1)
+        return original(self, posterior, data, n_lags)
+
+    monkeypatch.setattr(ProxySVAR, "_aligned_residuals", counting)
+    return calls
+
+
 class TestProxySVARImpactCache:
-    def test_repeated_identify_same_context_hits_cache(self):
+    def test_repeated_identify_same_context_hits_cache(self, residual_calls):
         """Per-t identification (SV path) calls identify once per period
         with the same posterior/data — the impact direction must be
         computed once and reused, and results must be identical."""
@@ -358,19 +376,77 @@ class TestProxySVARImpactCache:
         scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
 
         P1 = scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        assert scheme._impact_cache is not None
-        cached_d = scheme._impact_cache[1]
+        cached_d = scheme._impact_cache.get((idata.posterior, data), (1,))
+        assert cached_d is not _CACHE_MISS
 
         P2 = scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        assert scheme._impact_cache[1] is cached_d  # same object, no recompute
+        assert scheme._impact_cache.get((idata.posterior, data), (1,)) is cached_d
+        assert residual_calls == [1]  # no recompute on the second call
         np.testing.assert_array_equal(P1, P2)
 
-    def test_cache_invalidated_by_new_context(self):
+    def test_cache_invalidated_by_new_context(self, residual_calls):
         data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
         data2, idata2, _P2, _instrument2, L2 = _make_svar_world(relevance_noise=0.05, seed=9)
         scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
 
         scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        d_first = scheme._impact_cache[1]
+        d_first = scheme._impact_cache.get((idata.posterior, data), (1,))
         scheme.identify(L2, ["y1", "y2"], posterior=idata2.posterior, data=data2, n_lags=1)
-        assert scheme._impact_cache[1] is not d_first
+        assert scheme._impact_cache.get((idata2.posterior, data2), (1,)) is not d_first
+        assert len(residual_calls) == 2
+
+    def test_live_posterior_with_different_identity_misses(self, residual_calls):
+        """A distinct-but-live posterior object must never hit the entry
+        stored for another one, even with identical contents."""
+        data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
+        scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
+
+        first = idata.posterior.copy()
+        second = idata.posterior.copy()
+        assert first is not second
+
+        scheme.identify(L, ["y1", "y2"], posterior=first, data=data, n_lags=1)
+        assert scheme._impact_cache.get((second, data), (1,)) is _CACHE_MISS
+        scheme.identify(L, ["y1", "y2"], posterior=second, data=data, n_lags=1)
+        assert len(residual_calls) == 2
+
+    def test_dead_posterior_forces_recompute(self, residual_calls):
+        """Once the cached posterior is collected the weak reference dies,
+        so the next lookup recomputes instead of trusting a recycled id()."""
+        data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
+        scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
+
+        posterior = idata.posterior.copy()
+        scheme.identify(L, ["y1", "y2"], posterior=posterior, data=data, n_lags=1)
+        assert len(residual_calls) == 1
+
+        ref = weakref.ref(posterior)
+        del posterior
+        gc.collect()
+        assert ref() is None  # the cached referent really is gone
+
+        fresh = idata.posterior.copy()
+        assert scheme._impact_cache.get((fresh, data), (1,)) is _CACHE_MISS
+        scheme.identify(L, ["y1", "y2"], posterior=fresh, data=data, n_lags=1)
+        assert len(residual_calls) == 2
+
+    def test_cache_hit_suppresses_the_weak_instrument_warning(self):
+        """Warn-once semantics: the weak-instrument warning is raised on the
+        computing call only, not on every per-t cache hit."""
+        data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=50.0)
+        scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
+
+        with pytest.warns(UserWarning, match="Weak instrument"):
+            scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
+
+    def test_each_instance_gets_its_own_cache(self):
+        data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
+        a = ProxySVAR(instrument=instrument, policy_variable="y1")
+        b = ProxySVAR(instrument=instrument, policy_variable="y1")
+
+        a.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
+        assert b._impact_cache.get((idata.posterior, data), (1,)) is _CACHE_MISS


### PR DESCRIPTION
## Summary

`ProxySVAR`'s memoisation was keyed on `id(posterior)` — if a dead posterior's address were reused by a new object of matching shape, a stale cached impact matrix would return **silently** (unreproduced in 200 forced-GC attempts, but the exposure is real and the failure mode is wrong numbers with no signal).

New module-level `_PosteriorCache` (single-slot, `__slots__`): validity token is `ref() is owner` — a dead referent dereferences to `None`, which can never be an owner, so one check subsumes both "collected" and "different object", and no `id()` survives in the key. Non-weakref-able owners decline to cache (lose the speed-up, never an unsafe key). Verified in-venv that both owners ProxySVAR keys on (`xr.Dataset`, `VARData`) support weakrefs and that `idata.posterior` has stable identity across accesses, so the per-t loop's warn-once and compute-once semantics are preserved exactly (pinned by call-count and warning tests).

The helper's docstring records the one-line adoptions for `MaxShare._spectral_cache` (#200) and `LongRunRestriction._lr_cache` (#183) — I'll fold those in during each branch's post-merge rebase, which completes #203.

Refs #203 (closes fully once the two branch adoptions land)

## Tests

+20: weakref mechanics (dead-referent miss after `gc.collect()`, live-different-object miss, tuple/single-owner normalisation, non-weakref-able decline), ProxySVAR cache-hit/invalidation via monkeypatched call counts, and the warn-once pin. Fast suite: 628 passed, 29 deselected; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV