### PR TITLE
fix(sv): re-apply the per-variable log-vol level in the SV forecast (#241)

### DIFF
--- a/src/impulso/sv/spec.py
+++ b/src/impulso/sv/spec.py
@@ -283,6 +283,14 @@ class StochasticVolatility(ImpulsoBaseModel):
         hyperparameters directly from the full posterior.  The correlation
         Cholesky ``R_chol`` is held constant (Clark-style assumption).
 
+        The extrapolation reproduces the *same* composition
+        ``build_pymc_latent`` used in sample: when the dynamics carries no
+        intrinsic level (``has_explicit_level`` is False, i.e. random walk)
+        the per-variable level ``v{i}_mu`` is added back on, because
+        ``forecast_log_vol`` only extrapolates the level-free ``v{i}_h``.
+        Omitting it scales every forecast standard deviation by
+        ``exp(-mu_i / 2)`` while leaving the in-sample fit untouched (#241).
+
         Args:
             posterior: Dataset with per-variable log-vol paths (`h`)
                 and `R_chol`.
@@ -301,10 +309,13 @@ class StochasticVolatility(ImpulsoBaseModel):
 
         h_forecast = np.zeros((n_chains, n_draws, steps, n_vars))
         for i in range(n_vars):
-            h_forecast[:, :, :, i] = dynamics.forecast_log_vol(
-                posterior,
-                steps,
-                rng,
-                name_prefix=f"v{i}_",
-            )
+            prefix = f"v{i}_"
+            h_i = dynamics.forecast_log_vol(posterior, steps, rng, name_prefix=prefix)
+            if not dynamics.has_explicit_level:
+                # `build_pymc_latent` composed the in-sample path as
+                # `v{i}_h + v{i}_mu`, but `forecast_log_vol` extrapolates
+                # `v{i}_h` alone. Re-apply the level, or the forecast bands
+                # come out at exp(-mu_i / 2) times the in-sample ones (#241).
+                h_i = h_i + posterior[f"{prefix}mu"].values[..., None]
+            h_forecast[:, :, :, i] = h_i
         return self._clark_reconstruct(h_forecast, R_chol)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,13 +290,25 @@ def synthetic_sv_idata_2v():
     """Synthetic InferenceData mimicking a fitted multivariate SV model.
 
     Shape: 2 chains, 50 draws, T=20, n_vars=2.
-    Contains: h (2, 50, 20, 2), R_chol (2, 50, 2, 2), v0_mu, v1_mu,
-    v0_sigma_eta, v1_sigma_eta.
+    Contains: h (2, 50, 20, 2), R_chol (2, 50, 2, 2), v0_h, v1_h, v0_mu,
+    v1_mu, v0_sigma_eta, v1_sigma_eta.
+
+    Respects the composition `build_pymc_latent` actually registers under
+    random-walk dynamics: `h[..., i] == v{i}_h + v{i}_mu`, with `v{i}_h`
+    the level-free path and `v{i}_mu` a nonzero per-variable level. An
+    earlier version of this fixture set `v{i}_h = h[..., i]` *and* a
+    nonzero `v{i}_mu`, which asserts `mu_i == 0` — the exact assumption
+    the #241 forecast bug made, so every test built on it was blind to
+    the whole family of level bugs.
     """
     rng = np.random.default_rng(0)
     n_chains, n_draws, T, n_vars = 2, 50, 20, 2
 
-    h = rng.standard_normal((n_chains, n_draws, T, n_vars)) * 0.3 - 1.0
+    # Level-free per-variable RW paths and their separate levels.
+    v_h = rng.standard_normal((n_chains, n_draws, T, n_vars)) * 0.3
+    v_mu = rng.standard_normal((n_chains, n_draws, n_vars)) - 1.0
+    # The invariant: the stacked in-sample log-vol is path + level.
+    h = v_h + v_mu[:, :, None, :]
 
     R_chol = np.zeros((n_chains, n_draws, n_vars, n_vars))
     for c in range(n_chains):
@@ -309,10 +321,10 @@ def synthetic_sv_idata_2v():
     posterior = xr.Dataset({
         "h": (("chain", "draw", "time", "variable"), h),
         "R_chol": (("chain", "draw", "i", "j"), R_chol),
-        "v0_h": (("chain", "draw", "time"), h[:, :, :, 0]),
-        "v1_h": (("chain", "draw", "time"), h[:, :, :, 1]),
-        "v0_mu": (("chain", "draw"), rng.standard_normal((n_chains, n_draws))),
-        "v1_mu": (("chain", "draw"), rng.standard_normal((n_chains, n_draws))),
+        "v0_h": (("chain", "draw", "time"), v_h[:, :, :, 0]),
+        "v1_h": (("chain", "draw", "time"), v_h[:, :, :, 1]),
+        "v0_mu": (("chain", "draw"), v_mu[:, :, 0]),
+        "v1_mu": (("chain", "draw"), v_mu[:, :, 1]),
         "v0_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
         "v1_sigma_eta": (("chain", "draw"), np.abs(rng.standard_normal((n_chains, n_draws)))),
     })

--- a/tests/test_prefix_forecast.py
+++ b/tests/test_prefix_forecast.py
@@ -191,3 +191,80 @@ class TestForecastCholeskyPathUsesPrefix:
             "forecast_cholesky_path still builds a fake xr.Dataset — "
             "it should call dynamics.forecast_log_vol with name_prefix instead"
         )
+
+
+class TestForecastLevelComposition:
+    """The forecast must reproduce `build_pymc_latent`'s composition (#241).
+
+    In sample, random-walk dynamics registers `h[..., i] = v{i}_h + v{i}_mu`
+    — the level lives *outside* the extrapolated path. A forecast that reads
+    only `v{i}_h` therefore sits at `exp(-mu_i / 2)` times the right scale,
+    silently, with the in-sample fit looking perfect.
+    """
+
+    @staticmethod
+    def _zeroed_innovations(posterior, n_vars=2):
+        """Copy with `sigma_eta = 0`, making the RW a flat continuation."""
+        out = posterior.copy(deep=True)
+        for i in range(n_vars):
+            out[f"v{i}_sigma_eta"] = out[f"v{i}_sigma_eta"] * 0.0
+        return out
+
+    def test_zero_innovation_forecast_continues_the_in_sample_level(self, synthetic_sv_idata_2v):
+        """With no innovation the forecast is pinned to the last in-sample h.
+
+        `L_t = diag(exp(h_t / 2)) @ R_chol` and `R_chol` has a unit
+        diagonal, so `diag(L_t) == exp(h_t / 2)` exactly. Under the #241
+        bug this reads `exp(v_h[-1] / 2)` and the assertion fails by a
+        factor of `exp(mu_i / 2)`.
+        """
+        from impulso.sv.spec import StochasticVolatility
+
+        steps = 4
+        posterior = self._zeroed_innovations(synthetic_sv_idata_2v.posterior)
+        path = StochasticVolatility().forecast_cholesky_path(posterior, steps=steps, rng=np.random.default_rng(0))
+
+        expected = np.exp(posterior["h"].values[:, :, -1, :] / 2)  # (C, D, n_vars)
+        got = np.diagonal(path, axis1=-2, axis2=-1)  # (C, D, steps, n_vars)
+        for s in range(steps):
+            np.testing.assert_allclose(got[:, :, s, :], expected, rtol=1e-12)
+
+    def test_level_is_not_double_counted(self, synthetic_sv_idata_2v):
+        """The level is added exactly once, not twice.
+
+        A fix that added `v{i}_mu` on top of an already-levelled path would
+        pass the continuity test above only if `mu` were zero. Pin it against
+        the independently composed expectation.
+        """
+        from impulso.sv.spec import StochasticVolatility
+
+        posterior = self._zeroed_innovations(synthetic_sv_idata_2v.posterior)
+        path = StochasticVolatility().forecast_cholesky_path(posterior, steps=1, rng=np.random.default_rng(0))
+
+        got = np.diagonal(path, axis1=-2, axis2=-1)[:, :, 0, :]
+        for i in range(2):
+            manual = np.exp((posterior[f"v{i}_h"].values[:, :, -1] + posterior[f"v{i}_mu"].values) / 2)
+            np.testing.assert_allclose(got[:, :, i], manual, rtol=1e-12)
+
+    def test_ar1_needs_no_outer_level(self, synthetic_sv_idata_2v):
+        """AR(1) carries the level in `alpha`, so no `v{i}_mu` may be read.
+
+        `build_pymc_latent` registers no outer `mu_i` when
+        `has_explicit_level` is True, so a posterior from an AR(1) fit has
+        no `v{i}_mu` at all — reading one would raise.
+        """
+        from impulso.sv.dynamics import AR1
+        from impulso.sv.spec import StochasticVolatility
+
+        base = synthetic_sv_idata_2v.posterior
+        n_chains, n_draws, _, n_vars = base["h"].shape
+        posterior = base.drop_vars([f"v{i}_mu" for i in range(n_vars)])
+        for i in range(n_vars):
+            posterior[f"v{i}_phi"] = (("chain", "draw"), np.full((n_chains, n_draws), 0.95))
+            posterior[f"v{i}_alpha"] = (("chain", "draw"), np.full((n_chains, n_draws), -0.05))
+
+        sv = StochasticVolatility(dynamics=AR1())
+        assert sv.resolved_dynamics.has_explicit_level
+        path = sv.forecast_cholesky_path(posterior, steps=3, rng=np.random.default_rng(0))
+        assert path.shape == (n_chains, n_draws, 3, n_vars, n_vars)
+        assert np.all(np.isfinite(path))


### PR DESCRIPTION
Closes #241. Blocks the v0.0.9 release.

## The bug

`StochasticVolatility.build_pymc_latent` composes the in-sample log-vol as

```python
if dynamics.has_explicit_level:
    h_paths.append(h_i)              # AR(1): alpha carries the level
else:
    mu_i = pm.Normal(f"{prefix}mu", ...)
    h_paths.append(h_i + mu_i)       # RW: level lives OUTSIDE the path
```

so under random-walk dynamics `h[..., i] == v{i}_h + v{i}_mu`.

`forecast_cholesky_path` called `dynamics.forecast_log_vol(..., name_prefix=f"v{i}_")`, and `RandomWalk.forecast_log_vol` reads `posterior[f"{prefix}h"]` — the **level-free** path — and extrapolates from its last value. `v{i}_mu` was never re-applied.

Net effect: every multivariate SV forecast standard deviation came out at `exp(-mu_i / 2)` times the correct scale. The in-sample fit was unaffected, so nothing looked wrong. Every SV density, conditional and scenario forecast inherited the mis-scaled bands.

AR(1) was never affected: `has_explicit_level` is `True`, no outer `mu_i` is registered, and `AR1.forecast_log_vol` already reads `alpha`.

## The fix

`forecast_cholesky_path` now branches on `has_explicit_level` exactly as the in-sample registration does — adding `v{i}_mu` back for the random-walk path, leaving AR(1) alone.

## Why the tests missed it

`synthetic_sv_idata_2v` encoded the **inverse** of the true invariant:

```python
h = rng.standard_normal(...) * 0.3 - 1.0
"v0_h": h[:, :, :, 0],                            # v_h == h
"v0_mu": rng.standard_normal((n_chains, n_draws)) # ...and mu != 0
```

That asserts `mu_i == 0` while supplying a nonzero `mu_i` — precisely the assumption the buggy forecast made. Every test built on this fixture was structurally blind to the whole family of level bugs, and the existing `forecast_cholesky_path` tests only asserted shapes.

The fixture now respects `h[..., i] == v{i}_h + v{i}_mu`.

## Tests

`TestForecastLevelComposition`, three pins:

| Test | Fails unfixed? |
|---|---|
| `test_zero_innovation_forecast_continues_the_in_sample_level` | yes |
| `test_level_is_not_double_counted` | yes |
| `test_ar1_needs_no_outer_level` | no (unaffected branch, by design) |

The first sets `sigma_eta = 0`, making the walk a flat continuation, so `diag(L_t)` must equal `exp(h[-1] / 2)` exactly — `R_chol` has a unit diagonal. Seed-independent and exact (`rtol=1e-12`), not a tolerance-tuned approximation.

Verified locally: 1049 passed, `ruff check`/`ruff format`/`ty` clean.

## Out of scope

Companion issue #244 — `v{i}_mu` and the random walk’s own `h0` are additively redundant, so the level is not separately identified, and `SVDefaultPrior` reuses `mu_mu`/`mu_sigma` (calibrated from the series mean/SD) for what is a log-variance level. Both are prior-specification questions; this PR only makes the forecast agree with the model that was fitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV