### PR TITLE
chore(deps): lower the pandas floor to >=2.3.3, verify floors in CI, bump to 0.0.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,41 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  lowest-direct-deps:
+    # The lockfile pins the newest compatible release of everything, so the
+    # matrix above never exercises the floors declared in pyproject.toml. This
+    # job resolves every direct dependency down to its declared minimum, so a
+    # floor that is only nominally supported fails here instead of in a
+    # downstream install. Runs on the oldest supported Python, since the lowest
+    # dependencies and the lowest interpreter travel together (old releases
+    # have no wheels for new Pythons).
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "3.11"
+
+      - name: Resolve every dependency floor to its minimum
+        # Rewrites uv.lock in the runner's checkout; the committed lockfile is
+        # verified separately by the `quality` job's `uv lock --locked`.
+        run: uv sync --python 3.11 --resolution lowest-direct --group dev --extra nutpie --extra diagnostics
+
+      - name: Report the resolved floors
+        run: |
+          uv run --no-sync python -c "
+          import importlib.metadata as m
+          for p in ['numpy','pandas','pydantic','pymc','arviz','matplotlib','beartype','scipy','nutpie','statsmodels']:
+              print(f'{p:14}{m.version(p)}')
+          "
+
+      - name: Run tests against the floors
+        run: uv run --no-sync python -m pytest tests -m "not slow"
+
   build-docs:
     runs-on: ubuntu-latest
     # Full render on main executes real MCMC; smoke render on PRs is fast.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Impulso is a Python library for Bayesian Vector Autoregression (VAR). Early stage (v0.0.4), requires Python >=3.11.
+Impulso is a Python library for Bayesian Vector Autoregression (VAR). Early stage, requires Python >=3.11.
 
 ## Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "impulso"
-version = "0.0.9"
+version = "0.0.10"
 description = "Bayesian Vector Autoregression (VAR) in Python."
 authors = [{ name = "Thomas Pinder", email = "tompinder@live.co.uk" }]
 readme = "README.md"
@@ -8,7 +8,7 @@ keywords = ['python']
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "numpy>=2.0",
-    "pandas>=3.0",
+    "pandas>=2.3",
     "pydantic>=2.0",
     "pymc>=5.26.1",
     "arviz>=0.20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ keywords = ['python']
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "numpy>=2.0",
-    "pandas>=2.3",
+    "pandas>=2.3.3",
     "pydantic>=2.0",
     "pymc>=5.26.1",
     "arviz>=0.20",
-    "matplotlib>=3.7",
+    "matplotlib>=3.9",
     "beartype>=0.18",
     "scipy>=1.10",
 ]
