### PR TITLE
refactor(posterior): one owner for the posterior schema

### DIFF
--- a/src/impulso/_posterior.py
+++ b/src/impulso/_posterior.py
@@ -1,0 +1,88 @@
+"""THE posterior schema — the coefficient-block contract shared by both estimators.
+
+`spec.py`'s PyMC graph and `conjugate.py`'s hand-built Dataset are separate
+likelihood implementations by design (ADR-0011); what they share is only the
+schema below. Each registers its reduced-form coefficient blocks under these
+names and layouts, and every consumer — residual reconstruction, forecasting,
+the scenario engines, identification schemes — reads them back through this
+module's accessors instead of re-knowing the key strings by convention.
+
+Variable layouts (all leading with the `(chain, draw)` sample dims):
+
+* ``B`` — `(chain, draw, n, n*p)`: VAR lag coefficients with **lag-major**
+  coefficient columns (the lag-1 block first, mirroring the `X_lag` hstack
+  both estimators build their design matrix from).
+* ``intercept`` — `(chain, draw, n)`: per-equation intercepts.
+* ``B_exog`` — `(chain, draw, n, n_exog)`: contemporaneous exogenous
+  coefficients; present only when the estimator consumed an exogenous block.
+
+Not owned here: the volatility seam's ``L`` (owned by `volatility.py` /
+`conjugate_volatility.py`) and the error-distribution seam's ``nu``
+(owned by `observation.py`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    import xarray as xr
+
+    from impulso._arviz_compat import InferenceDataLike
+
+COEFFICIENTS = "B"
+"""VAR lag-coefficient draws, `(chain, draw, n, n*p)`, lag-major columns."""
+
+INTERCEPT = "intercept"
+"""Per-equation intercept draws, `(chain, draw, n)`."""
+
+EXOG_COEFFICIENTS = "B_exog"
+"""Exogenous-coefficient draws, `(chain, draw, n, n_exog)`; present only when consumed."""
+
+
+def posterior_dataset(idata: InferenceDataLike) -> xr.Dataset:
+    """The `posterior` group as an `xarray.Dataset`.
+
+    On ArviZ 1 the raw group is a `DataTree` node rather than a Dataset,
+    which would violate the `xr.Dataset` contract every volatility,
+    error-distribution, and identification implementation is written
+    against. A fresh Dataset is built on each call, so callers that use the
+    posterior more than once — or hand it to a memoising helper such as
+    `_PosteriorCache` — must bind the result to a local first and pass that
+    local through.
+
+    Args:
+        idata: The container holding the fit's groups.
+
+    Returns:
+        The posterior group as an `xarray.Dataset`.
+
+    Raises:
+        KeyError: If the container has no posterior group.
+    """
+    from impulso._arviz_compat import get_group_dataset
+
+    return get_group_dataset(idata, "posterior")
+
+
+def coefficient_draws(posterior: xr.Dataset) -> np.ndarray:
+    """`B` draws, `(chain, draw, n, n*p)` with lag-major coefficient columns."""
+    return posterior[COEFFICIENTS].values
+
+
+def intercept_draws(posterior: xr.Dataset) -> np.ndarray:
+    """`intercept` draws, `(chain, draw, n)`."""
+    return posterior[INTERCEPT].values
+
+
+def exog_coefficient_draws(posterior: xr.Dataset) -> np.ndarray | None:
+    """`B_exog` draws, `(chain, draw, n, n_exog)`, or `None` when absent."""
+    if EXOG_COEFFICIENTS not in posterior:
+        return None
+    return posterior[EXOG_COEFFICIENTS].values
+
+
+def has_exog_block(posterior: xr.Dataset) -> bool:
+    """Whether the estimator consumed an exogenous block (`B_exog` present)."""
+    return EXOG_COEFFICIENTS in posterior

--- a/src/impulso/_residuals.py
+++ b/src/impulso/_residuals.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from impulso._posterior import coefficient_draws, exog_coefficient_draws, has_exog_block, intercept_draws
+
 if TYPE_CHECKING:
     import xarray as xr
 
@@ -40,8 +42,8 @@ def fitted_values(posterior: "xr.Dataset", data: "VARData", n_lags: int) -> np.n
         Conditional-mean array of shape `(chains, draws, T - n_lags, n_vars)`,
         time-aligned with `data.index[n_lags:]`.
     """
-    B_draws = posterior["B"].values  # (C, D, n, n*p)
-    intercept_draws = posterior["intercept"].values  # (C, D, n)
+    B_draws = coefficient_draws(posterior)  # (C, D, n, n*p)
+    intercept_draws_arr = intercept_draws(posterior)  # (C, D, n)
 
     y = data.endog  # (T, n)
     T = y.shape[0]
@@ -50,9 +52,9 @@ def fitted_values(posterior: "xr.Dataset", data: "VARData", n_lags: int) -> np.n
         [y[n_lags - lag : T - lag] for lag in range(1, n_lags + 1)],
         axis=1,
     )  # (T-p, n*p)
-    y_hat = intercept_draws[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
-    if data.exog is not None and "B_exog" in posterior:
-        y_hat = y_hat + np.einsum("cdij,tj->cdti", posterior["B_exog"].values, data.exog[n_lags:])
+    y_hat = intercept_draws_arr[:, :, np.newaxis, :] + np.einsum("cdij,tj->cdti", B_draws, x_lag)
+    if data.exog is not None and has_exog_block(posterior):
+        y_hat = y_hat + np.einsum("cdij,tj->cdti", exog_coefficient_draws(posterior), data.exog[n_lags:])
     return y_hat
 
 

--- a/src/impulso/_scenario.py
+++ b/src/impulso/_scenario.py
@@ -15,6 +15,14 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from impulso._posterior import (
+    EXOG_COEFFICIENTS,
+    coefficient_draws,
+    exog_coefficient_draws,
+    has_exog_block,
+    intercept_draws,
+)
+
 if TYPE_CHECKING:
     import pandas as pd
     import xarray as xr
@@ -265,15 +273,15 @@ def counterfactual_paths(identified: IdentifiedVAR, edits: list[ShockPath]) -> n
     )
     u_cf = np.einsum("cdtij,cdtj->cdti", P, eps_cf) if per_t else np.einsum("cdij,cdtj->cdti", P, eps_cf)
 
-    intercept = posterior["intercept"].values  # (C, D, n)
+    intercept = intercept_draws(posterior)  # (C, D, n)
     n_chains, n_draws, n_vars = intercept.shape
     T_eff = u_cf.shape[2]
     forcing = np.broadcast_to(intercept[:, :, np.newaxis, :], (n_chains, n_draws, T_eff, n_vars)).copy()
-    if identified.data.exog is not None and "B_exog" in posterior:
-        forcing += np.einsum("cdij,tj->cdti", posterior["B_exog"].values, identified.data.exog[n_lags:])
+    if identified.data.exog is not None and has_exog_block(posterior):
+        forcing += np.einsum("cdij,tj->cdti", exog_coefficient_draws(posterior), identified.data.exog[n_lags:])
     forcing += u_cf
 
-    A = lag_matrices(posterior["B"].values, n_lags)
+    A = lag_matrices(coefficient_draws(posterior), n_lags)
     return propagate(A, forcing, identified.data.endog[:n_lags])
 
 
@@ -290,7 +298,7 @@ def resolve_exog_future(
 
     Two facts drive the checks: whether the data carries an exogenous
     block (`data.exog`) and whether the estimator consumed one
-    (`"B_exog" in posterior`). A fit whose data has exog the estimator
+    (`has_exog_block(posterior)`). A fit whose data has exog the estimator
     never consumed cannot forecast; a fit with an exogenous block
     requires the future path; a posterior carrying `B_exog` without
     `data.exog` (hand-built posteriors) may still receive one. The shape
@@ -313,7 +321,7 @@ def resolve_exog_future(
             unexpected `exog_future`, or a shape mismatch.
     """
     has_exog = data.exog is not None
-    consumed = "B_exog" in posterior
+    consumed = has_exog_block(posterior)
     if has_exog and not consumed:
         raise ValueError(
             "This fit's data carries exogenous regressors the estimator never "
@@ -327,7 +335,7 @@ def resolve_exog_future(
     if not consumed:
         raise ValueError("exog_future provided but the posterior carries no B_exog.")
     exog_arr = np.asarray(exog_future, dtype=float)
-    n_exog = posterior["B_exog"].shape[-1]
+    n_exog = posterior[EXOG_COEFFICIENTS].shape[-1]
     if exog_arr.shape != (steps, n_exog):
         raise ValueError(f"exog_future must have shape ({steps}, {n_exog}), got {exog_arr.shape}.")
     return exog_arr
@@ -362,12 +370,12 @@ def deterministic_forecast_path(
     from impulso._linalg import lag_matrices
     from impulso._propagate import propagate
 
-    intercept = posterior["intercept"].values
+    intercept = intercept_draws(posterior)
     n_chains, n_draws, n_vars = intercept.shape
     forcing = np.broadcast_to(intercept[:, :, np.newaxis, :], (n_chains, n_draws, steps, n_vars)).copy()
     if exog_future is not None:
-        forcing += np.einsum("cdij,hj->cdhi", posterior["B_exog"].values, exog_future)
-    A = lag_matrices(posterior["B"].values, n_lags)
+        forcing += np.einsum("cdij,hj->cdhi", exog_coefficient_draws(posterior), exog_future)
+    A = lag_matrices(coefficient_draws(posterior), n_lags)
     return propagate(A, forcing, data.endog[-n_lags:])
 
 
@@ -476,7 +484,7 @@ def conditional_forecast_engine(
         number of binding restrictions `r`.
     """
     posterior = fitted._posterior()
-    B_draws = posterior["B"].values
+    B_draws = coefficient_draws(posterior)
     n_vars = B_draws.shape[2]
 
     pins = resolve_variable_pins(conditions, fitted.var_names, steps)
@@ -725,7 +733,7 @@ def structural_scenario_engine(
         the prescribed `|v_S|^2` term has no chi-squared reference).
     """
     posterior = identified._posterior()
-    B_draws = posterior["B"].values
+    B_draws = coefficient_draws(posterior)
     shock_names = identified.shock_names
 
     pins = resolve_variable_pins(conditions, identified.var_names, steps)

--- a/src/impulso/conjugate.py
+++ b/src/impulso/conjugate.py
@@ -22,6 +22,7 @@ from impulso._arviz_compat import make_idata
 from impulso._base import ImpulsoBaseModel
 from impulso._conjugate import split_intercept
 from impulso._conjugate_sampler import select_and_sample
+from impulso._posterior import COEFFICIENTS, INTERCEPT
 from impulso.conjugate_volatility import ConjugateVolatility
 from impulso.data import VARData
 from impulso.evidence import ModelEvidence, _response_digest
@@ -154,8 +155,8 @@ class ConjugateVAR(ImpulsoBaseModel):
 
         # Add a singleton chain dimension (Metropolis / direct draws = single chain).
         posterior_vars: dict[str, tuple[list[str], object]] = {
-            "B": (["chain", "draw", "var", "coeff"], b_lags[None]),
-            "intercept": (["chain", "draw", "var"], intercept[None]),
+            COEFFICIENTS: (["chain", "draw", "var", "coeff"], b_lags[None]),
+            INTERCEPT: (["chain", "draw", "var"], intercept[None]),
             "L": (["chain", "draw", "var1", "var2"], result["L"][None]),
         }
         for name, arr in result["hyperparameters"].items():

--- a/src/impulso/fitted.py
+++ b/src/impulso/fitted.py
@@ -6,10 +6,18 @@ import numpy as np
 import xarray as xr
 from pydantic import Field
 
-from impulso._arviz_compat import InferenceDataLike, get_group_dataset, make_idata
+from impulso._arviz_compat import InferenceDataLike, make_idata
 from impulso._base import ImpulsoBaseModel
 from impulso._linalg import lag_matrices, sigma_from_cholesky
 from impulso._ma import compute_ma_phi
+from impulso._posterior import (
+    COEFFICIENTS,
+    EXOG_COEFFICIENTS,
+    coefficient_draws,
+    has_exog_block,
+    intercept_draws,
+    posterior_dataset,
+)
 from impulso.data import VARData
 from impulso.evidence import ModelEvidence
 from impulso.observation import Gaussian
@@ -78,16 +86,13 @@ class FittedVAR(ImpulsoBaseModel):
     evidence: ModelEvidence | None = Field(default=None, repr=False)
 
     def _posterior(self) -> xr.Dataset:
-        """The `posterior` group as an `xarray.Dataset`.
+        """The `posterior` group as an `xarray.Dataset`; see `impulso._posterior.posterior_dataset`.
 
-        On ArviZ 1 the raw group is a `DataTree` node rather than a Dataset,
-        which would violate the `xr.Dataset` contract every volatility,
-        error-distribution, and identification implementation is written
-        against. Methods that use the posterior more than once — or hand it
-        to a memoising helper — must bind this to a local first, because a
-        fresh Dataset is built on each call.
+        A fresh Dataset is built on each call, so methods that use the
+        posterior more than once — or hand it to a memoising helper — must
+        bind this to a local first.
         """
-        return get_group_dataset(self.idata, "posterior")
+        return posterior_dataset(self.idata)
 
     @property
     def has_exog(self) -> bool:
@@ -97,12 +102,12 @@ class FittedVAR(ImpulsoBaseModel):
     @property
     def coefficients(self) -> np.ndarray:
         """Posterior draws of B coefficient matrices."""
-        return self._posterior()["B"].values
+        return coefficient_draws(self._posterior())
 
     @property
     def intercepts(self) -> np.ndarray:
         """Posterior draws of intercept vectors."""
-        return self._posterior()["intercept"].values
+        return intercept_draws(self._posterior())
 
     def sigma(self) -> np.ndarray:
         """Posterior draws of the structural-shock scale matrix Σ.
@@ -251,7 +256,7 @@ class FittedVAR(ImpulsoBaseModel):
         from impulso._residuals import fitted_values
 
         posterior = self._posterior()
-        if self.data.exog is not None and "B_exog" not in posterior:
+        if self.data.exog is not None and not has_exog_block(posterior):
             raise ValueError(
                 "This FittedVAR's data carries exogenous regressors the estimator "
                 "never consumed (no B_exog in the posterior); refit with an "
@@ -343,7 +348,7 @@ class FittedVAR(ImpulsoBaseModel):
                     (n_chains, n_draws, n_vars), rng, posterior
                 )
             u = np.einsum("cdhij,cdhj->cdhi", L_path, eps)
-            A = lag_matrices(posterior["B"].values, self.n_lags)
+            A = lag_matrices(coefficient_draws(posterior), self.n_lags)
             forecasts = forecasts + propagate(A, u, np.zeros((self.n_lags, n_vars)))
 
         mode = "density" if include_shock_uncertainty else "mean"
@@ -546,15 +551,15 @@ class FittedVAR(ImpulsoBaseModel):
         posterior = self._posterior()
         # Guard on the posterior, not on `has_exog`: an estimator may carry
         # exogenous data it never actually consumed.
-        if "B_exog" not in posterior:
+        if not has_exog_block(posterior):
             raise ValueError(
                 "This FittedVAR has no B_exog in its posterior, so no dynamic "
                 "multiplier is defined. Fit a VAR with exogenous regressors "
                 "(VARData(..., exog=...)) using an estimator that supports them."
             )
 
-        B_da = posterior["B"]
-        B_exog_da = posterior["B_exog"]
+        B_da = posterior[COEFFICIENTS]
+        B_exog_da = posterior[EXOG_COEFFICIENTS]
         # Hand-built posteriors may order dims arbitrarily. Realign by name
         # when the canonical labels are present; otherwise trust the
         # positional (chain, draw, var, coeff/exog) convention.

--- a/src/impulso/identification/long_run.py
+++ b/src/impulso/identification/long_run.py
@@ -8,6 +8,7 @@ from pydantic import Field, PrivateAttr, model_validator
 
 from impulso._base import ImpulsoModel
 from impulso._linalg import lag_matrices
+from impulso._posterior import COEFFICIENTS, coefficient_draws
 from impulso.identification._cache import _CACHE_MISS, _PosteriorCache
 
 if TYPE_CHECKING:
@@ -283,7 +284,7 @@ class LongRunRestriction(ImpulsoModel):
                 `on_undefined="raise"` and some draw is undefined.
         """
         del data  # unused
-        if posterior is None or "B" not in posterior:
+        if posterior is None or COEFFICIENTS not in posterior:
             raise ValueError(
                 "LongRunRestriction.identify requires the full posterior with 'B' (the VAR lag "
                 "coefficients): the long-run multiplier C(1) = (I - sum_j A_j)^-1 is built from "
@@ -292,7 +293,7 @@ class LongRunRestriction(ImpulsoModel):
             )
         n_vars = L.shape[-1]
         if n_lags is None:
-            n_lags = posterior["B"].shape[-1] // n_vars
+            n_lags = posterior[COEFFICIENTS].shape[-1] // n_vars
 
         perm = self._permutation(var_names)
         inv = np.argsort(perm)
@@ -347,7 +348,7 @@ class LongRunRestriction(ImpulsoModel):
             self._last_diagnostics = {**self._last_diagnostics, "long_run_screen_cache_hit": 1.0}
             return cached
 
-        A = lag_matrices(posterior["B"].values, n_lags)
+        A = lag_matrices(coefficient_draws(posterior), n_lags)
         M = np.eye(n_vars) - np.sum(A, axis=0)
         # cond() returns inf for a singular matrix rather than raising,
         # which is what makes the sanitise-then-blank strategy possible.
@@ -429,10 +430,10 @@ class LongRunRestriction(ImpulsoModel):
             A large condition number means `C(1)` is barely defined; a
             spectral radius above one means the long-run sum diverges.
         """
-        n_vars = posterior["B"].shape[-2]
+        n_vars = posterior[COEFFICIENTS].shape[-2]
         if n_lags is None:
-            n_lags = posterior["B"].shape[-1] // n_vars
-        A = lag_matrices(posterior["B"].values, n_lags)
+            n_lags = posterior[COEFFICIENTS].shape[-1] // n_vars
+        A = lag_matrices(coefficient_draws(posterior), n_lags)
         M = np.eye(n_vars) - np.sum(A, axis=0)
         return {
             "condition": np.linalg.cond(M),

--- a/src/impulso/identification/sign.py
+++ b/src/impulso/identification/sign.py
@@ -9,6 +9,7 @@ from pydantic import Field, PrivateAttr
 from impulso._base import ImpulsoModel
 from impulso._linalg import lag_matrices
 from impulso._ma import compute_ma_phi
+from impulso._posterior import COEFFICIENTS, coefficient_draws
 from impulso.identification._shared import pad_shock_coords
 
 if TYPE_CHECKING:
@@ -92,13 +93,13 @@ class SignRestriction(ImpulsoModel):
         B_all: np.ndarray | None = None
         n_lags = 0
         if self.restriction_horizon > 0:
-            if posterior is None or "B" not in posterior:
+            if posterior is None or COEFFICIENTS not in posterior:
                 raise ValueError(
                     "restriction_horizon > 0 requires the full posterior with 'B' "
                     "(VAR coefficients). Pass the fit's posterior group as an xarray.Dataset "
                     "to identify() — FittedVAR.set_identification_strategy(...) does this for you."
                 )
-            B_all = posterior["B"].values
+            B_all = coefficient_draws(posterior)
             n_lags = B_all.shape[-1] // n_vars
 
         P = np.full((n_chains, n_draws, n_vars, n_vars), np.nan)

--- a/src/impulso/identification/zero_sign.py
+++ b/src/impulso/identification/zero_sign.py
@@ -10,6 +10,7 @@ from pydantic import Field, PrivateAttr, model_validator
 from impulso._base import ImpulsoModel
 from impulso._linalg import lag_matrices
 from impulso._ma import compute_ma_phi
+from impulso._posterior import COEFFICIENTS, coefficient_draws
 from impulso.identification._shared import pad_shock_coords
 
 if TYPE_CHECKING:
@@ -400,13 +401,13 @@ class ZeroSignRestriction(ImpulsoModel):
         """
         if self.restriction_horizon == 0:
             return None
-        if posterior is None or "B" not in posterior:
+        if posterior is None or COEFFICIENTS not in posterior:
             raise ValueError(
                 "restriction_horizon > 0 requires the full posterior with 'B' "
                 "(VAR coefficients). Pass the fit's posterior group as an xarray.Dataset "
                 "to identify() — FittedVAR.set_identification_strategy(...) does this for you."
             )
-        return posterior["B"].values
+        return coefficient_draws(posterior)
 
     def _compile_layout(self, var_names: list[str], n_vars: int) -> _ZeroSignLayout:
         """Resolve names to indices and fix the construction order, once per call.

--- a/src/impulso/identified.py
+++ b/src/impulso/identified.py
@@ -8,10 +8,17 @@ import pandas as pd
 import xarray as xr
 from pydantic import Field
 
-from impulso._arviz_compat import InferenceDataLike, get_group_dataset, make_idata
+from impulso._arviz_compat import InferenceDataLike, make_idata
 from impulso._base import ImpulsoBaseModel
 from impulso._linalg import lag_matrices
 from impulso._ma import compute_ma_phi
+from impulso._posterior import (
+    coefficient_draws,
+    exog_coefficient_draws,
+    has_exog_block,
+    intercept_draws,
+    posterior_dataset,
+)
 from impulso.data import VARData
 from impulso.observation import Gaussian
 from impulso.protocols import ErrorDistribution, IdentificationScheme, VolatilityProcess
@@ -65,15 +72,13 @@ class IdentifiedVAR(ImpulsoBaseModel):
     scheme: IdentificationScheme  # P3: needed for at= queries
 
     def _posterior(self) -> xr.Dataset:
-        """The `posterior` group as an `xarray.Dataset`.
+        """The `posterior` group as an `xarray.Dataset`; see `impulso._posterior.posterior_dataset`.
 
-        Identification schemes and volatility processes are written against
-        `xr.Dataset`; on ArviZ 1 the raw group is a `DataTree` node instead.
         A new Dataset is built per call, so per-`t` loops must bind it to a
         local once — both to avoid rebuilding it `T` times and to keep the
         identity-keyed memo in `_PosteriorCache` hitting.
         """
-        return get_group_dataset(self.idata, "posterior")
+        return posterior_dataset(self.idata)
 
     @property
     def shock_names(self) -> list[str]:
@@ -246,7 +251,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
         Returns:
             IRFResult with IRF posterior draws.
         """
-        B_draws = self._posterior()["B"].values  # (C, D, n, n*p)
+        B_draws = coefficient_draws(self._posterior())  # (C, D, n, n*p)
         Phi_arr = self._ma_coefficients(B_draws, self.n_lags, horizon)
         P = self.shock_matrix(at=at)
 
@@ -359,7 +364,7 @@ class IdentifiedVAR(ImpulsoBaseModel):
         Returns:
             FEVDResult with FEVD posterior draws.
         """
-        B_draws = self._posterior()["B"].values  # (C, D, n, n*p)
+        B_draws = coefficient_draws(self._posterior())  # (C, D, n, n*p)
         Phi_arr = self._ma_coefficients(B_draws, self.n_lags, horizon)
         P = self.shock_matrix(at=at)
 
@@ -484,15 +489,15 @@ class IdentifiedVAR(ImpulsoBaseModel):
             structural_resid = np.einsum("cdij,cdtj->cdti", P_inv, resid)
             impact = P[:, :, np.newaxis, :, :] * structural_resid[:, :, :, np.newaxis, :]
 
-        A = lag_matrices(posterior["B"].values, n_lags)
+        A = lag_matrices(coefficient_draws(posterior), n_lags)
         hd = propagate_contributions(A, impact)
 
-        intercept = posterior["intercept"].values  # (C, D, n)
+        intercept = intercept_draws(posterior)  # (C, D, n)
         n_chains, n_draws, n_vars = intercept.shape
         T_eff = resid.shape[2]
         forcing = np.broadcast_to(intercept[:, :, np.newaxis, :], (n_chains, n_draws, T_eff, n_vars)).copy()
-        if self.data.exog is not None and "B_exog" in posterior:
-            forcing += np.einsum("cdij,tj->cdti", posterior["B_exog"].values, self.data.exog[n_lags:])
+        if self.data.exog is not None and has_exog_block(posterior):
+            forcing += np.einsum("cdij,tj->cdti", exog_coefficient_draws(posterior), self.data.exog[n_lags:])
         baseline = propagate(A, forcing, self.data.endog[:n_lags])
 
         idx = self.data.index[n_lags:]

--- a/src/impulso/spec.py
+++ b/src/impulso/spec.py
@@ -8,6 +8,7 @@ from pydantic import Field, model_validator
 
 from impulso._arviz_compat import InferenceDataLike
 from impulso._base import ImpulsoBaseModel
+from impulso._posterior import COEFFICIENTS, EXOG_COEFFICIENTS, INTERCEPT
 from impulso.data import VARData, _format_names
 from impulso.observation import Gaussian, StudentT
 from impulso.priors import MinnesotaPrior
@@ -339,8 +340,9 @@ class VAR(ImpulsoBaseModel):
 
         # Coordinates make the posterior self-describing: `B` comes back labelled
         # by variable and by "L<lag>.<variable>" coefficient instead of positional
-        # `B_dim_0` / `B_dim_1`. Names match ConjugateVAR's posterior so both
-        # estimators agree. `coeff` is lag-major to mirror the X_lag hstack above.
+        # `B_dim_0` / `B_dim_1`. Variable names come from `impulso._posterior` —
+        # the schema ConjugateVAR constructs against too, so both estimators
+        # agree. `coeff` is lag-major to mirror the X_lag hstack above.
         coords: dict[str, object] = {
             "var": data.endog_names,
             "var1": data.endog_names,
@@ -354,11 +356,11 @@ class VAR(ImpulsoBaseModel):
         # Build PyMC model
         with pm.Model(coords=coords) as model:
             # Intercept
-            intercept = pm.Normal("intercept", mu=0, sigma=1, dims="var")
+            intercept = pm.Normal(INTERCEPT, mu=0, sigma=1, dims="var")
 
             # VAR coefficients with Minnesota prior
             B = pm.Normal(
-                "B",
+                COEFFICIENTS,
                 mu=prior_params["B_mu"],
                 sigma=prior_params["B_sigma"],
                 dims=("var", "coeff"),
@@ -369,7 +371,7 @@ class VAR(ImpulsoBaseModel):
             # happen to be measured in (#192).
             if X_exog is not None:
                 B_exog = pm.Normal(
-                    "B_exog",
+                    EXOG_COEFFICIENTS,
                     mu=0,
                     sigma=_exog_prior_sigma(y, X_exog, self.exog_prior_scale, data.exog_names),
                     dims=("var", "exog"),


### PR DESCRIPTION
Implements architecture-review candidate 4, stacked on #290.

## Problem

The posterior's variable names and layouts — `'B'` (chain, draw, n, n·p; lag-major), `'intercept'`, `'B_exog'` — are the de-facto interface between both estimators and everything downstream, but they were asserted in prose: `posterior["B"].values` was inlined at ~15 sites across 6 files, `_posterior()` was duplicated verbatim on `FittedVAR` and `IdentifiedVAR`, the public `coefficients`/`intercepts` properties were a second never-used path to the same fact, and `conjugate.py`'s "names match ConjugateVAR's posterior" was a docstring promise with no shared constant behind it.

## Change

New `src/impulso/_posterior.py` — the deep module the deletion test blesses (delete it and the same knowledge reappears in eight files):

- **Constants with layout docs**: `COEFFICIENTS = "B"`, `INTERCEPT = "intercept"`, `EXOG_COEFFICIENTS = "B_exog"`.
- **`posterior_dataset(idata)`** — the one ArviZ-0/1 group accessor; both `_posterior()` methods now delegate to it.
- **Accessors**: `coefficient_draws`, `intercept_draws`, `exog_coefficient_draws` (None when absent), `has_exog_block`.

Both construction sites now build against the schema — `spec.py`'s PyMC variable names and `conjugate.py`'s hand-built Dataset keys use the constants, so estimator parity is structural. Every inline read across `fitted.py`, `identified.py`, `_residuals.py`, `_scenario.py`, and the `identification/` schemes goes through the accessors; the public properties share the internal read path.

Deliberately out of scope: the volatility seam's `'L'` and observation's `'nu'` (each already single-owner), and ADR-0011's separation of the graph and NumPy likelihood paths (this removes the incidental drift surface — key strings — not the fenced one).

## Verification

- Pure name-lookup indirection: no read reordering, RNG stream and FP behaviour untouched; error messages byte-identical.
- Acceptance suite (13 test files spanning every migrated consumer): 384 passed, zero test edits.
- Full fast suite on this layer: 1100 passed, 1 skipped; all seeded pins unchanged.
