### PR TITLE
fix(typing): make SVDynamics members read-only; unblock linter bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,27 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "05:00" # UTC
-    # One PR per run for every Python dependency, rather than one PR each.
+    # Two PRs per run, not one per dependency.
+    #
+    # Linters are separated because ty, ruff and prek are pre-1.0 and ship
+    # new diagnostics in patch releases, while `quality` and
+    # `tests-and-type-check` both gate on `uv run ty check`. Grouped with
+    # everything else, one new rule blocks every runtime bump in the same PR
+    # — #296 stalled a numpy fix for `np.linalg.svd(hermitian=True)`
+    # returning non-unitary `vh` behind a ty 0.0.18 -> 0.0.65 jump.
     groups:
+      linters:
+        patterns:
+          - "ty"
+          - "ruff"
+          - "prek"
       python:
         patterns:
           - "*"
+        exclude-patterns:
+          - "ty"
+          - "ruff"
+          - "prek"
     # impulso is a library, so its `>=` floors are a compatibility promise.
     # Land the bump in uv.lock and only touch a floor if it genuinely excludes
     # the new release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,17 @@ invalid-argument-type = "ignore"
 # match against the generic `type.__init__` overloads.
 no-matching-overload = "ignore"
 
+# The frozen-model tests assert immutability by assigning to a frozen field
+# inside `pytest.raises(ValidationError)` — the assignment *is* the
+# assertion. ty >= 0.0.65 models Pydantic frozen semantics and rejects those
+# lines statically. Scoped to tests so `src/` keeps the rule: it is what
+# caught the mutable-member variance bug in the `SVDynamics` protocol.
+[[tool.ty.overrides]]
+include = ["tests/**"]
+
+[tool.ty.overrides.rules]
+invalid-assignment = "ignore"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/src/impulso/_stationarity.py
+++ b/src/impulso/_stationarity.py
@@ -117,7 +117,7 @@ def _check_finite(frame: pd.DataFrame) -> pd.DataFrame:
     """
     finite = np.isfinite(frame.to_numpy(dtype=np.float64)).all(axis=0)
     if not finite.all():
-        bad = [str(c) for c, ok in zip(frame.columns, finite, strict=True) if not ok]
+        bad = [str(c) for c in frame.columns[~finite]]
         raise ValueError(f"columns contain NaN or Inf and cannot be tested: {bad}")
     return frame
 

--- a/src/impulso/sv/dynamics.py
+++ b/src/impulso/sv/dynamics.py
@@ -19,12 +19,25 @@ class SVDynamics(Protocol):
     path and the forward simulation used for density forecasts.
     """
 