@@ -50,7 +50,7 @@ dev = [
     "statsmodels>=0.14.6",
     "tabulate>=0.10.0",
     "typing-extensions>=4.12",
-    "ipython"
+    "ipython>=8.18",
 ]
 docs = [
     "statsmodels>=0.14.6",

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -851,7 +851,9 @@ class TestLongRunRestrictionRecovery:
         data = VARData(
             endog=y,
             endog_names=["y1", "y2"],
-            index=pd.date_range("1900-01-01", periods=T, freq="QS"),
+            # unit="s": 2000 quarters from 1900 lands in 2400, past the
+            # nanosecond ceiling (2262-04-11) pandas 2.x defaults to.
+            index=pd.date_range("1900-01-01", periods=T, freq="QS", unit="s"),
         )
 
         fitted = ConjugateVAR(lags=1, prior=NIWPrior(), draws=200, seed=0).fit(data)

--- a/uv.lock
+++ b/uv.lock
@@ -1150,10 +1150,10 @@ docs = [
 requires-dist = [
     { name = "arviz", specifier = ">=0.20" },
     { name = "beartype", specifier = ">=0.18" },
-    { name = "matplotlib", specifier = ">=3.7" },
+    { name = "matplotlib", specifier = ">=3.9" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "nutpie", marker = "extra == 'nutpie'", specifier = ">=0.13" },
-    { name = "pandas", specifier = ">=2.3" },
+    { name = "pandas", specifier = ">=2.3.3" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pymc", specifier = ">=5.26.1" },
     { name = "scipy", specifier = ">=1.10" },
@@ -1163,7 +1163,7 @@ provides-extras = ["nutpie", "diagnostics"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ipython" },
+    { name = "ipython", specifier = ">=8.18" },
     { name = "ipywidgets", specifier = ">=8.1.8" },
     { name = "jupyter", specifier = ">=1.0" },
     { name = "nutpie", specifier = ">=0.13" },

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "impulso"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },
@@ -1153,7 +1153,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.7" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "nutpie", marker = "extra == 'nutpie'", specifier = ">=0.13" },
-    { name = "pandas", specifier = ">=3.0" },
+    { name = "pandas", specifier = ">=2.3" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pymc", specifier = ">=5.26.1" },
     { name = "scipy", specifier = ">=1.10" },


### PR DESCRIPTION
## Summary

Lowers `pandas>=3.0` to `pandas>=2.3.3`, adds a CI job that actually verifies dependency floors, fixes the two floors that job proved were fiction, and bumps to 0.0.10.

The `>=3.0` floor came from 58b9022 ("modernise dependency floors"), a blanket bump alongside the Python 3.11 move — no code ever required it. For a library, forcing a pandas major-version upgrade on every downstream user is a real cost, and nothing in Impulso earns it.

## Why dropping pandas is safe

Pandas is a **pure I/O boundary** here. Every numeric path crosses via `.to_numpy(dtype=np.float64)` (`data.py:170`, `_stationarity.py:118`), and results are rebuilt from numpy into fresh frames. So the two headline 3.0 changes — copy-on-write by default and the new `str` dtype — cannot reach the numerics. There is no mutation-through-a-view, no dtype introspection, and no `object`-dtype assumption anywhere in `src/`.

The API surface used is small and has been stable since 1.x:

> `DataFrame`, `Series`, `Index`, `MultiIndex`, `DatetimeIndex`, `RangeIndex`, `Timestamp`, `date_range`, `infer_freq`, `tseries.frequencies.to_offset`, `offsets.BaseOffset`

`_time.py` is the one genuinely version-sensitive spot, but it round-trips `pd.infer_freq` → `to_offset` within whichever pandas is installed, so the 2.2 frequency-alias renames (`M`→`ME`, `H`→`h`) stay self-consistent either way.

`>=2.3.3` specifically because 2.3.3 is the first 2.x release with `cp314` wheels — earlier 2.3.x stops at `cp313`, so only 2.3.3 is installable across the whole supported 3.11–3.14 matrix.

## The new `lowest-direct-deps` job

The lockfile pins the newest compatible release of everything, so the existing matrix **only ever tested current dependencies**. Every floor in `pyproject.toml` was declared but never installed by anything — including the new pandas one, which is exactly the problem this PR would otherwise have introduced.

The job resolves each direct dependency to its declared minimum and runs the fast suite there, on Python 3.11. Lowest deps and lowest interpreter have to travel together: nutpie 0.13.0 has no `cp313` wheel, and old releases generally lack wheels for new Pythons. It syncs `--group dev --extra nutpie --extra diagnostics` so the extras' floors are covered too.

## Floors it immediately proved were fiction

**`matplotlib>=3.7` → `>=3.9`.** matplotlib 3.7 and 3.8 are built against the NumPy 1.x C ABI and cannot import under `numpy>=2.0` — itself a declared floor. `import arviz` died with `ImportError: numpy.core.multiarray failed to import`. The project was claiming a dependency pairing that could never install. 3.9.0 is the first release with NumPy 2 support.

**`ipython` (dev group) → `>=8.18`.** Declared with no version constraint at all, so lowest-direct selected ipython **0.10**, from 2010. Python 2 syntax; fails to build.

## Verification

| Environment | fast suite | slow (MCMC) |
|---|---|---|
| pandas 3.0.1 (lockfile) | 1049 passed | — |
| **all floors at minimum** | **1049 passed** | — |
| pandas 2.3.3, rest current | 1049 passed | 39 passed |

Floors exercised: numpy 2.0.0, pandas 2.3.3, pydantic 2.0, pymc 5.26.1, arviz 0.20.0, matplotlib 3.9.0, beartype 0.18.2, scipy 1.13.0, nutpie 0.13.0, statsmodels 0.14.6.

`ruff check`, `ruff format --check`, `ty check`, and `uv lock --locked` all pass.

## The one fixture fix

Lowering the pandas floor surfaced exactly one test failure, and it was a **fixture, not library code**. `tests/test_identification.py` built 2000 quarterly periods from `1900-01-01`, landing in year **2400** — past the nanosecond ceiling (`2262-04-11`) that pandas 2.x defaults to. pandas 3.0 auto-selects `datetime64[us]` and succeeds; 2.x raises `OutOfBoundsDatetime`. Pinning the fixture to `unit="s"` is correct on both.

## Also

Removes the hardcoded version string from `CLAUDE.md`. It was a stale second source of truth — still claiming `v0.0.4`. Deleted rather than corrected, so it cannot drift again; `pyproject.toml` and GitHub are the record.

## Deliberately not done

`deploy-docs`'s `needs:` list is unchanged — doc deploys are not gated on the new job. That felt like a separate call.

Note the new job runs `uv sync --resolution lowest-direct`, which rewrites `uv.lock` inside the runner's checkout, so it cannot use `--frozen`. The committed lockfile is still verified independently by `quality`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egjd7ToFeb9TQqFnfRQZxV
