### PR TITLE
Validate hdi_bounds probability range

### DIFF
--- a/src/impulso/_arviz_compat.py
+++ b/src/impulso/_arviz_compat.py
@@ -146,8 +146,11 @@ def hdi_bounds(da: xr.DataArray, prob: float) -> tuple[xr.DataArray, xr.DataArra
 
     Raises:
         TypeError: If `da` is not an `xarray.DataArray`.
-        ValueError: If `da` is unnamed or is missing `chain` or `draw`.
+        ValueError: If `prob` is outside (0, 1), or if `da` is unnamed or is
+            missing `chain` or `draw`.
     """
+    if not 0.0 < prob < 1.0:
+        raise ValueError(f"hdi_bounds() prob must be in (0, 1), got {prob}.")
     if not isinstance(da, xr.DataArray):
         raise TypeError(f"hdi_bounds() expects an xarray.DataArray, got {type(da).__name__}.")
     if da.name is None:

--- a/tests/test_arviz_compat.py
+++ b/tests/test_arviz_compat.py
@@ -252,6 +252,14 @@ def test_hdi_bounds_handles_sampling_dims_only():
     assert float(lower) < float(upper)
 
 
+@pytest.mark.parametrize("prob", [0.0, 1.0, -0.1, 1.5])
+def test_hdi_bounds_rejects_probability_outside_open_unit_interval(asymmetric_draws, prob):
+    with pytest.raises(ValueError) as exc_info:
+        hdi_bounds(asymmetric_draws, prob=prob)
+
+    assert str(exc_info.value) == f"hdi_bounds() prob must be in (0, 1), got {prob}."
+
+
 def test_hdi_bounds_rejects_an_unnamed_dataarray(rng):
     da = xr.DataArray(rng.standard_normal((2, 50, 3)), dims=["chain", "draw", "term"])
     with pytest.raises(ValueError, match="named DataArray"):


### PR DESCRIPTION
## Summary

- reject `hdi_bounds()` probabilities outside the open interval `(0, 1)` before dispatching to ArviZ
- return one stable, first-party error message across supported ArviZ versions
- cover both boundaries and representative out-of-range values

## Testing

- `make check`
- `make test` (`1154 passed`)

Closes #280