### PR TITLE
fix(tilting): one coordinate row per distinct target

### DIFF
--- a/src/impulso/_tilting.py
+++ b/src/impulso/_tilting.py
@@ -46,7 +46,22 @@ LAMBDA_GUARD = 1e6
 
 
 def target_label(target: Target) -> str:
-    """Human-readable label for a target, used as the `target` coordinate."""
+    """Human-readable label for a target, used as the `target` coordinate.
+
+    The label names the *quantity* a target constrains — variable and
+    horizon, plus threshold and direction for a `ProbabilityTarget` — but
+    not the value requested of it, so two targets share a label exactly
+    when they speak about the same event or the same mean. `build_moments`
+    keys its duplicate handling on that: identical targets collapse to one
+    column, and same-label targets asking for different values are
+    rejected as contradictory.
+
+    Args:
+        target: The target to label.
+
+    Returns:
+        The label, e.g. `P(y1[h=4] < 0)` or `E[y2[h=2]]`.
+    """
     from impulso.scenario import ProbabilityTarget
 
     if isinstance(target, ProbabilityTarget):
@@ -60,13 +75,18 @@ def build_moments(
     targets: list[Target],
     var_names: list[str],
     steps: int,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Build the moment matrix `G` and requested moment vector `t`.
+) -> tuple[np.ndarray, np.ndarray, list[Target]]:
+    """Build the moment matrix `G`, requested vector `t`, and target list.
 
     Column `k` holds the moment function of target `k` evaluated on every
     draw: the event indicator for a `ProbabilityTarget`, the level itself
     for a `MomentTarget`. Draws are flattened over `(chain, draw)` in C
     order, so `G[i]` lines up with `forecast.reshape(N, steps, n)[i]`.
+
+    The targets are deduplicated first (see `dedupe_targets`), so the
+    returned list — not the one passed in — is what the columns
+    correspond to and what the caller must label the `target` coordinate
+    with.
 
     Feasibility that does not depend on the solver is checked here: an
     event no draw satisfies (or, for `p < 1`, one every draw satisfies)
@@ -80,18 +100,21 @@ def build_moments(
         steps: Forecast horizon.
 
     Returns:
-        Tuple `(G, t)` with `G` of shape `(N, K)` and `t` of shape `(K,)`.
+        Tuple `(G, t, targets)` with `G` of shape `(N, K)`, `t` of shape
+        `(K,)`, and the `K` deduplicated targets in their original order.
 
     Raises:
         TypeError: If a target is neither a `ProbabilityTarget` nor a
             `MomentTarget`.
-        ValueError: On an empty target list, an unknown variable, a
+        ValueError: On an empty target list, two targets on the same
+            quantity requesting different values, an unknown variable, a
             horizon beyond the forecast, or an unachievable target.
     """
-    from impulso.scenario import MomentTarget, ProbabilityTarget
+    from impulso.scenario import ProbabilityTarget
 
     if not targets:
         raise ValueError("Tilting requires at least one target; an empty target list would leave the weights uniform.")
+    targets = dedupe_targets(targets)
     n_chains, n_draws, _, n_vars = forecast.shape
     n_total = n_chains * n_draws
     flat = forecast.reshape(n_total, steps, n_vars)
