### PR TITLE
fix(sampling): reject interrupted NaN-padded posteriors; fit proxy-svar SV cell to the CI budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ Shared fixtures available in all test files:
 
 - **LKJCholeskyCov/LKJCorr are broken** with PyMC 5.28 + PyTensor 2.38 + NumPy 2.4 (einsum unpacking bug). Use manual Cholesky parameterization instead (HalfCauchy diagonal + Normal off-diagonal), as done in `spec.py`.
 - **Parallel sampling segfaults**: Use `cores=1` in `NUTSSampler` for tests to avoid multiprocessing crashes. Tests marked `@pytest.mark.slow` exercise MCMC.
+- **Interrupted nutpie runs return NaN-padded posteriors, not errors**: nutpie catches KeyboardInterrupt (e.g. a MyST-NB cell hitting `nb_execution_timeout` and tearing down the kernel), aborts, and returns the partial trace — unfinished draws come back NaN with `diverging` zero-filled, so diagnostics print `ESS = nan` with "0 divergences". `NUTSSampler.sample` guards against this and raises. Keep each docs notebook MCMC cell under the 1800 s cell budget; nutpie runs chains in parallel threads regardless of `cores`, so a cell's wall time tracks one chain's `tune + draws`.
 
 ## PR Review Policy
 

--- a/docs/tutorials/proxy-svar.py
+++ b/docs/tutorials/proxy-svar.py
@@ -318,12 +318,17 @@ if ci:
         nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
     )
 else:
+    # Sized to the docs CI cell budget: nutpie runs chains in parallel, so the
+    # cell's wall time tracks one chain's tune+draws. Heavier settings (e.g.
+    # tune=2000, draws=1000, chains=4) push this cell past the 1800 s
+    # nb_execution_timeout on CI runners; the interrupted sampler then returns
+    # a NaN-padded posterior (see NUTSSampler's incomplete-draw guard).
     sv_sampler = NUTSSampler(
-        draws=1000,
-        tune=2000,
-        chains=4,
+        draws=500,
+        tune=1000,
+        chains=2,
         cores=1,
-        target_accept=0.95,
+        target_accept=0.9,
         random_seed=42,
         nuts_sampler_kwargs={"low_rank_modified_mass_matrix": True},
     )

--- a/src/impulso/samplers.py
+++ b/src/impulso/samplers.py
@@ -3,11 +3,77 @@
 import os
 from typing import Literal
 
+import numpy as np
 import pymc as pm
 from pydantic import Field
 
-from impulso._arviz_compat import InferenceDataLike
+from impulso._arviz_compat import InferenceDataLike, get_group_dataset
 from impulso._base import ImpulsoModel
+
+
+def _raise_on_incomplete_draws(idata: InferenceDataLike, expected_draws: int) -> None:
+    """Reject a posterior with draws the sampler never delivered.
+
+    An interrupted run (Ctrl-C, a notebook cell timeout sending SIGINT
+    through the kernel) or a dead chain does not raise: nutpie's Python
+    wrapper catches the interrupt, aborts, and returns the partial trace,
+    and PyMC's own backend likewise returns whatever it has. The damage
+    takes two shapes:
+
+    - **Truncated:** every chain stopped early, so the `draw` dimension is
+      shorter than requested (zero-length when the interrupt lands during
+      tuning).
+    - **NaN-padded:** chains stopped at different points; nutpie pre-fills
+      its trace buffers with NaN and zero-fills the boolean `diverging`
+      stat, so slower chains come back as silently NaN-padded draws with
+      zero divergences. Every downstream statistic then degrades to NaN
+      without a single error (the proxy-svar docs deploy shipped exactly
+      that).
+
+    A draw counts as missing only when *every* value of *every* float
+    posterior variable is NaN at that (chain, draw) — the padding
+    signature. Legitimate NaN in an individual variable never trips this.
+
+    Args:
+        idata: The container returned by `pm.sample`.
+        expected_draws: Post-tuning draws requested per chain.
+
+    Raises:
+        RuntimeError: If the posterior is truncated or NaN-padded,
+            reporting the delivered draw count per affected chain.
+    """
+    posterior = get_group_dataset(idata, "posterior")
+    n_draws = int(posterior.sizes.get("draw", 0))
+
+    per_chain = []
+    if n_draws < expected_draws:
+        per_chain.append(f"every chain delivered at most {n_draws} of {expected_draws} draws")
+    else:
+        missing = None
+        for var in posterior.data_vars.values():
+            if not np.issubdtype(var.dtype, np.floating):
+                continue
+            reduce_dims = [d for d in var.dims if d not in ("chain", "draw")]
+            var_all_nan = var.isnull().all(dim=reduce_dims) if reduce_dims else var.isnull()
+            missing = var_all_nan if missing is None else missing & var_all_nan
+        if missing is None or not bool(missing.any()):
+            return
+        for chain in missing.coords.get("chain", range(missing.sizes["chain"])).values:
+            n_missing = int(missing.sel(chain=chain).sum())
+            if n_missing:
+                per_chain.append(f"chain {chain} delivered {n_draws - n_missing} of {expected_draws} draws")
+
+    raise RuntimeError(
+        "Sampling returned an incomplete posterior: "
+        + "; ".join(per_chain)
+        + ". Missing draws come back NaN-padded (or absent), so every "
+        "downstream statistic (ESS, r_hat, IRFs, forecasts) would silently "
+        "degrade to NaN. This happens when the sampler is interrupted "
+        "mid-run (Ctrl-C, a notebook cell timeout) or a chain fails; the "
+        "backend returns the partial trace instead of raising. Re-run the "
+        "fit to completion, or reduce its cost (fewer draws/tune steps or "
+        "chains) so it fits the available time budget."
+    )
 
 
 def _default_nuts_sampler() -> Literal["pymc", "nutpie"]:
@@ -69,6 +135,11 @@ class NUTSSampler(ImpulsoModel):
 
         Returns:
             ArviZ InferenceData with posterior and log_likelihood groups.
+
+        Raises:
+            RuntimeError: If the returned posterior is incomplete — an
+                interrupted or failed nutpie run comes back as silently
+                NaN-padded draws (see `_raise_on_incomplete_draws`).
         """
         with model:
             idata = pm.sample(
@@ -83,4 +154,5 @@ class NUTSSampler(ImpulsoModel):
                 nuts_sampler_kwargs=self.nuts_sampler_kwargs or {},
                 idata_kwargs={"log_likelihood": True},
             )
+        _raise_on_incomplete_draws(idata, self.draws)
         return idata

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,10 +1,98 @@
 """Tests for sampler specifications."""
 
+import numpy as np
 import pytest
+import xarray as xr
 from pydantic import ValidationError
 
+from impulso._arviz_compat import make_idata
 from impulso.protocols import Sampler
 from impulso.samplers import NUTSSampler
+
+
+def _synthetic_idata(nan_pad_chain: int | None = None, pad_from: int = 30, scattered_nan: bool = False):
+    """Posterior with 2 chains x 50 draws of one matrix and one scalar variable.
+
+    ``nan_pad_chain`` reproduces nutpie's interrupted-chain signature: every
+    value of every variable is NaN from ``pad_from`` onward in that chain,
+    while ``diverging`` stays False (nutpie zero-fills non-float buffers).
+    ``scattered_nan`` instead poisons a few isolated cells of a single
+    variable, which a legitimate posterior may contain.
+    """
+    rng = np.random.default_rng(0)
+    b = rng.normal(size=(2, 50, 3, 3))
+    mu = rng.normal(size=(2, 50))
+    if nan_pad_chain is not None:
+        b[nan_pad_chain, pad_from:] = np.nan
+        mu[nan_pad_chain, pad_from:] = np.nan
+    if scattered_nan:
+        b[0, 5, 1, 2] = np.nan
+        b[1, 40, 0, 0] = np.nan
+    posterior = xr.Dataset({
+        "B": (("chain", "draw", "var", "coeff"), b),
+        "mu": (("chain", "draw"), mu),
+    })
+    sample_stats = xr.Dataset({"diverging": (("chain", "draw"), np.zeros((2, 50), dtype=bool))})
+    return make_idata(posterior=posterior, sample_stats=sample_stats)
+
+
+class TestIncompleteDrawGuard:
+    """`NUTSSampler.sample` must not hand back a truncated or NaN-padded posterior.
+
+    An interrupted or dead chain does not raise: nutpie aborts and returns
+    the partial trace, NaN-padding slower chains (zero-filling `diverging`)
+    and truncating the draw dimension when every chain stopped early — the
+    proxy-svar CI incident. The guard turns both shapes into a loud error
+    at the sampling seam.
+    """
+
+    @staticmethod
+    def _sample_with(monkeypatch, idata):
+        import pymc as pm
+
+        monkeypatch.setattr(pm, "sample", lambda *args, **kwargs: idata)
+        with pm.Model():
+            return NUTSSampler(draws=50, chains=2).sample(pm.Model())
+
+    def test_nan_padded_chain_raises(self, monkeypatch):
+        idata = _synthetic_idata(nan_pad_chain=1)
+        with pytest.raises(RuntimeError, match=r"chain 1 delivered 30 of 50"):
+            self._sample_with(monkeypatch, idata)
+
+    def test_error_names_interrupt_and_remedy(self, monkeypatch):
+        idata = _synthetic_idata(nan_pad_chain=0, pad_from=1)
+        with pytest.raises(RuntimeError, match=r"(?i)interrupt"):
+            self._sample_with(monkeypatch, idata)
+
+    def test_truncated_posterior_raises(self, monkeypatch):
+        """All chains stopped early: shorter draw dim, no NaN anywhere."""
+        idata = _synthetic_idata()
+        import pymc as pm
+
+        monkeypatch.setattr(pm, "sample", lambda *args, **kwargs: idata)
+        with pm.Model(), pytest.raises(RuntimeError, match=r"at most 50 of 200"):
+            NUTSSampler(draws=200, chains=2).sample(pm.Model())
+
+    def test_interrupt_during_tuning_zero_draws_raises(self, monkeypatch):
+        """Interrupt during tuning: nutpie returns a zero-length draw dim."""
+        import pymc as pm
+
+        posterior = xr.Dataset(
+            {"B": (("chain", "draw", "var"), np.empty((2, 0, 3)))},
+        )
+        idata = make_idata(posterior=posterior)
+        monkeypatch.setattr(pm, "sample", lambda *args, **kwargs: idata)
+        with pm.Model(), pytest.raises(RuntimeError, match=r"at most 0 of 50"):
+            NUTSSampler(draws=50, chains=2).sample(pm.Model())
+
+    def test_scattered_nan_values_pass_through(self, monkeypatch):
+        """Isolated NaN in one variable is not the padding signature."""
+        idata = _synthetic_idata(scattered_nan=True)
+        assert self._sample_with(monkeypatch, idata) is idata
+
+    def test_clean_posterior_passes_through(self, monkeypatch):
+        idata = _synthetic_idata()
+        assert self._sample_with(monkeypatch, idata) is idata
 
 
 class TestNUTSSampler:


### PR DESCRIPTION
## Symptom

The deployed proxy-svar tutorial's stochastic-volatility section printed

```
B coefficients: min ESS = nan, max r_hat = nan, divergences: 0
arviz - WARNING - Array contains NaN-value.
```

and the month-by-month shock-scale figure was missing entirely. The strict weekly full render also began failing (#284, `CellTimeoutError`).

## Root cause (confirmed hypothesis)

1. **#278 quadrupled the SV cell's sampling work** (tune 1000→2000, draws 500→1000, chains 2→4, target_accept 0.9→0.95). PyMC does not forward `cores` to nutpie — nutpie always runs chains in parallel Rust threads — so the cell's wall time tracks *one chain's* `tune + draws` = 3000 iterations: ~22 min on an M3, past the 1800 s `nb_execution_timeout` on ubuntu runners.
2. **nbclient hit the per-cell deadline** during the SV fit (v0.0.12 deploy run `30953804733`: execution 21:48:25 → CellTimeoutError 22:27:39; the strict canary run `30953842238` failed identically) and began kernel teardown, which interrupts the kernel.
3. **nutpie converts the interrupt into a silently poisoned posterior**: `nutpie/sample.py` catches `KeyboardInterrupt` → `sampler.abort()` → partial traces; `_add_arrow_data` pre-fills float trace buffers with NaN and zero-fills the boolean `diverging` stat. Result: NaN-padded draws, "0 divergences", no error.
4. The cell finished printing the NaN diagnostics during the teardown race; the **resilient deploy** (`IMPULSO_DOCS_RESILIENT=1`, `nb_execution_raise_on_error=False`) rendered the in-place partially executed notebook and published it (pages artifact `8911225859` contains exactly the poisoned page; cells after the SV fit never ran, hence the missing figure).

Falsified along the way: NaN is not seed/model-dependent — the exact tutorial config with the same seed and dependency stack (pymc 5.28 / arviz 0.23.4 / nutpie 0.16.7, py3.11) completes on faster hardware with finite diagnostics (min ESS 31, r̂ 1.11, 0 divergences). In arviz 0.23.4, only NaN-valued draws produce `ess_bulk = nan` **and** `r_hat = nan` simultaneously; stuck chains and constant parameters give different signatures.

## Fix

- **`NUTSSampler.sample` guard** (`_raise_on_incomplete_draws`): rejects the two shapes an interrupted/dead run comes back in — a truncated `draw` dimension (all chains stopped early; zero-length when interrupted during tuning) and NaN-padded (chain, draw) cells where *every* float posterior variable is NaN (the padding signature — legitimate NaN in a single variable never trips it). Raises `RuntimeError` with per-chain delivered/requested counts and remediation guidance. Works on both ArviZ 0 `InferenceData` and ArviZ 1 `DataTree` via `get_group_dataset`.
- **Tutorial**: revert the SV cell's full-render sampler to `draws=500, tune=1000, chains=2, target_accept=0.9` (the pre-#278 configuration that CI full renders completed for weeks), with a comment tying the budget to nutpie's chain parallelism.
- **AGENTS.md**: document the nutpie interrupt→NaN-padding gotcha under PyMC / Sampling Gotchas.

## Verification

- `tests/test_samplers.py::TestIncompleteDrawGuard` (6 new tests): NaN-padded chain, all-padded chain, truncated posterior, zero-draw posterior each raise with the right counts; scattered legitimate NaN and clean posteriors pass through. Green on py3.11 (pymc 5.28/arviz 0.23.4) **and** py3.13 (pymc 6.2/arviz 1.2 DataTree).
- End-to-end: SIGINT delivered to a live nutpie fit mid-run now raises `RuntimeError: Sampling returned an incomplete posterior: every chain delivered at most 15855 of 50000 draws…` instead of returning NaN.
- Reverted tutorial config on the real Känzig data: completes in 474 s on an M3 (comfortably inside the 1800 s CI cell budget at 2–3× runner slowdown) with finite diagnostics — min ESS 178, max r̂ 1.020, 1 divergence — matching the tutorial's "less clean than the baseline" narrative. Guard stays silent.
- `ruff check`, `ruff format --check`, `ty check`, and the fast suite (1087 passed, 1 skipped) all green.

Closes #284.