-    name: str
-    has_explicit_level: bool
-    """Whether the dynamics owns the log-vol level via an explicit intercept
-    (e.g. AR(1)'s `alpha`). Multivariate adapters use this to avoid a
-    redundant outer `mu_i` shift when the dynamics already carries the
-    level. `True` for AR(1), `False` for random-walk."""
+    @property
+    def name(self) -> str:
+        """Registry key for this dynamics adapter.
+
+        Declared read-only so concrete adapters may narrow it to a
+        `Literal`. A mutable protocol member is invariant, which would
+        reject `name: Literal["random_walk"]` as an implementation of
+        `name: str` and make `SV_DYNAMICS_REGISTRY` unassignable.
+        """
+        ...
+
+    @property
+    def has_explicit_level(self) -> bool:
+        """Whether the dynamics owns the log-vol level via an explicit intercept
+        (e.g. AR(1)'s `alpha`). Multivariate adapters use this to avoid a
+        redundant outer `mu_i` shift when the dynamics already carries the
+        level. `True` for AR(1), `False` for random-walk.
+        """
+        ...
 
     def build_latent_path(
         self,

--- a/tests/test_sv_spec.py
+++ b/tests/test_sv_spec.py
@@ -146,14 +146,14 @@ class TestSVDynamicsDiscriminator:
 
         rw = RandomWalk()
         with pytest.raises(ValidationError):
-            rw.name = "ar1"  # ty: ignore[invalid-assignment]
+            rw.name = "ar1"
 
     def test_ar1_name_is_frozen(self):
         from impulso.sv.dynamics import AR1
 
         ar = AR1()
         with pytest.raises(ValidationError):
-            ar.name = "random_walk"  # ty: ignore[invalid-assignment]
+            ar.name = "random_walk"
 
 
 class TestHasExplicitLevel:
@@ -212,7 +212,7 @@ class TestStochasticVolatilityIsVolatilityProcess:
 
         sv = StochasticVolatility()
         with pytest.raises(ValidationError):
-            sv.name = "constant"  # ty: ignore[invalid-assignment]
+            sv.name = "constant"
 
 
 class TestSVMultivariateBuild:

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -33,7 +33,7 @@ class TestConstantAdapter:
         with pytest.raises(ValidationError):
             # Deliberately violate the `Literal["constant"]` static type to
             # assert that the frozen Pydantic model raises at runtime.
-            adapter.name = "other"  # ty: ignore[invalid-assignment]
+            adapter.name = "other"
 
 
 class TestConstantBuildPymcLatent:


### PR DESCRIPTION
Unblocks #296 and fixes the one real bug it surfaced.

## Why #296 fails

Dependabot's 16-package bump fails `quality` and all four `tests-and-type-check` legs. The runtime stack is fine — every failing leg prints `1111 passed, 1 skipped` and *then* dies on `uv run ty check`. `lowest-direct-deps`, `arviz-1-2-compat`, `wheel-install`, `build-docs` and `docs-linkcheck` all pass, which is the tell: the floors are fine, a newly **locked** version isn't.

One package of the sixteen is responsible: `ty` **0.0.18 → 0.0.65**, 47 releases of a pre-1.0 type checker, emitting 16 diagnostics. Reproduced against `main` with `uvx --from ty==0.0.65 ty check`.

Fifteen were tooling artifacts. One was a real bug.

## The real bug: `SVDynamics` protocol variance

```python
class SVDynamics(Protocol):
    name: str                    # mutable => invariant
    has_explicit_level: bool
```

A **mutable** protocol member is invariant, so `RandomWalk.name: Literal["random_walk"]` never actually satisfied `name: str`, and `SV_DYNAMICS_REGISTRY: dict[str, type[SVDynamics]]` was unassignable. ty 0.0.18 just didn't check it. Declaring both as read-only properties makes them covariant and the narrowing legal.

`@runtime_checkable` is unaffected — `isinstance` checks attribute *presence*, which the pydantic fields still provide. Confirmed: `isinstance(RandomWalk(), SVDynamics)` and `isinstance(AR1(), SVDynamics)` both still `True`, registry resolves, 208 SV/volatility tests pass.

Worth recording: `Mapping[str, type[SVDynamics]]` does **not** fix this. I measured it — still 16 diagnostics. `Mapping`'s covariance is in the container, not the element check; each value must still be assignable to `type[SVDynamics]`.

## The 14 false positives

```python
with pytest.raises(ValidationError):
    data.endog = np.zeros((100, 3))
```

The assignment *is* the assertion. ty ≥ 0.0.65 models pydantic frozen semantics and rejects statically the exact line whose runtime rejection is being asserted. `invalid-assignment` is now ignored for `tests/**` only — `src/` keeps the rule, which is what surfaced the protocol bug above.

Four inline `# ty: ignore[invalid-assignment]` comments in `test_sv_spec.py` and `test_volatility.py` become redundant and are removed. They were earlier one-off patches for this same pattern, which is evidence the friction predates this bump.

## The `zip` diagnostic

`_check_finite` used `zip(frame.columns, finite, strict=True)`, which ty couldn't unpack (`_T_co@zip is not iterable`). Rewritten as a boolean mask over the index — shorter, faster, no suppression needed.

## Dependabot grouping

`ty`, `ruff` and `prek` now group separately from runtime dependencies. Bundled under `patterns: ["*"]`, one new lint rule blocks everything else in the same PR — #296 stalled numpy 2.4.6's fix for `np.linalg.svd(..., hermitian=True)` returning non-unitary `vh` ([numpy#31347](https://github.com/numpy/numpy/pull/31347)) behind a type-checker bump, and this library factorises covariance matrices.

## Verification

Both halves of the pinned PyMC/ArviZ matrix, since the lock carries both families:

| | py3.11 / PyMC 5 / ArviZ 0 | py3.12 / PyMC 6 / ArviZ 1 |
|---|---|---|
| `ty` 0.0.18 (locked) | clean | clean |
| `ty` 0.0.65 (#296) | clean | clean |
| `ty` 0.0.67 (latest) | clean | clean |
| suite | 1111 passed, 1 skipped | 1112 passed |

`make check` passes. The skip is `test_arviz_compat.py:70`, ArviZ-1-only, pre-existing.

**Then, decisively:** overlaid #296's `uv.lock` onto this branch and re-ran everything. `ty` 0.0.65 → `All checks passed`, `prek run --all-files` → all hooks pass, suite → 1111 passed. This branch is sufficient to unblock #296; that PR needs only a rebase afterwards.

## Two things found but deliberately not fixed here

**Unbounded ty floor.** `pyproject.toml` has `"ty>=0.0.14"`, so the lock is the only thing holding it at 0.0.18 — *any* `uv lock` regeneration reintroduces these 16 diagnostics, not just a dependabot PR. This branch makes that harmless rather than papering over it.

**Two different ruffs.** `.pre-commit-config.yaml` pins `ruff-pre-commit` at `v0.14.14` (what prek and therefore CI enforce), while the lock's dev-dependency ruff is 0.15.2 → 0.16.1. They have already drifted: `uv run ruff format --check` under 0.16.1 wants to reformat 13 files that prek's 0.14.14 considers clean. Not a #296 blocker and not touched here, but `dependabot.yml` has no `pre-commit` ecosystem entry, so that rev is never bumped automatically. Worth its own PR.
