### PR TITLE
refactor(identification): declare last_diagnostics as the scheme seam's diagnostics capability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,8 +13,12 @@ The reduced-form VAR fits dynamics without economic interpretation; the structur
 _Avoid_: "raw" / "interpretable" — they obscure the technical meaning.
 
 **Identification scheme**:
-A rule for recovering structural shocks from reduced-form covariance, implemented as adapters of the `IdentificationScheme` Protocol (`Cholesky`, `SignRestriction`, `LongRunRestriction`, `ProxySVAR`). The scheme is a pure function: it consumes a Cholesky factor `L` and produces a structural shock matrix `B = identify(L)`. It does not own time iteration.
+A rule for recovering structural shocks from reduced-form covariance, implemented as adapters of the `IdentificationScheme` Protocol (`Cholesky`, `SignRestriction`, `ZeroSignRestriction`, `LongRunRestriction`, `ProxySVAR`). The scheme is pure in its output — it consumes a Cholesky factor `L` and produces a structural shock matrix `B = identify(L)` — with one declared side effect: per-call **identification diagnostics** exposed via `last_diagnostics`. It does not own time iteration.
 _Avoid_: "identification strategy" (used colloquially; the Protocol is named "scheme").
+
+**Identification diagnostics (`last_diagnostics`)**:
+Per-`identify()`-call diagnostic scalars — acceptance rates, first-stage instrument strength, long-run screen condition numbers, cache-hit flags (0.0/1.0) — a flat `dict[str, float]` under scheme-prefixed keys, surfaced onto `shock_matrix().attrs`. A single-call scratchpad, not state: each `identify()` overwrites it and the pipeline reads it back immediately. An optional capability of the identification-scheme seam: schemes with nothing to report (`Cholesky`) simply lack it.
+_Avoid_: treating it as cumulative or reentrant state; the private spellings `_last_diagnostics` / `_last_acceptance_rate` (retired).
 
 **Long-run multiplier (C(1))**:
 The sum of the moving-average coefficients of a stable reduced-form VAR, `C(1) = Σ_h Φ_h = (I − Σ_j A_j)^{-1}` — the total effect of a one-off reduced-form innovation on the *level* of each variable. Exists only when the companion spectral radius is below one; `I − Σ_j A_j` near-singular means it is numerically undefined, which is a distinct failure from divergence.
@@ -22,8 +26,6 @@ The sum of the moving-average coefficients of a stable reduced-form VAR, `C(1) =
 **Cumulative MA impact matrix (Θ(1))**:
 The structural counterpart, `Θ(1) = C(1) P`: the total effect of each structural shock on each variable's level. Where `Cholesky` and `SignRestriction` constrain the impact matrix `Θ(0) = P`, `LongRunRestriction` constrains `Θ(1)` to be lower-triangular in a stated variable ordering, with positive diagonal (shock `j` raises variable `j`'s long-run level).
 _Avoid_: "Blanchard-Quah identification" as an API name — the scheme is named for what it restricts, not for its first users (the prose citation is fine). "Permanent shock" for anything but the first column: only the shock restricted nowhere is unambiguously permanent.
-A rule for recovering structural shocks from reduced-form covariance, implemented as adapters of the `IdentificationScheme` Protocol (`Cholesky`, `SignRestriction`, `ZeroSignRestriction`, `ProxySVAR`). The scheme is a pure function: it consumes a Cholesky factor `L` and produces a structural shock matrix `B = identify(L)`. It does not own time iteration.
-_Avoid_: "identification strategy" (used colloquially; the Protocol is named "scheme").
 
 **Zero-and-sign restrictions (ARW construction)**:
 Identification combining exact zeros on the impact matrix with sign restrictions on impulse responses, via the recursive orthogonalisation of Arias, Rubio-Ramírez & Waggoner (2018). With `P = L Q`, a zero is a *linear* condition on one column of `Q` (`Z_j L q_j = 0`), so columns are built one at a time — each drawn uniformly from the unit sphere of the null space of the stacked zero conditions and the already-drawn columns. The zeros hold by construction; only the signs are accept/reject. Admissibility is the Rubio-Ramírez, Waggoner & Zha (2010) counting condition `z_j <= n - j` on shocks sorted by zero count, checked before sampling. Equality throughout is exact identification and reproduces the Cholesky factor; anything looser is set identification. Draws are *unweighted* — no volume-element correction for the ARW uniform-conditional prior — which is documented rather than silent. Failed draws are `NaN`, never a fallback to `L`, because a fallback would violate the zeros the scheme exists to impose.
@@ -193,6 +195,8 @@ _Avoid_: "extra lags" without saying they are untested; "corrected for non-stati
 ## Conventions
 
 **Discriminator field on adapters**: every concrete adapter class (`Constant`, `RandomWalk`, `AR1`, …) declares its registry key with `name: Literal["x"] = "x"`, *not* `name: ClassVar[str] = "x"`. The Literal form is the modern Pydantic v2 idiom: it makes `name` a real instance attribute, fires `ValidationError` on construction-time mismatch (`Constant(name="other")`) and on post-construction mutation (under `frozen=True`), and participates in `model_dump`/`model_validate` round-trips. Class-level access (`Constant.name`) does *not* work with this pattern — registries that need the key value should hardcode the literal string.
+
+**Scheme-prefixed diagnostic keys**: every key a scheme writes into `last_diagnostics` names its scheme family in a prefix (`sign_restriction_`, `zero_sign_`, `long_run_`, `proxy_`), so entries surfaced onto shared `attrs` can never collide with — or mislabel themselves as — another scheme's diagnostics. `sign_restriction_acceptance_rate` keeps its exact historical spelling; it is public behaviour.
 
 ## Flagged ambiguities
 

--- a/docs/adr/0013-identification-diagnostics-are-a-declared-optional-capability.md
+++ b/docs/adr/0013-identification-diagnostics-are-a-declared-optional-capability.md
@@ -1,0 +1,18 @@
+# Identification diagnostics are a declared optional capability, not a Protocol member
+
+Every identification scheme that has something to report about its most recent `identify()` call — acceptance rates, first-stage instrument strength, long-run screen condition numbers, memoisation cache hits — exposes it through one public surface: `last_diagnostics`, a flat `dict[str, float]` under scheme-prefixed keys, backed by a single-call scratchpad that each `identify()` overwrites. The pipeline (`IdentifiedVAR.shock_matrix`) reads it with a single `getattr(scheme, "last_diagnostics", None)` and surfaces the entries onto the shock-matrix `attrs`. The capability is documented on the `IdentificationScheme` Protocol docstring but deliberately **not** declared as a structural Protocol member.
+
+This replaces a shadow protocol: two undeclared private spellings (`SignRestriction._last_acceptance_rate`, a bare float; `_last_diagnostics` dicts on `LongRunRestriction`/`ProxySVAR`/`ZeroSignRestriction`) that `IdentifiedVAR` reached for through separate `getattr` probes — one concept, two attribute names, two value shapes, none of it on the declared seam.
+
+## Considered options
+
+- **A structural Protocol member** (`last_diagnostics` declared in the `IdentificationScheme` body) — rejected. The Protocol is `@runtime_checkable`, and `isinstance` checks member *presence*: declaring it would break any minimal third-party scheme implementing only `identify()`/`shock_coords()` the moment `enable_runtime_checks()` is on, and would force `Cholesky` to carry an empty dict purely for uniformity. The strictness buys nothing Impulso's own five adapters need.
+- **A pure return** (`identify()` returns `(P, diagnostics)`) — rejected for now, not on principle. It would restore strict purity to the scheme contract, but it churns the seam signature at every callsite — `shock_matrix`, `_identify_per_t`, the forecast-side scenario engine, and dozens of direct `identify()` calls across four test files whose interface-level style is the suite's strength. Revisit if a consumer ever needs diagnostics the immediately-read scratchpad cannot express (e.g. concurrent identify calls on one scheme instance).
+
+## Consequences
+
+- CONTEXT.md's identification-scheme entry now reads "pure in its output" with `last_diagnostics` as the one declared side effect, and records the **scheme-prefixed diagnostic keys** convention (`sign_restriction_`, `zero_sign_`, `long_run_`, `proxy_`) so entries surfaced onto shared `attrs` can never mislabel another scheme's diagnostics.
+- Public `shock_matrix().attrs` keys are bit-stable, including the historical spelling `sign_restriction_acceptance_rate`. The only additions are the cache-hit flags `long_run_screen_cache_hit` and `proxy_impact_cache_hit` (0.0/1.0 floats — NetCDF-attr-safe).
+- Memoisation became observable through the interface: the cache tests that previously monkeypatched `ProxySVAR._aligned_residuals` and read `_impact_cache`/`_lr_cache` directly now assert the cache-hit flag.
+- The scratchpad is single-call and not reentrant. Reading it between calls, or after another `identify()`, is undefined behaviour — documented on the Protocol and in CONTEXT.md.
+- `_samples_rotations` (the rotation-sampling capability flag) is deliberately untouched: a separate concern with one consumer, documented alongside the diagnostics capability on the Protocol docstring.

--- a/src/impulso/identification.py
+++ b/src/impulso/identification.py
@@ -269,12 +269,21 @@ class SignRestriction(ImpulsoModel):
     # this capability flag and refuses time-varying volatility.
     _samples_rotations: ClassVar[bool] = True
 
-    # Single-call scratchpad: identify() writes the rate; the pipeline
-    # (IdentifiedVAR.shock_matrix) reads it immediately afterwards and
-    # attaches it to the shock-matrix DataArray's attrs. Not reentrant —
-    # overwritten on each identify() call. Do not rely on this between
-    # calls; the surviving public surface is the shock-matrix attr.
-    _last_acceptance_rate: float = PrivateAttr(default=0.0)
+    # Single-call scratchpad backing `last_diagnostics`: identify() writes
+    # the acceptance rate; the pipeline (IdentifiedVAR.shock_matrix) reads
+    # it back immediately afterwards and attaches it to the shock-matrix
+    # DataArray's attrs. Not reentrant — overwritten on each identify() call.
+    _last_diagnostics: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    @property
+    def last_diagnostics(self) -> dict[str, float]:
+        """Diagnostics from the most recent `identify()` call.
+
+        Scheme-prefixed scalars (see CONTEXT.md "Identification
+        diagnostics"), overwritten per call and surfaced onto
+        `IdentifiedVAR.shock_matrix().attrs` by the pipeline. Returns a copy.
+        """
+        return dict(self._last_diagnostics)
 
     def identify(
         self,
@@ -300,8 +309,8 @@ class SignRestriction(ImpulsoModel):
             Structural shock matrix, shape (chains, draws, n_vars, n_vars).
             Per-draw fallback to the supplied `L` for draws where no
             rotation satisfies the restrictions. The acceptance rate is
-            available via the `sign_restriction_acceptance_rate` attr on
-            `IdentifiedVAR.shock_matrix()` (attached by the pipeline).
+            available as `last_diagnostics["sign_restriction_acceptance_rate"]`
+            and on the matching `IdentifiedVAR.shock_matrix()` attr.
         """
         del data, n_lags  # unused
         from scipy.stats import special_ortho_group
@@ -357,9 +366,9 @@ class SignRestriction(ImpulsoModel):
                 stacklevel=2,
             )
 
-        # Stash the acceptance rate as a side channel — the pipeline reads
-        # it back to attach to the InferenceData.attrs.
-        self._last_acceptance_rate = accepted_count / total_count
+        # Stash the acceptance rate in the diagnostics scratchpad — the
+        # pipeline reads `last_diagnostics` back to attach to the attrs.
+        self._last_diagnostics = {"sign_restriction_acceptance_rate": accepted_count / total_count}
         return P
 
     @staticmethod
@@ -506,10 +515,20 @@ class LongRunRestriction(ImpulsoModel):
     on_undefined: Literal["nan", "raise"] = "nan"
     max_condition: float = Field(default=1e8, gt=0.0)
 
-    # Single-call scratchpad, mirroring ProxySVAR._last_diagnostics:
-    # _screen() writes the long-run diagnostics; the pipeline reads them
-    # back and attaches them to the shock-matrix attrs.
+    # Single-call scratchpad backing `last_diagnostics`: _screen() writes
+    # the long-run diagnostics; the pipeline reads them back and attaches
+    # them to the shock-matrix attrs.
     _last_diagnostics: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    @property
+    def last_diagnostics(self) -> dict[str, float]:
+        """Diagnostics from the most recent `identify()` call.
+
+        Scheme-prefixed scalars (see CONTEXT.md "Identification
+        diagnostics"), overwritten per call and surfaced onto
+        `IdentifiedVAR.shock_matrix().attrs` by the pipeline. Returns a copy.
+        """
+        return dict(self._last_diagnostics)
 
     # Memoised screen. `M`, its conditioning and the spectral radii depend
     # only on (posterior, n_lags) — not on L — so under time-varying
@@ -716,6 +735,7 @@ class LongRunRestriction(ImpulsoModel):
         """
         cached = self._lr_cache.get(posterior, (n_lags,))
         if cached is not _CACHE_MISS:
+            self._last_diagnostics = {**self._last_diagnostics, "long_run_screen_cache_hit": 1.0}
             return cached
 
         A = lag_matrices(posterior["B"].values, n_lags)
@@ -737,6 +757,7 @@ class LongRunRestriction(ImpulsoModel):
             "long_run_explosive_fraction": float(explosive.mean()),
             "long_run_spectral_radius_median": float(np.median(rho)),
             "long_run_spectral_radius_max": float(rho.max()),
+            "long_run_screen_cache_hit": 0.0,
         }
         self._report(bad, explosive)
         self._lr_cache.set(posterior, (n_lags,), (M, bad))
@@ -861,10 +882,20 @@ class ProxySVAR(ImpulsoBaseModel):
     shock_name: str = "instrumented"
     scale: float | None = None
 
-    # Single-call scratchpad, mirroring SignRestriction._last_acceptance_rate:
-    # identify() writes first-stage diagnostics; the pipeline reads them
-    # immediately afterwards and attaches to the shock matrix attrs.
+    # Single-call scratchpad backing `last_diagnostics`: identify() writes
+    # first-stage diagnostics; the pipeline reads them immediately
+    # afterwards and attaches to the shock matrix attrs.
     _last_diagnostics: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    @property
+    def last_diagnostics(self) -> dict[str, float]:
+        """Diagnostics from the most recent `identify()` call.
+
+        Scheme-prefixed scalars (see CONTEXT.md "Identification
+        diagnostics"), overwritten per call and surfaced onto
+        `IdentifiedVAR.shock_matrix().attrs` by the pipeline. Returns a copy.
+        """
+        return dict(self._last_diagnostics)
 
     # Memoised impact direction. The instrument-residual covariance (and
     # the first-stage diagnostics) depend only on (posterior, data, n_lags)
@@ -934,6 +965,7 @@ class ProxySVAR(ImpulsoBaseModel):
                 "proxy_first_stage_f_median": f_median,
                 "proxy_first_stage_f_q05": float(np.quantile(f_draws, 0.05)),
                 "proxy_first_stage_f_q95": float(np.quantile(f_draws, 0.95)),
+                "proxy_impact_cache_hit": 0.0,
             }
             self._impact_cache.set((posterior, data), (n_lags,), d)
             if f_median < 10.0:
@@ -945,6 +977,8 @@ class ProxySVAR(ImpulsoBaseModel):
                     UserWarning,
                     stacklevel=2,
                 )
+        else:
+            self._last_diagnostics = {**self._last_diagnostics, "proxy_impact_cache_hit": 1.0}
 
         # Complete the matrix: q1 = L^{-1} d normalised, extended to an
         # orthonormal basis via a Householder reflection; P = L @ Q gives
@@ -1221,14 +1255,22 @@ class ZeroSignRestriction(ImpulsoModel):
     # time-varying volatility for such schemes.
     _samples_rotations: ClassVar[bool] = True
 
-    # Single-call scratchpad, mirroring ProxySVAR._last_diagnostics: identify()
-    # writes, IdentifiedVAR.shock_matrix reads it back immediately and attaches
-    # the entries to the shock-matrix attrs. Not reentrant.
-    #
-    # Deliberately *not* `_last_acceptance_rate`: the pipeline surfaces that
-    # private attribute under the name `sign_restriction_acceptance_rate`,
-    # which would mislabel this scheme's diagnostics.
+    # Single-call scratchpad backing `last_diagnostics`: identify() writes,
+    # IdentifiedVAR.shock_matrix reads it back immediately and attaches the
+    # entries to the shock-matrix attrs. Not reentrant. Keys carry the
+    # zero_sign_ prefix so they can never mislabel another scheme's
+    # diagnostics (see CONTEXT.md "Scheme-prefixed diagnostic keys").
     _last_diagnostics: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    @property
+    def last_diagnostics(self) -> dict[str, float]:
+        """Diagnostics from the most recent `identify()` call.
+
+        Scheme-prefixed scalars (see CONTEXT.md "Identification
+        diagnostics"), overwritten per call and surfaced onto
+        `IdentifiedVAR.shock_matrix().attrs` by the pipeline. Returns a copy.
+        """
+        return dict(self._last_diagnostics)
 
     @model_validator(mode="after")
     def _validate_restrictions(self) -> "ZeroSignRestriction":

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -153,14 +153,10 @@ class IdentifiedVAR(ImpulsoBaseModel):
                 name="structural_shock_matrix",
             )
 
-        # Attach sign-restriction acceptance rate if available.
-        rate = getattr(self.scheme, "_last_acceptance_rate", None)
-        if isinstance(rate, float):
-            result.attrs["sign_restriction_acceptance_rate"] = rate
-
-        # Attach any scheme-specific diagnostics (e.g. ProxySVAR first-stage
-        # strength) the same way — identify() stashes them, we surface them.
-        diagnostics = getattr(self.scheme, "_last_diagnostics", None)
+        # Surface the scheme's identification diagnostics (acceptance rates,
+        # first-stage strength, cache-hit flags) — the seam's optional
+        # `last_diagnostics` capability; see CONTEXT.md.
+        diagnostics = getattr(self.scheme, "last_diagnostics", None)
         if diagnostics:
             result.attrs.update(diagnostics)
 

--- a/src/impulso/protocols.py
+++ b/src/impulso/protocols.py
@@ -36,13 +36,24 @@ class Sampler(Protocol):
 class IdentificationScheme(Protocol):
     """Contract for structural identification schemes.
 
-    Optional capability flag: schemes that *sample* rotations inside
-    `identify` (a fresh draw per call, as `SignRestriction` does) must set
-    a truthy class attribute `_samples_rotations`. Forecast-side scenario
-    machinery reads it via `getattr(scheme, "_samples_rotations", False)`
-    and refuses time-varying volatility for such schemes — no single
-    structural coordinate system would span the forecast steps otherwise.
-    Deterministic schemes (`Cholesky`, `ProxySVAR`) omit the flag.
+    Optional capabilities — read by consumers with a `getattr` default, so
+    minimal third-party schemes implementing only `identify` and
+    `shock_coords` keep satisfying this Protocol under runtime checks
+    (ADR-0013):
+
+    - `last_diagnostics: dict[str, float]` — per-`identify()`-call
+      diagnostic scalars under scheme-prefixed keys (acceptance rates,
+      first-stage strength, cache-hit flags as 0.0/1.0). A single-call
+      scratchpad, overwritten on each call; `IdentifiedVAR.shock_matrix`
+      reads it immediately after `identify` and surfaces the entries onto
+      the result's attrs. Schemes with nothing to report omit it.
+    - `_samples_rotations` — schemes that *sample* rotations inside
+      `identify` (a fresh draw per call, as `SignRestriction` does) must
+      set this truthy class attribute. Forecast-side scenario machinery
+      reads it via `getattr(scheme, "_samples_rotations", False)` and
+      refuses time-varying volatility for such schemes — no single
+      structural coordinate system would span the forecast steps
+      otherwise. Deterministic schemes (`Cholesky`, `ProxySVAR`) omit it.
     """
 
     def identify(

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -137,7 +137,7 @@ class TestSignRestriction:
         assert scheme.restriction_horizon == 0
 
     def test_sign_restriction_identify_stores_acceptance_rate(self, synthetic_idata_2v):
-        """identify() should record acceptance_rate on the scheme instance."""
+        """identify() should record the acceptance rate in last_diagnostics."""
         scheme = SignRestriction(
             restrictions={"y1": {"y1": "+"}},
             n_rotations=100,
@@ -147,7 +147,7 @@ class TestSignRestriction:
         sigma = synthetic_idata_2v.posterior["Sigma"].values
         L = np.linalg.cholesky(sigma)
         scheme.identify(L, ["y1", "y2"])
-        rate = scheme._last_acceptance_rate
+        rate = scheme.last_diagnostics["sign_restriction_acceptance_rate"]
         assert 0.0 <= rate <= 1.0
 
     def test_identify_multi_horizon_through_identify(self, synthetic_idata_2v):
@@ -163,7 +163,7 @@ class TestSignRestriction:
         P = scheme.identify(L, ["y1", "y2"], posterior=synthetic_idata_2v.posterior)
         assert P.shape == L.shape
         assert not np.any(np.isnan(P))
-        assert 0.0 <= scheme._last_acceptance_rate <= 1.0
+        assert 0.0 <= scheme.last_diagnostics["sign_restriction_acceptance_rate"] <= 1.0
 
     def test_shock_coordinates_with_partial_identification(self):
         """When fewer shocks are named than variables, remaining get 'unidentified_N' labels."""
@@ -650,8 +650,8 @@ class TestLongRunRestriction:
         assert not np.isnan(P[0, 5:]).any()
         assert not np.isnan(P[1]).any()
         np.testing.assert_allclose(P[0, 5:], np.broadcast_to(fx["P_true"], P[0, 5:].shape), atol=1e-12)
-        assert scheme._last_diagnostics["long_run_singular_draws"] == 5.0
-        assert scheme._last_diagnostics["long_run_singular_fraction"] == pytest.approx(0.05)
+        assert scheme.last_diagnostics["long_run_singular_draws"] == 5.0
+        assert scheme.last_diagnostics["long_run_singular_fraction"] == pytest.approx(0.05)
 
     def test_singular_draws_raise_when_asked(self, permanent_transitory_2v):
         fx = permanent_transitory_2v
@@ -672,12 +672,12 @@ class TestLongRunRestriction:
         with pytest.warns(UserWarning, match="long-run multiplier"):
             P_strict = strict.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
         assert np.isnan(P_strict[0, :3]).all()
-        assert strict._last_diagnostics["long_run_singular_draws"] == 3.0
+        assert strict.last_diagnostics["long_run_singular_draws"] == 3.0
 
         lenient = self._scheme(max_condition=1e20)
         P_lenient = lenient.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
         assert not np.isnan(P_lenient).any()
-        assert lenient._last_diagnostics["long_run_singular_draws"] == 0.0
+        assert lenient.last_diagnostics["long_run_singular_draws"] == 0.0
 
     # --- 15. explosive is not singular -------------------------------------
 
@@ -690,9 +690,9 @@ class TestLongRunRestriction:
             P = scheme.identify(fx["L"], ["y1", "y2"], posterior=posterior, n_lags=1)
 
         assert np.isfinite(P).all()
-        assert scheme._last_diagnostics["long_run_explosive_draws"] == 4.0
-        assert scheme._last_diagnostics["long_run_singular_draws"] == 0.0
-        assert scheme._last_diagnostics["long_run_spectral_radius_max"] == pytest.approx(1.5)
+        assert scheme.last_diagnostics["long_run_explosive_draws"] == 4.0
+        assert scheme.last_diagnostics["long_run_singular_draws"] == 0.0
+        assert scheme.last_diagnostics["long_run_spectral_radius_max"] == pytest.approx(1.5)
 
     # --- 16. the diagnostics query -----------------------------------------
 
@@ -734,7 +734,9 @@ class TestLongRunRestriction:
         gc.collect()
         assert ref() is None
 
-        assert scheme._lr_cache.get(self._posterior_with(fx, lambda c, d: None), (1,)) is _CACHE_MISS
+        fresh = self._posterior_with(fx, lambda c, d: None)
+        scheme.identify(fx["L"], ["y1", "y2"], posterior=fresh, n_lags=1)
+        assert scheme.last_diagnostics["long_run_screen_cache_hit"] == 0.0
 
     # --- 17-19. from_zero_restrictions -------------------------------------
 

--- a/tests/test_proxy_svar.py
+++ b/tests/test_proxy_svar.py
@@ -11,7 +11,7 @@ import xarray as xr
 
 from impulso._arviz_compat import make_idata
 from impulso.data import VARData
-from impulso.identification import _CACHE_MISS, ProxySVAR
+from impulso.identification import ProxySVAR
 
 
 def _make_svar_world(relevance_noise: float = 0.1, T: int = 400, seed: int = 3):
@@ -102,7 +102,7 @@ class TestProxySVARDiagnostics:
         data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
         scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
         scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        diag = scheme._last_diagnostics
+        diag = scheme.last_diagnostics
         assert diag["proxy_first_stage_f_median"] > 10.0
         assert diag["proxy_first_stage_f_q05"] <= diag["proxy_first_stage_f_median"]
 
@@ -114,7 +114,7 @@ class TestProxySVARDiagnostics:
         assert f_draws.shape == (2, 40)
         assert np.isclose(
             float(np.median(f_draws)),
-            scheme._last_diagnostics["proxy_first_stage_f_median"],
+            scheme.last_diagnostics["proxy_first_stage_f_median"],
         )
 
     def test_pure_noise_instrument_warns_weak(self):
@@ -124,7 +124,7 @@ class TestProxySVARDiagnostics:
         scheme = ProxySVAR(instrument=noise_instrument, policy_variable="y1")
         with pytest.warns(UserWarning, match="Weak instrument"):
             scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        assert scheme._last_diagnostics["proxy_first_stage_f_median"] < 10.0
+        assert scheme.last_diagnostics["proxy_first_stage_f_median"] < 10.0
 
 
 class TestProxySVARAlignment:
@@ -353,22 +353,8 @@ class TestProxySVARPipelineSlow:
         assert (da.isel(horizon=0).sel(response="y1") > 0).all()
 
 
-@pytest.fixture
-def residual_calls(monkeypatch):
-    """Count `_aligned_residuals` invocations — the expensive cache-missed step."""
-    calls: list[int] = []
-    original = ProxySVAR._aligned_residuals
-
-    def counting(self, posterior, data, n_lags):
-        calls.append(1)
-        return original(self, posterior, data, n_lags)
-
-    monkeypatch.setattr(ProxySVAR, "_aligned_residuals", counting)
-    return calls
-
-
 class TestProxySVARImpactCache:
-    def test_repeated_identify_same_context_hits_cache(self, residual_calls):
+    def test_repeated_identify_same_context_hits_cache(self):
         """Per-t identification (SV path) calls identify once per period
         with the same posterior/data — the impact direction must be
         computed once and reused, and results must be identical."""
@@ -376,26 +362,22 @@ class TestProxySVARImpactCache:
         scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
 
         P1 = scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        cached_d = scheme._impact_cache.get((idata.posterior, data), (1,))
-        assert cached_d is not _CACHE_MISS
+        assert scheme.last_diagnostics["proxy_impact_cache_hit"] == 0.0
 
         P2 = scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        assert scheme._impact_cache.get((idata.posterior, data), (1,)) is cached_d
-        assert residual_calls == [1]  # no recompute on the second call
+        assert scheme.last_diagnostics["proxy_impact_cache_hit"] == 1.0  # no recompute
         np.testing.assert_array_equal(P1, P2)
 
-    def test_cache_invalidated_by_new_context(self, residual_calls):
+    def test_cache_invalidated_by_new_context(self):
         data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
         data2, idata2, _P2, _instrument2, L2 = _make_svar_world(relevance_noise=0.05, seed=9)
         scheme = ProxySVAR(instrument=instrument, policy_variable="y1")
 
         scheme.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        d_first = scheme._impact_cache.get((idata.posterior, data), (1,))
         scheme.identify(L2, ["y1", "y2"], posterior=idata2.posterior, data=data2, n_lags=1)
-        assert scheme._impact_cache.get((idata2.posterior, data2), (1,)) is not d_first
-        assert len(residual_calls) == 2
+        assert scheme.last_diagnostics["proxy_impact_cache_hit"] == 0.0  # recomputed
 
-    def test_live_posterior_with_different_identity_misses(self, residual_calls):
+    def test_live_posterior_with_different_identity_misses(self):
         """A distinct-but-live posterior object must never hit the entry
         stored for another one, even with identical contents."""
         data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
@@ -406,11 +388,10 @@ class TestProxySVARImpactCache:
         assert first is not second
 
         scheme.identify(L, ["y1", "y2"], posterior=first, data=data, n_lags=1)
-        assert scheme._impact_cache.get((second, data), (1,)) is _CACHE_MISS
         scheme.identify(L, ["y1", "y2"], posterior=second, data=data, n_lags=1)
-        assert len(residual_calls) == 2
+        assert scheme.last_diagnostics["proxy_impact_cache_hit"] == 0.0  # identity, not content
 
-    def test_dead_posterior_forces_recompute(self, residual_calls):
+    def test_dead_posterior_forces_recompute(self):
         """Once the cached posterior is collected the weak reference dies,
         so the next lookup recomputes instead of trusting a recycled id()."""
         data, idata, _P_true, instrument, L = _make_svar_world(relevance_noise=0.05)
@@ -418,7 +399,7 @@ class TestProxySVARImpactCache:
 
         posterior = idata.posterior.copy()
         scheme.identify(L, ["y1", "y2"], posterior=posterior, data=data, n_lags=1)
-        assert len(residual_calls) == 1
+        assert scheme.last_diagnostics["proxy_impact_cache_hit"] == 0.0
 
         ref = weakref.ref(posterior)
         del posterior
@@ -426,9 +407,8 @@ class TestProxySVARImpactCache:
         assert ref() is None  # the cached referent really is gone
 
         fresh = idata.posterior.copy()
-        assert scheme._impact_cache.get((fresh, data), (1,)) is _CACHE_MISS
         scheme.identify(L, ["y1", "y2"], posterior=fresh, data=data, n_lags=1)
-        assert len(residual_calls) == 2
+        assert scheme.last_diagnostics["proxy_impact_cache_hit"] == 0.0
 
     def test_cache_hit_suppresses_the_weak_instrument_warning(self):
         """Warn-once semantics: the weak-instrument warning is raised on the
@@ -449,4 +429,5 @@ class TestProxySVARImpactCache:
         b = ProxySVAR(instrument=instrument, policy_variable="y1")
 
         a.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
-        assert b._impact_cache.get((idata.posterior, data), (1,)) is _CACHE_MISS
+        b.identify(L, ["y1", "y2"], posterior=idata.posterior, data=data, n_lags=1)
+        assert b.last_diagnostics["proxy_impact_cache_hit"] == 0.0  # b's cache was empty

--- a/tests/test_zero_sign_restriction.py
+++ b/tests/test_zero_sign_restriction.py
@@ -207,7 +207,7 @@ class TestCholeskyDegeneracyAnchor:
         )
         P = scheme.identify(L, ["y1", "y2", "y3"])
 
-        assert scheme._last_diagnostics["zero_sign_acceptance_rate"] == 1.0
+        assert scheme.last_diagnostics["zero_sign_acceptance_rate"] == 1.0
         expected = np.abs(np.linalg.cholesky(sigma))
         max_dev = float(np.max(np.abs(np.abs(P) - expected)))
         assert max_dev < 1e-8, f"max deviation from |cholesky(Sigma)| = {max_dev:g}"
@@ -228,7 +228,7 @@ class TestCholeskyDegeneracyAnchor:
         )
         P = scheme.identify(L, ["y1", "y2", "y3"])
 
-        assert scheme._last_diagnostics["zero_sign_acceptance_rate"] == 1.0
+        assert scheme.last_diagnostics["zero_sign_acceptance_rate"] == 1.0
         np.testing.assert_allclose(P, np.linalg.cholesky(sigma), atol=1e-8)
 
 
@@ -263,7 +263,7 @@ class TestClosedFormAndInvariants:
         )
         P = scheme.identify(L, ["y1", "y2", "y3"])
         assert np.nanmax(np.abs(P[..., 1, 0])) < 1e-10
-        assert scheme._last_diagnostics["zero_sign_max_zero_violation"] < 1e-10
+        assert scheme.last_diagnostics["zero_sign_max_zero_violation"] < 1e-10
 
     def test_reproduces_sigma(self, synthetic_idata_3v):
         """P P' = Sigma on every accepted draw — Q is exactly orthogonal."""
@@ -389,8 +389,8 @@ class TestSignOnlyEquivalence:
         P_zs = zs.identify(L, ["y1", "y2"])
         P_sr = sr.identify(L, ["y1", "y2"])
 
-        rate_zs = zs._last_diagnostics["zero_sign_acceptance_rate"]
-        rate_sr = sr._last_acceptance_rate
+        rate_zs = zs.last_diagnostics["zero_sign_acceptance_rate"]
+        rate_sr = sr.last_diagnostics["sign_restriction_acceptance_rate"]
         assert abs(rate_zs - rate_sr) < 0.15
 
         for row in (0, 1):
@@ -424,8 +424,8 @@ class TestFailurePolicy:
         with pytest.warns(UserWarning, match="NaN"):
             P = scheme.identify(L, ["y1", "y2", "y3"])
         assert np.isnan(P).any()
-        assert scheme._last_diagnostics["zero_sign_failed_draws"] > 0
-        assert 0.0 <= scheme._last_diagnostics["zero_sign_acceptance_rate"] < 1.0
+        assert scheme.last_diagnostics["zero_sign_failed_draws"] > 0
+        assert 0.0 <= scheme.last_diagnostics["zero_sign_acceptance_rate"] < 1.0
 
     def test_raise_policy(self, synthetic_idata_3v):
         L = synthetic_idata_3v.posterior["L"].values
@@ -452,21 +452,21 @@ class TestFailurePolicy:
             random_seed=2,
         )
         scheme.identify(L, ["y1", "y2", "y3"])
-        assert set(scheme._last_diagnostics) == {
+        assert set(scheme.last_diagnostics) == {
             "zero_sign_acceptance_rate",
             "zero_sign_failed_draws",
             "zero_sign_failed_fraction",
             "zero_sign_mean_attempts",
             "zero_sign_max_zero_violation",
         }
-        assert scheme._last_diagnostics["zero_sign_mean_attempts"] >= 1.0
+        assert scheme.last_diagnostics["zero_sign_mean_attempts"] >= 1.0
 
     def test_does_not_set_sign_restriction_acceptance_rate(self, synthetic_idata_3v):
-        """The scheme must not attach the misnamed SignRestriction attr."""
+        """The scheme must not emit the SignRestriction-prefixed key."""
         L = synthetic_idata_3v.posterior["L"].values
         scheme = _quiet(shock_names=["s1", "s2"], zero_restrictions={"y2": ["s1"]}, n_rotations=10)
         scheme.identify(L, ["y1", "y2", "y3"])
-        assert getattr(scheme, "_last_acceptance_rate", None) is None
+        assert "sign_restriction_acceptance_rate" not in scheme.last_diagnostics
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Implements architecture-review candidate 1: the identification-scheme seam's diagnostics side channel becomes a declared capability. Design record: `docs/adr/0013-identification-diagnostics-are-a-declared-optional-capability.md`.

## Problem

`IdentifiedVAR` reached around the declared `IdentificationScheme` Protocol via three `getattr` probes for undeclared private attributes — `_last_acceptance_rate` (bare float, `SignRestriction` only), `_last_diagnostics` (dict, three schemes), and the scheme docstrings called the convention a scratchpad "the pipeline reads back". One concept, two attribute names, two value shapes, none of it on the seam. The memoisation caches (`_lr_cache`, `_impact_cache`) had zero public observability, forcing the cache tests to monkeypatch `ProxySVAR._aligned_residuals` and read private caches directly.

## Change

- **One public surface**: `last_diagnostics` — read-only property returning a copy of a `dict[str, float]` under scheme-prefixed keys — on all four emitting schemes. `Cholesky` (nothing to report) omits it; the consumer reads `getattr(scheme, "last_diagnostics", None)` once.
- **SignRestriction folds in**: its rate travels as `{"sign_restriction_acceptance_rate": …}`; the private float attribute is deleted.
- **Caches become observable**: `long_run_screen_cache_hit` / `proxy_impact_cache_hit` (`0.0`/`1.0`) are set on both hit and miss branches; the cache tests now assert through the interface — no monkeypatching, no private reads.
- **Deliberately *not* a structural Protocol member**: the Protocol is `@runtime_checkable`, so declaring the attribute would break minimal third-party schemes under `enable_runtime_checks()`. Documented on the Protocol docstring alongside `_samples_rotations`; rationale and rejected alternatives (structural member, pure `identify()` return) in ADR-0013.
- **CONTEXT.md**: new *Identification diagnostics* term, scheme "pure in its output" wording, the scheme-prefixed-keys convention, and removal of a stray duplicated scheme definition inside the Θ(1) entry.

## Invariants

Every pre-existing `shock_matrix().attrs` key is bit-identical (including the historical `sign_restriction_acceptance_rate` spelling); the only additions are the two cache-hit floats. Confirmed by the untouched, passing `TestShockMatrixDiagnostics` and `test_diagnostics_reach_shock_matrix_attrs`.

## Verification

- `pytest -m "not slow"`: 1087 passed, 1 skipped
- `ruff check` / `ruff format --check`: clean
- `ty check`: clean on this change

First layer of the architecture-review stack; the scenario-engine unification (candidate 2) stacks on top.