@@ -99,8 +122,6 @@ def build_moments(
     G = np.empty((n_total, len(targets)))
     t = np.empty(len(targets))
     for k, target in enumerate(targets):
-        if not isinstance(target, ProbabilityTarget | MomentTarget):
-            raise TypeError(f"tilt() accepts ProbabilityTarget or MomentTarget, got {type(target).__name__}")
         i, h = _resolve_target(target, var_names, steps)
         y = flat[:, h, i]
         if isinstance(target, ProbabilityTarget):
@@ -112,7 +133,64 @@ def build_moments(
             _check_moment_support(target, y, n_total)
             G[:, k] = y
             t[k] = target.mean
-    return G, t
+    return G, t, targets
+
+
+def dedupe_targets(targets: list[Target]) -> list[Target]:
+    """Drop repeated targets and reject same-quantity targets that disagree.
+
+    Labels key the `target` coordinate of a tilted result, so a repeated
+    label would make `.sel(target=...)` return several rows. A target
+    passed twice verbatim is harmless redundancy — one moment column
+    achieves it exactly as the two identical ones would — so the repeat
+    is dropped silently and the first occurrence kept, preserving order.
+
+    Two *different* targets sharing a label are another matter: they ask
+    the same event to carry two probabilities (or the same mean to take
+    two values), which no reweighting can do. Without this check they
+    surface late, as a joint-infeasibility failure from the dual, naming
+    neither the label nor the values that clash.
+
+    Args:
+        targets: The targets as passed by the caller.
+
+    Returns:
+        The deduplicated targets, first occurrence first.
+
+    Raises:
+        TypeError: If a target is neither a `ProbabilityTarget` nor a
+            `MomentTarget`.
+        ValueError: If two targets share a label but are not identical.
+    """
+    from impulso.scenario import MomentTarget, ProbabilityTarget
+
+    first_seen: dict[str, Target] = {}
+    unique: list[Target] = []
+    for target in targets:
+        if not isinstance(target, ProbabilityTarget | MomentTarget):
+            raise TypeError(f"tilt() accepts ProbabilityTarget or MomentTarget, got {type(target).__name__}")
+        label = target_label(target)
+        first = first_seen.get(label)
+        if first is None:
+            first_seen[label] = target
+            unique.append(target)
+        elif first != target:
+            raise ValueError(
+                f"Conflicting targets for {label}: {_requested_value(first)} and "
+                f"{_requested_value(target)}. A target label pins the quantity, not the value "
+                "asked of it, so these are two contradictory constraints on the same "
+                "quantity — keep one."
+            )
+    return unique
+
+
+def _requested_value(target: Target) -> str:
+    """The value a target asks for, for the conflicting-targets message."""
+    from impulso.scenario import ProbabilityTarget
+
+    if isinstance(target, ProbabilityTarget):
+        return f"probability={target.probability:g}"
+    return f"mean={target.mean:g}"
 
 
 def _resolve_target(target: Target, var_names: list[str], steps: int) -> tuple[int, int]:
@@ -415,7 +493,9 @@ def tilt_result(
     Args:
         result: A density-mode `ForecastResult` or
             `ConditionalForecastResult` (`ScenarioResult` included).
-        targets: `ProbabilityTarget` / `MomentTarget` list.
+        targets: `ProbabilityTarget` / `MomentTarget` list. Repeats are
+            dropped, so the result's `targets` and its `target`
+            coordinate carry one entry per distinct target.
         ess_warn_fraction: Warn when the effective sample size falls
             below this fraction of the draw count.
 
@@ -424,8 +504,9 @@ def tilt_result(
 
     Raises:
         ValueError: If the parent result is a mean forecast, if
-            `ess_warn_fraction` is outside `[0, 1]`, or if the targets
-            are unachievable.
+            `ess_warn_fraction` is outside `[0, 1]`, if two targets
+            constrain the same quantity with different values, or if the
+            targets are unachievable.
     """
     import arviz as az
     import xarray as xr
@@ -443,9 +524,10 @@ def tilt_result(
     if not 0.0 <= ess_warn_fraction <= 1.0:
         raise ValueError(f"ess_warn_fraction must lie in [0, 1], got {ess_warn_fraction}")
 
-    targets = list(targets)
     da = result.idata.posterior_predictive["forecast"]
-    G, t = build_moments(da.values, targets, result.var_names, result.steps)
+    # build_moments returns the deduplicated targets: one column, one
+    # label, one row of achieved/requested per distinct target.
+    G, t, targets = build_moments(da.values, targets, result.var_names, result.steps)
     weights, achieved = solve_tilt(G, t)
 
     n_chains, n_draws = da.shape[:2]

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -673,7 +673,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
         exog_future = self._validate_forecast_exog(steps, exog_future)
 
         paths, eps = structural_forecast_draws(self, steps, seed=seed, exog_future=exog_future)
-        G, t = build_moments(paths, [target], self.var_names, steps)
+        G, t, _ = build_moments(paths, [target], self.var_names, steps)
         weights, achieved = solve_tilt(G, t)
         diagnostics = tilt_diagnostics(weights, stacklevel=3)
 

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -171,7 +171,9 @@ class ForecastResult(VARResultBase):
         than a re-solve.
 
         Args:
-            targets: `ProbabilityTarget` / `MomentTarget` list.
+            targets: `ProbabilityTarget` / `MomentTarget` list. A target
+                repeated verbatim is kept once; two targets constraining
+                the same quantity with different values are rejected.
             ess_warn_fraction: Warn when the effective sample size falls
                 below this fraction of the draw count. Default 0.1.
 
@@ -511,7 +513,9 @@ class ConditionalForecastResult(VARResultBase):
         exactly — a theorem, not a code path.
 
         Args:
-            targets: `ProbabilityTarget` / `MomentTarget` list.
+            targets: `ProbabilityTarget` / `MomentTarget` list. A target
+                repeated verbatim is kept once; two targets constraining
+                the same quantity with different values are rejected.
             ess_warn_fraction: Warn when the effective sample size falls
                 below this fraction of the draw count. Default 0.1.
 

--- a/tests/test_tilting.py
+++ b/tests/test_tilting.py
@@ -11,6 +11,8 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import re
+
 import numpy as np
 import pytest
 
@@ -19,6 +21,7 @@ from impulso._tilting import (
     ess,
     kl_divergence,
     solve_tilt,
+    target_label,
     weighted_hdi,
     weighted_quantile,
 )
@@ -64,7 +67,7 @@ class TestClosedForm:
         # The first n_event draws sit below the threshold.
         forecast = _forecast_from_series(x)
         target = ProbabilityTarget(variable="y1", horizon=1, threshold=float(n_event) - 0.5, probability=probability)
-        G, t = build_moments(forecast, [target], ["y1"], steps=1)
+        G, t, _ = build_moments(forecast, [target], ["y1"], steps=1)
         return G, t, n_total, n_event, probability
 
     def test_weights_match_the_analytic_two_mass_solution(self):
@@ -100,7 +103,7 @@ class TestClosedForm:
     def test_direction_above_flips_the_event(self):
         x = np.arange(100.0)
         target = ProbabilityTarget(variable="y1", horizon=1, threshold=79.5, probability=0.5, direction="above")
-        G, _ = build_moments(_forecast_from_series(x), [target], ["y1"], steps=1)
+        G, *_ = build_moments(_forecast_from_series(x), [target], ["y1"], steps=1)
         assert G[:, 0].sum() == 20.0
         assert np.all(G[80:, 0] == 1.0)
 
@@ -118,7 +121,7 @@ class TestGaussianMeanTilt:
     def _solve(mean=0.5, n_total=50_000):
         x = np.random.default_rng(0).standard_normal(n_total)
         target = MomentTarget(variable="x", horizon=1, mean=mean)
-        G, t = build_moments(_forecast_from_series(x), [target], ["x"], steps=1)
+        G, t, _ = build_moments(_forecast_from_series(x), [target], ["x"], steps=1)
         w, achieved = solve_tilt(G, t)
         return x, w, achieved
 
@@ -168,7 +171,7 @@ class TestMultiTargetDual:
             MomentTarget(variable="y1", horizon=1, mean=0.3),
             ProbabilityTarget(variable="y2", horizon=2, threshold=0.0, probability=0.7),
         ]
-        G, t = build_moments(y, targets, ["y1", "y2"], steps=2)
+        G, t, _ = build_moments(y, targets, ["y1", "y2"], steps=2)
         w, achieved = solve_tilt(G, t)
         assert np.allclose(achieved, t, atol=1e-6)
 
@@ -196,7 +199,7 @@ class TestMultiTargetDual:
             ProbabilityTarget(variable="y1", horizon=1, threshold=0.0, probability=0.8),
             ProbabilityTarget(variable="y1", horizon=3, threshold=0.5, probability=0.6),
         ]
-        G, t = build_moments(y, targets, ["y1"], steps=3)
+        G, t, _ = build_moments(y, targets, ["y1"], steps=3)
         w, achieved = solve_tilt(G, t)
         assert np.allclose(achieved, t, atol=1e-8)
         assert w.min() >= 0.0
@@ -229,7 +232,7 @@ class TestInfeasibility:
             ProbabilityTarget(variable="y1", horizon=1, threshold=49.5, probability=0.7),
             ProbabilityTarget(variable="y1", horizon=1, threshold=49.5, probability=0.7, direction="above"),
         ]
-        G, t = build_moments(forecast, targets, ["y1"], steps=1)
+        G, t, _ = build_moments(forecast, targets, ["y1"], steps=1)
         with pytest.raises(ValueError, match="not jointly achievable"):
             solve_tilt(G, t)
 
@@ -259,6 +262,80 @@ class TestInfeasibility:
                 ["y1"],
                 steps=1,
             )
+
+
+class TestDuplicateTargets:
+    """Repeated targets collapse; same-quantity disagreements are rejected (issue #214)."""
+
+    @staticmethod
+    def _prob_target(probability=0.3):
+        return ProbabilityTarget(variable="y1", horizon=1, threshold=49.5, probability=probability)
+
+    def test_identical_probability_targets_collapse_to_one_column(self):
+        forecast = _forecast_from_series(np.arange(100.0))
+        target = self._prob_target()
+        G, t, targets = build_moments(forecast, [target, target], ["y1"], steps=1)
+        assert G.shape == (100, 1)
+        assert t.shape == (1,)
+        assert targets == [target]
+
+        once = build_moments(forecast, [target], ["y1"], steps=1)
+        assert np.allclose(solve_tilt(G, t)[0], solve_tilt(once[0], once[1])[0], atol=1e-15, rtol=0.0)
+
+    def test_identical_moment_targets_collapse_to_one_column(self):
+        x = np.random.default_rng(21).standard_normal(500)
+        forecast = _forecast_from_series(x)
+        target = MomentTarget(variable="y1", horizon=1, mean=0.4)
+        G, t, targets = build_moments(forecast, [target, target, target], ["y1"], steps=1)
+        assert G.shape == (500, 1)
+        assert targets == [target]
+
+        once = build_moments(forecast, [target], ["y1"], steps=1)
+        w_dup, achieved = solve_tilt(G, t)
+        assert np.allclose(w_dup, solve_tilt(once[0], once[1])[0], atol=1e-12, rtol=0.0)
+        assert achieved[0] == pytest.approx(0.4, abs=1e-8)
+
+    def test_same_event_with_two_probabilities_raises_early(self):
+        forecast = _forecast_from_series(np.arange(100.0))
+        targets = [self._prob_target(0.3), self._prob_target(0.4)]
+        with pytest.raises(ValueError) as excinfo:
+            build_moments(forecast, targets, ["y1"], steps=1)
+        message = str(excinfo.value)
+        assert re.search(
+            re.escape("Conflicting targets for P(y1[h=1] < 49.5): probability=0.3 and probability=0.4"), message
+        )
+        # The clash is caught before the solve, not left to the dual's guard.
+        assert "not jointly achievable" not in message
+
+    def test_same_mean_with_two_values_raises_early(self):
+        forecast = _forecast_from_series(np.arange(100.0))
+        targets = [
+            MomentTarget(variable="y1", horizon=1, mean=40.0),
+            MomentTarget(variable="y1", horizon=1, mean=60.0),
+        ]
+        with pytest.raises(ValueError, match=re.escape("Conflicting targets for E[y1[h=1]]: mean=40 and mean=60")):
+            build_moments(forecast, targets, ["y1"], steps=1)
+
+    def test_distinct_targets_are_untouched(self):
+        y = np.random.default_rng(22).standard_normal((1, 400, 2, 2))
+        targets = [
+            MomentTarget(variable="y1", horizon=1, mean=0.3),
+            ProbabilityTarget(variable="y2", horizon=2, threshold=0.0, probability=0.7),
+            # Same event as the target above but at a different horizon.
+            ProbabilityTarget(variable="y2", horizon=1, threshold=0.0, probability=0.7),
+        ]
+        G, t, kept = build_moments(y, targets, ["y1", "y2"], steps=2)
+        assert kept == targets
+        assert G.shape == (400, 3)
+        assert np.allclose(t, [0.3, 0.7, 0.7])
+
+    def test_a_repeat_next_to_a_distinct_target_keeps_both(self):
+        y = np.random.default_rng(23).standard_normal((1, 400, 2, 2))
+        first = MomentTarget(variable="y1", horizon=1, mean=0.3)
+        second = ProbabilityTarget(variable="y2", horizon=2, threshold=0.0, probability=0.7)
+        _, t, kept = build_moments(y, [first, second, first], ["y1", "y2"], steps=2)
+        assert kept == [first, second]
+        assert np.allclose(t, [0.3, 0.7])
 
 
 class TestWeightedSummaries:
@@ -487,6 +564,27 @@ class TestTiltedResultSurface:
         assert rows[0]["draws_in_event"] == 50
         assert rows[1]["draws_in_event"] is None
         assert tilted.targets == [prob_target, moment_target]
+
+    def test_a_repeated_target_yields_one_coordinate_row(self, fitted_2v):
+        forecast = fitted_2v.forecast(4, seed=7)
+        target = _median_target(forecast, horizon=2, probability=0.65)
+        tilted = forecast.tilt([target, target])
+        label = target_label(target)
+        pp = tilted.idata.posterior_predictive
+        assert pp["target"].values.tolist() == [label]
+        # Duplicated labels would make this select two rows instead of a scalar.
+        assert pp["achieved"].sel(target=label).shape == ()
+        assert float(pp["achieved"].sel(target=label)) == pytest.approx(0.65, abs=1e-12)
+        assert tilted.targets == [target]
+        assert len(tilted.summary()["targets"]) == 1
+        assert np.allclose(tilted.weights, forecast.tilt([target]).weights, atol=1e-15, rtol=0.0)
+
+    def test_conflicting_targets_raise_through_tilt(self, fitted_2v):
+        forecast = fitted_2v.forecast(4, seed=7)
+        target = _median_target(forecast, horizon=2, probability=0.65)
+        clash = target.model_copy(update={"probability": 0.35})
+        with pytest.raises(ValueError, match="Conflicting targets for"):
+            forecast.tilt([target, clash])
 
     def test_weights_are_chain_draw_shaped_and_normalised(self, fitted_2v):
         forecast = fitted_2v.forecast(4, seed=8)


### PR DESCRIPTION
## Summary

Follow-up on the tilting branch (#213), stacked on `feat/150-entropic-tilting`:

Passing the same target twice produced duplicate `target` coordinate labels — correct numbers, but `.sel(target=...)` returned multiple rows. New `dedupe_targets` (called before any moment column is built) implements a two-way split:

- **Exact duplicates** (full frozen-model equality, probability/mean included): dropped silently, first occurrence kept, order preserved — harmless user redundancy.
- **Same label, different target** (e.g. P=0.3 *and* P=0.4 on the same event): **immediate `ValueError`** naming the label and both requested values — previously this surfaced only post-solve as an opaque "not jointly achievable" that named neither. The label pins the *quantity*; two values for it are contradictory constraints, and now they fail early and legibly.

`build_moments` returns the deduped list so `achieved`/`requested`/`event_draws`/the coordinate all align; `reverse_stress` (single target) is a no-op pass-through.

Closes #214

## Gates

82 tilting+reverse-stress tests green (+8); branch fast suite 683 passed; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV