### PR TITLE
refactor(results): deepen the result base; plotting consumes the result interface

### DIFF
--- a/src/impulso/plotting/_conditional_forecast.py
+++ b/src/impulso/plotting/_conditional_forecast.py
@@ -6,8 +6,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
 
-from impulso._arviz_compat import hdi_bounds
-
 if TYPE_CHECKING:
     from impulso.results import ConditionalForecastResult
 
@@ -31,15 +29,11 @@ def plot_conditional_forecast(
     Returns:
         Matplotlib Figure.
     """
-    from impulso._scenario import resolve_variable_pins
-
-    pp = result._pp()
-    da = pp["forecast"]
-    med = da.median(dim=("chain", "draw"))
-    hdi_lower, hdi_upper = hdi_bounds(da, prob)
+    med = result.median()
+    hdi = result.hdi(prob)
     steps_axis = np.arange(1, result.steps + 1)
     n_vars = len(result.var_names)
-    pins = resolve_variable_pins(list(result.conditions), result.var_names, result.steps)
+    pins = result.pinned_values()
 
     if figsize is None:
         figsize = (12, 3 * n_vars)
@@ -48,30 +42,30 @@ def plot_conditional_forecast(
     if n_vars == 1:
         axes = [axes]
     title = "Conditional Forecast"
-    n_restrictions = int(pp.attrs.get("n_restrictions", 0))
+    n_restrictions = result.n_restrictions
     if n_restrictions:
-        q_cal = float(pp["plausibility_calibrated"].median())
+        q_cal = result.plausibility()["q_calibrated_median"]
         title += f" (calibrated plausibility q = {q_cal:.2f})"
     fig.suptitle(title)
 
     for i, var in enumerate(result.var_names):
         axes[i].plot(
             steps_axis,
-            med.isel(variable=i).values,
+            med[var].values,
             color="C0",
             linewidth=1.2,
             label="median",
         )
         axes[i].fill_between(
             steps_axis,
-            hdi_lower.isel(variable=i).values,
-            hdi_upper.isel(variable=i).values,
+            hdi.lower[var].values,
+            hdi.upper[var].values,
             color="C0",
             alpha=0.25,
             linewidth=0,
             label=f"{int(prob * 100)}% HDI",
         )
-        pinned = [(h + 1, value) for (j, h, value) in pins if j == i]
+        pinned = pins[var]
         if pinned:
             xs, ys = zip(*pinned, strict=True)
             axes[i].scatter(xs, ys, color="black", marker="x", s=30, zorder=3, label="pinned")

--- a/src/impulso/plotting/_counterfactual.py
+++ b/src/impulso/plotting/_counterfactual.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
-from impulso._arviz_compat import hdi_bounds
-
 if TYPE_CHECKING:
     from impulso.results import CounterfactualResult
 
@@ -29,12 +27,10 @@ def plot_counterfactual(
     Returns:
         Matplotlib Figure.
     """
-    pp = result._pp()
-    cf_da = pp["counterfactual"]
-    actual_da = pp["actual"]
-    med = cf_da.median(dim=("chain", "draw"))
-    hdi_lower, hdi_upper = hdi_bounds(cf_da, prob)
-    time = cf_da.coords["time"].values
+    med = result.median()
+    hdi = result.hdi(prob)
+    actual = result.actual()
+    time = med.index.values
     n_vars = len(result.var_names)
 
     if figsize is None:
@@ -46,18 +42,18 @@ def plot_counterfactual(
     fig.suptitle("Historical Counterfactual")
 
     for i, var in enumerate(result.var_names):
-        axes[i].plot(time, actual_da.sel(variable=var).values, color="black", linewidth=1.2, label="actual")
+        axes[i].plot(time, actual[var].values, color="black", linewidth=1.2, label="actual")
         axes[i].plot(
             time,
-            med.sel(variable=var).values,
+            med[var].values,
             color="C0",
             linewidth=1.2,
             label="counterfactual (median)",
         )
         axes[i].fill_between(
             time,
-            hdi_lower.sel(variable=var).values,
-            hdi_upper.sel(variable=var).values,
+            hdi.lower[var].values,
+            hdi.upper[var].values,
             color="C0",
             alpha=0.25,
             linewidth=0,

--- a/src/impulso/plotting/_fevd.py
+++ b/src/impulso/plotting/_fevd.py
@@ -25,8 +25,7 @@ def plot_fevd(
     Returns:
         Matplotlib Figure.
     """
-    fevd_da = result._pp()["fevd"]
-    med = fevd_da.median(dim=("chain", "draw"))
+    med = result.median()
     n_vars = len(result.var_names)
     horizons = range(result.horizon + 1)
 
@@ -39,7 +38,7 @@ def plot_fevd(
     fig.suptitle("Forecast Error Variance Decomposition")
 
     for i, resp in enumerate(result.var_names):
-        shares = med.sel(response=resp).values  # (horizon+1, n_shocks)
+        shares = med[resp].values  # (horizon+1, n_shocks)
         axes[i].stackplot(horizons, shares.T, labels=result.var_names, alpha=0.8)
         axes[i].set_ylabel(resp)
         axes[i].set_ylim(0, 1)

--- a/src/impulso/plotting/_historical_decomposition.py
+++ b/src/impulso/plotting/_historical_decomposition.py
@@ -32,12 +32,11 @@ def plot_historical_decomposition(
     Returns:
         Matplotlib Figure.
     """
-    hd_da = result._pp()["hd"]
-    med = hd_da.median(dim=("chain", "draw"))
-    deviation = hd_da.sum("shock").median(dim=("chain", "draw"))
-    shock_names = [str(s) for s in hd_da.coords["shock"].values]
+    med = result.median()
+    deviation = result.deviation()
+    shock_names = result.shock_names
     n_vars = len(result.var_names)
-    T = med.sizes["time"]
+    T = len(med.index)
 
     if figsize is None:
         figsize = (12, 3 * n_vars)
@@ -49,7 +48,7 @@ def plot_historical_decomposition(
 
     time_idx = range(T)
     for i, resp in enumerate(result.var_names):
-        panel = med.sel(response=resp).values  # (T, n_shocks)
+        panel = med[resp].values  # (T, n_shocks)
         bottom_pos = None
         bottom_neg = None
         for j, shock in enumerate(shock_names):
@@ -75,7 +74,7 @@ def plot_historical_decomposition(
                 bottom_neg += neg
         axes[i].plot(
             time_idx,
-            deviation.sel(response=resp).values,
+            deviation[resp].values,
             color="black",
             linewidth=1.1,
             label="deviation from baseline",

--- a/src/impulso/plotting/_irf.py
+++ b/src/impulso/plotting/_irf.py
@@ -33,7 +33,7 @@ def plot_irf(
     fig.suptitle("Impulse Response Functions")
 
     horizons = range(result.horizon + 1)
-    shock_names = result._pp()["irf"].coords["shock"].values.tolist()
+    shock_names = result.shock_names
     for i, resp in enumerate(var_names):
         for j, shock in enumerate(shock_names[:n_vars]):
             ax = axes[i][j]

--- a/src/impulso/results.py
+++ b/src/impulso/results.py
@@ -127,6 +127,41 @@ class VARResultBase(ImpulsoBaseModel):
                 f"single-time {key.upper()}."
             )
 
+    def _wide_median(self, key: str, row_dim: str, col_dim: str = "shock") -> pd.DataFrame:
+        """Posterior median of `_pp()[key]` as a wide DataFrame.
+
+        Args:
+            key: Name of the variable in the `posterior_predictive` group.
+            row_dim: Dimension to use as the frame index.
+            col_dim: Dimension pairing with `response` on the columns.
+
+        Returns:
+            DataFrame indexed by `row_dim` with a
+            `MultiIndex(['response', col_dim])` on columns.
+        """
+        da = self._pp()[key]
+        return _wide_frame(da.median(dim=("chain", "draw")), row_dim, col_dim=col_dim)
+
+    def _wide_hdi(self, key: str, prob: float, row_dim: str, col_dim: str = "shock") -> HDIResult:
+        """HDI of `_pp()[key]` as wide lower/upper DataFrames.
+
+        Args:
+            key: Name of the variable in the `posterior_predictive` group.
+            prob: Probability mass for the HDI.
+            row_dim: Dimension to use as the frame index.
+            col_dim: Dimension pairing with `response` on the columns.
+
+        Returns:
+            HDIResult whose `lower` / `upper` DataFrames mirror the shape
+            and labels of `_wide_median(key, row_dim, col_dim)`.
+        """
+        lower_da, upper_da = hdi_bounds(self._pp()[key], prob)
+        return HDIResult(
+            lower=_wide_frame(lower_da, row_dim, col_dim=col_dim),
+            upper=_wide_frame(upper_da, row_dim, col_dim=col_dim),
+            prob=prob,
+        )
+
 
 class ForecastResult(VARResultBase):
     """Result from VAR forecasting.
@@ -185,6 +220,11 @@ class IRFResult(VARResultBase):
     horizon: int
     var_names: list[str]
 
+    @property
+    def shock_names(self) -> list[str]:
+        """Names of the structural shocks, in the order of the `shock` coordinate."""
+        return [str(s) for s in self._pp()["irf"].coords["shock"].values]
+
     def median(self) -> pd.DataFrame:
         """Posterior median IRF.
 
@@ -193,8 +233,7 @@ class IRFResult(VARResultBase):
             `MultiIndex(['response', 'shock'])` on columns.
         """
         self._guard_no_time_dim()
-        irf = self._pp()["irf"]
-        return _wide_frame(irf.median(dim=("chain", "draw")), "horizon")
+        return self._wide_median("irf", "horizon")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
         """HDI for IRF.
@@ -204,10 +243,7 @@ class IRFResult(VARResultBase):
             labels of `median()`.
         """
         self._guard_no_time_dim()
-        lower_da, upper_da = hdi_bounds(self._pp()["irf"], prob)
-        lower = _wide_frame(lower_da, "horizon")
-        upper = _wide_frame(upper_da, "horizon")
-        return HDIResult(lower=lower, upper=upper, prob=prob)
+        return self._wide_hdi("irf", prob, "horizon")
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert IRF to DataFrame (passthrough to `median()`)."""
@@ -247,8 +283,7 @@ class DynamicMultiplierResult(VARResultBase):
             `MultiIndex(['response', 'exog'])` on columns.
         """
         self._guard_no_time_dim()
-        dm = self._pp()["dynamic_multiplier"]
-        return _wide_frame(dm.median(dim=("chain", "draw")), "horizon", col_dim="exog")
+        return self._wide_median("dynamic_multiplier", "horizon", col_dim="exog")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
         """HDI for the dynamic multiplier.
@@ -258,10 +293,7 @@ class DynamicMultiplierResult(VARResultBase):
             labels of `median()`.
         """
         self._guard_no_time_dim()
-        lower_da, upper_da = hdi_bounds(self._pp()["dynamic_multiplier"], prob)
-        lower = _wide_frame(lower_da, "horizon", col_dim="exog")
-        upper = _wide_frame(upper_da, "horizon", col_dim="exog")
-        return HDIResult(lower=lower, upper=upper, prob=prob)
+        return self._wide_hdi("dynamic_multiplier", prob, "horizon", col_dim="exog")
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert the dynamic multiplier to a DataFrame (passthrough to `median()`)."""
@@ -288,6 +320,11 @@ class FEVDResult(VARResultBase):
     horizon: int
     var_names: list[str]
 
+    @property
+    def shock_names(self) -> list[str]:
+        """Names of the structural shocks, in the order of the `shock` coordinate."""
+        return [str(s) for s in self._pp()["fevd"].coords["shock"].values]
+
     def median(self) -> pd.DataFrame:
         """Posterior median FEVD.
 
@@ -296,8 +333,7 @@ class FEVDResult(VARResultBase):
             `MultiIndex(['response', 'shock'])` on columns.
         """
         self._guard_no_time_dim()
-        fevd = self._pp()["fevd"]
-        return _wide_frame(fevd.median(dim=("chain", "draw")), "horizon")
+        return self._wide_median("fevd", "horizon")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
         """HDI for FEVD.
@@ -307,10 +343,7 @@ class FEVDResult(VARResultBase):
             labels of `median()`.
         """
         self._guard_no_time_dim()
-        lower_da, upper_da = hdi_bounds(self._pp()["fevd"], prob)
-        lower = _wide_frame(lower_da, "horizon")
-        upper = _wide_frame(upper_da, "horizon")
-        return HDIResult(lower=lower, upper=upper, prob=prob)
+        return self._wide_hdi("fevd", prob, "horizon")
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert FEVD to DataFrame (passthrough to `median()`)."""
@@ -339,6 +372,32 @@ class HistoricalDecompositionResult(VARResultBase):
     """
 
     var_names: list[str]
+
+    @property
+    def shock_names(self) -> list[str]:
+        """Names of the shock contributions, in the order of the `shock` coordinate.
+
+        Partially-identified decompositions include the
+        `unidentified_remainder` column.
+        """
+        return [str(s) for s in self._pp()["hd"].coords["shock"].values]
+
+    def deviation(self) -> pd.DataFrame:
+        """Posterior median of the total deviation from the deterministic baseline.
+
+        Median of the per-draw sum of contributions over shocks, so it
+        matches `data - baseline()` exactly; because median-of-sum differs
+        from sum-of-medians, it need not equal `median()` summed over the
+        shock column level.
+
+        Returns:
+            DataFrame indexed by the same `DatetimeIndex` as `median()`,
+            with one column per variable.
+        """
+        da = self._pp()["hd"]
+        med = da.sum("shock").median(dim=("chain", "draw")).transpose("time", "response")
+        index = pd.DatetimeIndex(da.coords["time"].values, name="time")
+        return pd.DataFrame(med.values, index=index, columns=self.var_names)
 
     def baseline(self) -> pd.DataFrame:
         """Posterior median of the deterministic baseline path.
@@ -372,8 +431,7 @@ class HistoricalDecompositionResult(VARResultBase):
             decomposition time), with a `MultiIndex(['response', 'shock'])`
             on columns.
         """
-        hd = self._pp()["hd"]
-        return _wide_frame(hd.median(dim=("chain", "draw")), "time")
+        return self._wide_median("hd", "time")
 
     def hdi(self, prob: float = 0.89) -> HDIResult:
         """HDI for historical decomposition.
@@ -382,10 +440,7 @@ class HistoricalDecompositionResult(VARResultBase):
             HDIResult whose `lower` / `upper` DataFrames mirror the shape and
             labels of `median()`.
         """
-        lower_da, upper_da = hdi_bounds(self._pp()["hd"], prob)
-        lower = _wide_frame(lower_da, "time")
-        upper = _wide_frame(upper_da, "time")
-        return HDIResult(lower=lower, upper=upper, prob=prob)
+        return self._wide_hdi("hd", prob, "time")
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert historical decomposition to DataFrame (passthrough to `median()`)."""
@@ -474,6 +529,40 @@ class ConditionalForecastResult(VARResultBase):
             "n_restrictions": int(pp.attrs["n_restrictions"]),
             "tail_probability": float(pp.attrs["chi2_tail_of_median"]),
         }
+
+    @property
+    def n_restrictions(self) -> int:
+        """Number of binding restrictions recorded on the result.
+
+        Returns:
+            The `n_restrictions` Dataset attribute, or 0 when the result
+            carries no plausibility metadata (e.g. a hand-built result).
+        """
+        return int(self._pp().attrs.get("n_restrictions", 0))
+
+    def pinned_values(self) -> dict[str, list[tuple[int, float]]]:
+        """Resolved pinned values per variable.
+
+        Resolves the echoed `conditions` against the forecast grid the
+        same way the sampler did: a scalar broadcasts to every step, an
+        array pins a leading run of steps, and `NaN` entries stay free.
+
+        Returns:
+            Dict mapping each variable name to its `(step, value)` pins
+            with 1-based steps, in condition order; variables without
+            pins map to an empty list.
+
+        Raises:
+            ValueError: On unknown variables, scalar-NaN conditions,
+                over-length arrays, or duplicate pins.
+        """
+        from impulso._scenario import resolve_variable_pins
+
+        pins = resolve_variable_pins(list(self.conditions), self.var_names, self.steps)
+        resolved: dict[str, list[tuple[int, float]]] = {name: [] for name in self.var_names}
+        for var_idx, step_idx, value in pins:
+            resolved[self.var_names[var_idx]].append((step_idx + 1, value))
+        return resolved
 
     def to_dataframe(self) -> pd.DataFrame:
         """Conditional-forecast posterior median as a DataFrame (passthrough to `median()`)."""

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from impulso._arviz_compat import make_idata
 from impulso.results import (
+    ConditionalForecastResult,
     FEVDResult,
     ForecastResult,
     HDIResult,
@@ -16,6 +17,7 @@ from impulso.results import (
     LagOrderResult,
     VARResultBase,
 )
+from impulso.scenario import VariablePath
 
 
 class TestHDIResult:
@@ -209,6 +211,12 @@ class TestIRFResultMethods:
             assert list(frame.index) == list(range(11))
         assert (hdi.upper.values >= hdi.lower.values).all()
 
+    def test_shock_names_follow_shock_coord(self):
+        """shock_names reads the `shock` coordinate, not var_names."""
+        result = _make_irf_result(shocks=("supply", "demand"))
+        assert result.shock_names == ["supply", "demand"]
+        assert all(isinstance(s, str) for s in result.shock_names)
+
 
 class TestFEVDResultMethods:
     def test_median_shape_and_labels(self):
@@ -250,6 +258,12 @@ class TestFEVDResultMethods:
             assert frame.columns.names == ["response", "shock"]
             assert list(frame.index) == list(range(11))
         assert (hdi.upper.values >= hdi.lower.values).all()
+
+    def test_shock_names_follow_shock_coord(self):
+        """shock_names reads the `shock` coordinate, not var_names."""
+        result = _make_fevd_result(shocks=("supply", "demand"))
+        assert result.shock_names == ["supply", "demand"]
+        assert all(isinstance(s, str) for s in result.shock_names)
 
 
 class TestHistoricalDecompositionResultMethods:
@@ -299,3 +313,71 @@ class TestHistoricalDecompositionResultMethods:
             assert isinstance(frame.columns, pd.MultiIndex)
             assert frame.columns.names == ["response", "shock"]
         assert (hdi.upper.values >= hdi.lower.values).all()
+
+    def test_shock_names_follow_shock_coord(self):
+        """shock_names reads the `shock` coordinate, so a partially-identified
+        decomposition surfaces its `unidentified_remainder` column.
+        """
+        result = _make_hd_result(shocks=("target", "unidentified_remainder"))
+        assert result.shock_names == ["target", "unidentified_remainder"]
+
+    def test_deviation_is_median_of_shock_sum(self):
+        """deviation() is the median of the per-draw sum over shocks, with
+        the index and columns of the per-variable frames.
+        """
+        result = _make_hd_result(n_periods=24)
+        dev = result.deviation()
+        raw = result.idata.posterior_predictive["hd"]
+        expected = raw.sum("shock").median(dim=("chain", "draw")).transpose("time", "response")
+        assert isinstance(dev.index, pd.DatetimeIndex)
+        assert dev.index.name == "time"
+        assert list(dev.columns) == ["gdp", "inf"]
+        np.testing.assert_allclose(dev.values, expected.values)
+
+
+def _make_conditional_forecast_result(conditions=(), attrs=None, steps=4, n_vars=2):
+    rng = np.random.default_rng(45)
+    names = [f"y{i + 1}" for i in range(n_vars)]
+    data = rng.standard_normal((2, 50, steps, n_vars))
+    da = xr.DataArray(
+        data,
+        dims=["chain", "draw", "step", "variable"],
+        coords={"variable": names},
+        name="forecast",
+    )
+    ds = xr.Dataset({"forecast": da}, attrs=dict(attrs or {}))
+    idata = make_idata(posterior_predictive=ds)
+    return ConditionalForecastResult.model_construct(
+        idata=idata,
+        steps=steps,
+        var_names=names,
+        conditions=list(conditions),
+    )
+
+
+class TestConditionalForecastResultAccessors:
+    def test_n_restrictions_reads_dataset_attrs(self):
+        result = _make_conditional_forecast_result(attrs={"n_restrictions": 3})
+        assert result.n_restrictions == 3
+
+    def test_n_restrictions_defaults_to_zero_without_metadata(self):
+        """A hand-built result without plausibility attrs reports zero."""
+        result = _make_conditional_forecast_result()
+        assert result.n_restrictions == 0
+
+    def test_pinned_values_resolves_scalars_arrays_and_nans(self):
+        """A scalar broadcasts to every step; an array pins a leading run
+        with NaN entries left free; unconditioned variables map to [].
+        """
+        conditions = [
+            VariablePath(variable="y1", values=np.array([0.4, np.nan, -0.2])),
+            VariablePath(variable="y2", values=1.5),
+        ]
+        result = _make_conditional_forecast_result(conditions=conditions, steps=4)
+        pins = result.pinned_values()
+        assert pins["y1"] == [(1, 0.4), (3, -0.2)]
+        assert pins["y2"] == [(1, 1.5), (2, 1.5), (3, 1.5), (4, 1.5)]
+
+    def test_pinned_values_empty_without_conditions(self):
+        result = _make_conditional_forecast_result()
+        assert result.pinned_values() == {"y1": [], "y2": []}


### PR DESCRIPTION
Implements architecture-review candidate 5, stacked on #291.

## Problem

`VARResultBase` owned nothing — an `idata` field, a `_pp()` accessor, and four abstract stubs — so every subclass re-implemented `median()`/`hdi()` against raw xarray dims. Four of ten plotting adapters (`_fevd`, `_historical_decomposition`, `_counterfactual`, `_conditional_forecast`) bypassed the public result surface entirely, re-deriving reductions from `result._pp()`; `_conditional_forecast.py` additionally reached across modules into `impulso._scenario.resolve_variable_pins` for pin markers. The dim vocabulary was hand-typed in three layers with no owner.

## Change

Two behaviour-preserving moves:

- **Deep reduction core.** `VARResultBase._wide_median` / `_wide_hdi` (primary-key + row/col-dim driven, built on the existing `_wide_frame`) absorb the shared reduction; `IRFResult`, `DynamicMultiplierResult`, `FEVDResult`, and `HistoricalDecompositionResult` delegate instead of re-implementing. Outputs are bit-identical. Result classes with genuinely different shapes (`ForecastResult`, `CounterfactualResult`, `VolatilityResult`, `SVForecastResult`, the five standalone diagnostics) are deliberately left alone — depth, not uniformity.
- **Plotting consumes only the result interface.** All five leaking adapters now use `median()`/`hdi()`/public attributes, via new public accessors where one was missing: `shock_names` on IRF/FEVD/HD results, `HistoricalDecompositionResult.deviation()`, and `ConditionalForecastResult.pinned_values()` / `.n_restrictions` — the last moving the `resolve_variable_pins` reach behind the result's interface (lazy import inside `results.py`; `ScenarioResult` inherits both). `grep "_pp()" src/impulso/plotting/` is now empty.

Each new accessor has a direct unit test; `tests/test_plotting.py` needed no edits — its existing assertions now regress the accessors through the plots.

## Verification

- Targeted: `test_results.py` + `test_plotting.py` + `test_cholskey_irf_pins.py` — 57 passed; hand-built results driven through the reworked plots verified pin markers, plausibility title, and line data against raw reductions.
- Full fast suite at the stack top: **1108 passed** (8 new accessor tests), 1 skipped; `ruff` / `ty` clean.
- One edge sharpened: `plot_fevd` on a hypothetical time-dim FEVD now raises the informative `_guard_no_time_dim` error instead of failing inside `stackplot`.
