### PR TITLE
chore(release): v0.0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "impulso"
-version = "0.0.8"
+version = "0.0.9"
 description = "Bayesian Vector Autoregression (VAR) in Python."
 authors = [{ name = "Thomas Pinder", email = "tompinder@live.co.uk" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "impulso"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
Version bump for v0.0.9. `pyproject.toml` + `uv.lock` only, matching the v0.0.8 release commit (99ee00c).

Ships the 27 commits on main since v0.0.8. Release notes are drafted separately; three behaviour-changing fixes lead them:

- **#208** — custom `Cholesky(ordering=...)` now returns rows in data order. Previously mislabelled, so those IRF/FEVD/HD numbers change. Identity orderings byte-identical.
- **#237** — the `B_exog` prior now scales to the regressor, so every NUTS-with-exog posterior changes. Constant exog columns rejected.
- **#241** — multivariate SV forecast bands change (the per-variable log-vol level was dropped from the forecast).

Blocked on nothing; #268 (the #241 fix) is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV